### PR TITLE
New crate: `enclave_encrypt` to interact with Auth, Export, and Import bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +117,12 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -97,6 +138,12 @@ name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bitflags"
@@ -120,10 +167,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -145,6 +208,41 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "const-oid"
@@ -179,6 +277,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -196,7 +306,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -216,6 +336,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "der"
@@ -258,14 +388,27 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "ecdsa"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "serdect",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.8",
  "digest",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
  "signature",
 ]
 
@@ -277,18 +420,40 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "hkdf",
+ "pkcs8",
+ "rand_core",
+ "sec1 0.3.0",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "rand_core",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -323,6 +488,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "ff"
@@ -465,6 +640,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -494,6 +670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,11 +687,22 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -577,6 +774,18 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -585,6 +794,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hpke"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf39e5461bfdc6ad0fbc97067519fcaf96a7a2e67f24cc0eb8a1e7c0c45af792"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "byteorder",
+ "chacha20poly1305",
+ "digest",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "p256 0.11.1",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -892,6 +1123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,13 +1328,35 @@ dependencies = [
 
 [[package]]
 name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "elliptic-curve 0.12.3",
+]
+
+[[package]]
+name = "p256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+dependencies = [
+ "ecdsa 0.15.1",
+ "elliptic-curve 0.12.3",
+ "primeorder 0.12.1",
+ "serdect",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2",
 ]
 
@@ -1144,10 +1412,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1161,11 +1462,20 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+dependencies = [
+ "elliptic-curve 0.12.3",
+]
+
+[[package]]
+name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -1388,6 +1698,17 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -1508,12 +1829,27 @@ dependencies = [
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.8",
  "generic-array",
  "subtle",
  "zeroize",
@@ -1587,6 +1923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+dependencies = [
+ "base16ct 0.1.1",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
  "rand_core",
@@ -1645,6 +1991,16 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -1772,12 +2128,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tkhq_api_key_stamper"
 version = "0.0.2"
 dependencies = [
  "base64 0.22.0",
  "hex",
- "p256",
+ "p256 0.13.2",
  "rand_core",
  "serde",
  "serde_json",
@@ -1816,6 +2187,19 @@ dependencies = [
  "syn",
  "tonic-build",
  "walkdir",
+]
+
+[[package]]
+name = "tkhq_enclave_encrypt"
+version = "0.1.0"
+dependencies = [
+ "bs58",
+ "hex",
+ "hpke",
+ "p256 0.12.0",
+ "rand_core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1949,6 +2333,16 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2374,6 +2768,20 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,31 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
-dependencies = [
- "thiserror-impl 1.0.58",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2153,7 +2133,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.58",
+ "thiserror",
 ]
 
 [[package]]
@@ -2166,7 +2146,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror",
  "tkhq_api_key_stamper",
  "tokio",
  "wiremock",
@@ -2200,6 +2180,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -2212,6 +2193,7 @@ dependencies = [
  "serde_json",
  "tkhq_api_key_stamper",
  "tkhq_client",
+ "tkhq_enclave_encrypt",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
   "client",
   # Contains tools and script to generate client code from proto
   "codegen",
+  # Contains utilities to encrypt and decrypt data to and from Turnkey secure enclaves
+  "enclave_encrypt",
   # Examples using the Turnkey stamper
   "examples",
 ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains tooling to interact with the Turnkey API using Rust, an
 The two user-facing crates are:
 * [`client`](./client/): fully typed client to send requests to Turnkey
 * [`api_key_stamper`](./api_key_stamper/): used by `client` to stamp requests before they're sent to Turnkey
+* [`enclave_encrypt`](./enclave_encrypt/): used in the context of features which leverage enclave [secure channels](https://docs.turnkey.com/security/enclave-secure-channels) ([Social Logins](https://docs.turnkey.com/authentication/social-logins), [Export](https://docs.turnkey.com/wallets/export-wallets), [Import](https://docs.turnkey.com/wallets/import-wallets))
 
 ## Usage
 
@@ -34,7 +35,7 @@ To make a request to Turnkey:
 
 ## Examples
 
-For fully working examples, see our ['examples/' folder](./examples/README.md).
+For fully working code examples, see our ['examples/' folder](./examples/README.md).
 
 ## Development
 

--- a/api_key_stamper/Cargo.toml
+++ b/api_key_stamper/Cargo.toml
@@ -12,7 +12,7 @@ p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0.197", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.115", default-features = false, features = ["std"] }
-thiserror = { version = "1.0.58", default-features = false }
+thiserror = { version = "2.0.12", default-features = false }
 
 [dev-dependencies]
 tempfile = { version = "3.19.1", default-features = false }

--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bs58 = { version = "0.5.0", features = [
+  "std",
+  "check",
+], default-features = false }
 hex = { version = "0.4.3", features = ["serde"] }
 hpke = { version = "0.10", features = [
   "alloc",
@@ -20,7 +24,4 @@ p256 = { version = "0.12", features = [
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1", features = ["derive"], default-features = false }
 serde_json = { version = "1", features = ["alloc"], default-features = false }
-bs58 = { version = "0.5.0", features = [
-  "std",
-  "check",
-], default-features = false }
+thiserror = { version = "2.0.12" }

--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tkhq_enclave_encrypt"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+hex = { version = "0.4.3", features = ["serde"] }
+hpke = { version = "0.10", features = [
+  "alloc",
+  "p256",
+  "serde_impls",
+], default-features = false }
+p256 = { version = "0.12", features = [
+  "ecdsa",
+  "ecdsa-core",
+  "std",
+  "serde",
+], default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
+serde = { version = "1", features = ["derive"], default-features = false }
+serde_json = { version = "1", features = ["alloc"], default-features = false }
+bs58 = { version = "0.5.0", features = [
+  "std",
+  "check",
+], default-features = false }

--- a/enclave_encrypt/README.md
+++ b/enclave_encrypt/README.md
@@ -1,0 +1,101 @@
+# tkhq_enclave_encrypt
+
+This repository contains primitives to encrypt and decrypt data, sent to and from Turnkey secure enclaves (see Enclave to [end-user secure channels](https://docs.turnkey.com/security/enclave-secure-channels)).
+
+Encryption and decryption are "one-shot" using the HPKE standard ([RFC 9180](https://datatracker.ietf.org/doc/rfc9180/)).  Neither the client or the server should ever be reused to send/receive more than one message. We want to avoid the recipient target key being used more then once in order to improve forward secrecy; see [security profile](#security-profile) section for important details and caveats.
+
+The flows where encryption and decryption are relevant are:
+* Authentication: [Email](https://docs.turnkey.com/authentication/email), [SMS](https://docs.turnkey.com/authentication/sms), or [Social](https://docs.turnkey.com/authentication/social-logins) logins return encrypted authentication bundles produced by Turnkey secure enclaves
+* Key or Wallet export: key material (private key or wallet mnemonic phase) are encrypted by Turnkey enclaves to end-user public keys. See [Export Wallets and Keys](https://docs.turnkey.com/wallets/export-wallets#export-wallets-and-keys).
+* Key or Wallet import: Turnkey enclaves send a bundle containing a signed public key, to which end-users encrypt their key material (private key or wallet mnemonic phrase). See [Import Wallets and Keys](https://docs.turnkey.com/wallets/import-wallets).
+
+## Usage
+
+Decrypting a bundle:
+
+```rust
+let client_ikm = hex::decode("...private bytes from client...").expect("cannot decode client secret bytes");
+let (client_private_key, client_public_key) = Kem::derive_keypair(&client_ikm);
+
+// Create a new `EnclaveEncryptClient` bound to the client's private/public key
+let mut client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+    // required to construct `EnclaveEncryptClient`, but unused when decrypting auth bundles.
+    *SigningKey::random(&mut OsRng).verifying_key(), 
+    // client public key (to which the bundle is encrypted)
+    client_public_key,
+    // client private key, used for decryption of the auth bundle
+    client_private_key,
+);
+
+let bundle = "<auth bundle goes here, it's a base58-encoded string>";
+let decrypted = client.auth_decrypt(bundle)
+```
+
+## Running test
+
+```
+cargo test
+```
+
+## HPKE Protocol Details
+
+### Terms
+
+- Encapsulated ("Encapped") Key - the public key of the sender used for ECDH.
+- Target Key Pair - the key pair of the receiver that the sender encrypts to the public key of. Only one message should ever be encrypted to the public key.
+- Server - a server inside of the enclave; normally an enclave application.
+- Client - a client outside of the enclave; normally a turnkey end user.
+- Enclave Auth Key Pair - a key pair derived from the quorum master seed specifically for the purpose of authentication with clients.
+
+### Overview
+
+This protocol builds on top of the HPKE standard ([RFC 9180](https://datatracker.ietf.org/doc/html/rfc9180)) by adding recipient pre-flight authentication so the client can verify it is sending ciphertext to a turnkey controlled enclave and the enclave can verify its sending ciphertext to the correct client. See the [security profile](#security-profile) section more details.
+
+### HPKE Configuration
+
+* KEM: `KEM_P256_HKDF_SHA256`
+* KDF: `KDF_HKDF_SHA256`
+* AEAD: `AEAD_AES256GCM`
+* INFO: `b"turnkey_hpke"`
+* ADDITIONAL ASSOCIATED DATA: `EncappedPublicKey||ReceiverPublicKey`
+
+### Protocol Flow
+
+#### Server to Client
+
+1. Client generates target pair and sends clientTargetPub key to server. The authenticity of the clientTargetPub is assumed to have been verified by the Ump policy engine.
+1. Server computes ciphertext, `serverEncappedPub` = `ENCRYPT(plaintext, clientTargetPub)` and clears `clientTargetPub` from memory.
+1. Server computes `serverEncappedPub_sig_enclaveAuthPriv` = `SIGN(serverEncappedPub, enclaveAuthPriv)`.
+1. Server sends `(ciphertext, serverEncappedPub, serverEncappedPub_sig_enclaveAuthPriv)` to client.
+1. Client runs `VERIFY(serverEncappedPub, serverEncappedPub_sig_enclaveAuthPriv)`.
+1. Client recovers plaintext by computing `DECRYPT(ciphertext, serverEncappedPub, clientTargetPriv)` and the client target pair is cleared from memory. If the target pair is used multiple times we increase the count of messages that an attacker with the compromised target private key can decrypt.
+
+Note there is no mechanism to prevent a faulty client from resubmitting the same target public key.
+
+#### Client to Server
+
+1. Client sends request to server for target key.
+1. Server generates server target pair and computes `serverTargetPub_sig_enclaveAuthPriv` = `SIGN(serverTargetPub, enclaveAuthPriv)`.
+1. Server sends `(serverTargetPub, serverTargetPub_sig_enclaveAuthPriv)` to client.
+1. Client runs `VERIFY(serverTargetPub, serverTargetPub_sig_enclaveAuthPriv)`.
+1. Client computes ciphertext, `clientEncappedPub` = `ENCRYPT(plaintext, serverTargetPub)` and clears `serverTargetPub` from memory.
+1. Client sends `(ciphertext, clientEncappedPub)` to server and the client is cleared from memory.
+1. Server assumes the authenticity of `clientEncappedPub` has been verified by the Ump policy engine.
+1. Server recovers plaintext by computing `DECRYPT(ciphertext, clientEncappedPub, clientTargetPriv)` and server target pair is cleared from memory. If the target pair is used multiple times we increase the count of messages that an attacker with the compromised target private key can decrypt.
+
+### Security profile
+
+#### Receiver pre-flight authentication
+
+We achieve recipient authentication for both the server and client:
+
+- **Client to Server**: client verifies that the server's target key is signed by the enclaveAuth key. This check is critical for import/export flows. If the client accepts key material (e.g. a wallet seed) from a malicious party, they might not realize they have the wrong wallet (compromised seed because known or with bad entropy). If the client encrypts their seed to a malicious party, they lose funds directly. This is NOT required for email recovery and authentication flows: the client can afford to decrypt and use a bad API key. A bad API key will simply produce an invalid signature when used.
+- **Server to Client**: server relies on upstream checks by Ump + activity signing scheme to enforce rules that guarantee authenticity of the client's target key. Specifically, when the client "sends" clientTargetPub it actually submits a signed payload (activity), and that payload must be signed with an existing credential persisted in org data.
+
+#### Forward secrecy
+
+The underlying HPKE spec does not provide forward secrecy on the recipient side since the target key can be long lived. To improve forward secrecy we specify that the target key should only be used once by the sender and receiver. We cannot enforce this strictly on the client-side because a client may choose to reuse their key. We could implement timestamp-based validation or rate limiting client-side but it wouldn't be a complete solution. For now we accept that a client can use an encryption bundle multiple times if it so desires. However we enforce one-time use of the key pair on the enclave side by deleting it once a successful decryption happens.
+
+#### Sender authentication
+
+We use OpMode Base because the sender's KEM private key is not long lived and thus does not need HPKE authentication. In order for this to be exploited one side's private key data would have to be leaked or an attacker would need to spoof a message from the sender. Turnkey mitigates this attack by layering a signature from an authentication key over payloads that contain ciphertext + encappedPub. Note that in the case of client to server the authentication signature is implicitly verified by the Ump policy engine. Read more about HPKE asymmetric authentication [here](https://datatracker.ietf.org/doc/html/rfc9180#name-authentication-using-an-asy).

--- a/enclave_encrypt/README.md
+++ b/enclave_encrypt/README.md
@@ -11,24 +11,64 @@ The flows where encryption and decryption are relevant are:
 
 ## Usage
 
-Decrypting a bundle:
+### Authentication bundles
+
+```rust
+let client = AuthenticationClient::new()
+let target_public_key = client.target_public_key(); // can be used in auth activity params
+
+let bundle = "<auth bundle>";
+
+let client.decrypt(bundle).expect("decryption should succeed");
+```
+
+If you persist client key material between initiation and decryption you may use `dangerous_from_bytes` to create an `AuthenticationClient`. Keep in mind the one-shot encryption semantics, you may not use the same client IKM to decrypt many different bundles.
 
 ```rust
 let client_ikm = hex::decode("...private bytes from client...").expect("cannot decode client secret bytes");
-let (client_private_key, client_public_key) = Kem::derive_keypair(&client_ikm);
-
-// Create a new `EnclaveEncryptClient` bound to the client's private/public key
-let mut client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
-    // required to construct `EnclaveEncryptClient`, but unused when decrypting auth bundles.
-    *SigningKey::random(&mut OsRng).verifying_key(), 
-    // client public key (to which the bundle is encrypted)
-    client_public_key,
-    // client private key, used for decryption of the auth bundle
-    client_private_key,
-);
-
 let bundle = "<auth bundle goes here, it's a base58-encoded string>";
-let decrypted = client.auth_decrypt(bundle)
+
+let decrypted = AuthenticationClient::dangerous_from_bytes(client_ikm)
+    .decrypt(bundle)
+    .expect("decryption should succeed");
+```
+
+### Export bundles
+
+To decrypt an exported private key or wallet, use `decrypt_private_key` or `decrypt_wallet`:
+
+```rust
+let mut client = ExportClient::new(&QuorumPublicKey::production_signer());
+
+// Decrypt a wallet (result: string)
+let wallet_mnemonic_phrase = client.decrypt_wallet_mnemonic_phrase("<bundle>", "<organization id>")
+
+// Decrypt a private key (result: bytes)
+let private_key = client.decrypt_private_key("<bundle>", "<organization id>")
+```
+
+### Import bundles
+
+To encrypt private keys or wallets, use `encrypt_private_key_with_bundle` or `encrypt_wallet_with_bundle`. The resulting value is a string, ready to use as an activity param. The organization and user IDs need to match the organization and user who initiated import.
+
+```rust
+let mut client = ImportClient::new(&QuorumPublicKey::production_signer());
+
+// Encrypt private keys
+let encrypted_key = client.encrypt_private_key_with_bundle(
+    "<bytes to encrypt>",
+    "<bundle>",
+    "<organization id>",
+    "<user id>",
+).expect("encryption should succeed");
+
+// Encrypt wallet seed phrase
+let encrypted_wallet = client.encrypt_wallet_with_bundle(
+    "<mnemonic phrase>",
+    "<bundle>",
+    "<organization id>",
+    "<user id>",
+).expect("encryption should succeed");
 ```
 
 ## Running test

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -1,16 +1,284 @@
 //! Enclave Encrypt Client
 use hpke::{Deserializable, Kem as KemTrait, Serializable};
 use p256::{
-    ecdsa::{signature::Verifier, DerSignature, VerifyingKey},
+    ecdsa::{signature::Verifier, DerSignature, SigningKey, VerifyingKey},
     PublicKey,
 };
 use rand_core::OsRng;
+use std::str::from_utf8;
 
 use crate::{
-    decompress_p256_public, decrypt, encrypt, errors::EnclaveEncryptError, ClientSendMsg, Kem,
-    P256Public, ServerSendData, ServerSendMsg, ServerSendMsgV0, ServerSendMsgV1, ServerTargetData,
-    ServerTargetMsg, ServerTargetMsgV0, ServerTargetMsgV1, DATA_VERSION, TURNKEY_HPKE_INFO,
+    decompress_p256_public, decrypt, encrypt, errors::EnclaveEncryptError,
+    quorum_public_key::QuorumPublicKey, ClientSendMsg, Kem, P256Public, ServerSendData,
+    ServerSendMsg, ServerSendMsgV0, ServerSendMsgV1, ServerTargetData, ServerTargetMsg,
+    ServerTargetMsgV0, ServerTargetMsgV1, DATA_VERSION, TURNKEY_HPKE_INFO,
 };
+
+/// Expected length (in bytes) for imported private keys
+const EXPECTED_PRIVATE_KEY_BYTE_LENGTH: usize = 32;
+
+/// Abstraction over `EnclaveEncryptClient` for authentication flows.
+pub struct AuthenticationClient {
+    encrypt_client: EnclaveEncryptClient,
+}
+
+impl Default for AuthenticationClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthenticationClient {
+    /// Creates a new `AuthenticationClient` with a fresh target key pair.
+    pub fn new() -> Self {
+        // A VerifyingKey is required to construct `EnclaveEncryptClient`, but unused when decrypting auth bundles.
+        // This is safe not to verify auth bundles authenticity, because this bundles contain credential private key material.
+        // If these bundles are bogus or tampered with they would contain "bad" bytes, which implies the decrypted bytes would either not result in a valid credential, or result in a credential that is not capable to sign Turnkey activities.
+        let random_key = SigningKey::random(&mut OsRng);
+        let encrypt_client =
+            EnclaveEncryptClient::from_enclave_auth_key(*random_key.verifying_key());
+        Self { encrypt_client }
+    }
+
+    /// Creates a new `AuthenticationClient` from known private bytes.
+    ///
+    /// Note that these private bytes are NOT the same as the private key bytes of the target key pair.
+    /// The private bytes are used as ikm (input key material) and used to derive a key pair.
+    ///
+    /// The size of the input key material SHOULD be >=32 bytes, so we enforce this here and return an error if the ikm is not long enough.
+    ///
+    /// WARNING: This interface can be misused if the same key material is provided over and over.
+    /// Indeed, enclave-to-end-user secure channels assume that encryption is "one-shot". After decryption is done, the key should not be reused.
+    /// You may use this interface to allow for ikm persistence and loading if it's not realistic or convenient to hold ikm in memory between initialization and decryption.
+    pub fn dangerous_from_bytes<B: AsRef<[u8]>>(private: B) -> Self {
+        let random_key = SigningKey::random(&mut OsRng);
+        let (pair_private_key, pair_public_key) = Kem::derive_keypair(private.as_ref());
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            *random_key.verifying_key(),
+            pair_public_key,
+            pair_private_key,
+        );
+        Self { encrypt_client }
+    }
+
+    /// Returns the target public key bytes, encoded as SEC1 bytes (04 || X || Y)
+    /// This value is returned as a string, ready to be inserted in auth-related init activities.
+    pub fn target_public_key(&self) -> Result<String, EnclaveEncryptError> {
+        Ok(hex::encode(self.encrypt_client.target_bytes()?))
+    }
+
+    /// Decrypts an authentication bundle and returns the credential bytes (raw private key bytes)
+    pub fn decrypt<S: AsRef<str>>(
+        &mut self,
+        auth_bundle: S,
+    ) -> Result<Vec<u8>, EnclaveEncryptError> {
+        self.encrypt_client.auth_decrypt(auth_bundle.as_ref())
+    }
+}
+
+/// Abstraction over `EnclaveEncryptClient` for private key or wallet export flows.
+pub struct ExportClient {
+    encrypt_client: EnclaveEncryptClient,
+}
+
+impl ExportClient {
+    /// Creates a new Export client. Takes in a Quorum public key (use `QuorumPublicKey::production_signer()`)
+    ///
+    /// # Panics
+    /// Not expected, unless you are using an invalid quorum key
+    #[must_use]
+    pub fn new(quorum_public_key: &QuorumPublicKey) -> Self {
+        let verifying_key = quorum_public_key
+            .verifying_key()
+            .expect("quorum public key should yield a valid verifying key");
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key(verifying_key);
+        Self { encrypt_client }
+    }
+
+    /// Note that these private bytes are NOT the same as the private key bytes of the target key pair.
+    /// The private bytes are used as ikm (input key material) and used to derive a key pair.
+    ///
+    /// The size of the input key material SHOULD be >=32 bytes, so we enforce this here and return an error if the ikm is not long enough.
+    ///
+    /// WARNING: This interface can be misused if the same key material is provided over and over.
+    /// Indeed, enclave-to-end-user secure channels assume that encryption is "one-shot". After decryption is done, the key should not be reused.
+    /// You may use this interface to allow for ikm persistence and loading if it's not realistic or convenient to hold ikm in memory between initialization and decryption.
+    ///
+    /// # Panics
+    /// Not expected, unless you are using an invalid quorum key
+    pub fn dangerous_from_bytes<B: AsRef<[u8]>>(
+        private: B,
+        quorum_public_key: &QuorumPublicKey,
+    ) -> Self {
+        let (pair_private_key, pair_public_key) = Kem::derive_keypair(private.as_ref());
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            quorum_public_key
+                .verifying_key()
+                .expect("quorum public key should yield a valid verifying key"),
+            pair_public_key,
+            pair_private_key,
+        );
+        Self { encrypt_client }
+    }
+
+    /// Returns the target public key bytes, encoded as SEC1 bytes (04 || X || Y)
+    ///
+    /// This value is returned as a string, ready to be inserted in `EXPORT_WALLET` or `EXPORT_PRIVATE_KEY` activity params.
+    pub fn target_public_key(&self) -> Result<String, EnclaveEncryptError> {
+        Ok(hex::encode(self.encrypt_client.target_bytes()?))
+    }
+
+    /// Decrypts a private key bundle.
+    ///
+    /// Bundles are JSON encoded strings, e.g. "{\"version\":\"v1.0.0\",\"data\":\"7b22656e63617070656450...\"}"
+    ///
+    /// This function returns the raw private key bytes
+    pub fn decrypt_private_key<S: AsRef<str>, T: AsRef<str>>(
+        &mut self,
+        export_bundle: S,
+        organization_id: T,
+    ) -> Result<Vec<u8>, EnclaveEncryptError> {
+        let decrypted_bytes = self
+            .encrypt_client
+            .decrypt(export_bundle.as_ref().as_bytes(), organization_id.as_ref())?;
+        // We expect 32 bytes exactly
+        if decrypted_bytes.len() != EXPECTED_PRIVATE_KEY_BYTE_LENGTH {
+            return Err(EnclaveEncryptError::InvalidPrivateKeyByteLength);
+        }
+        Ok(decrypted_bytes)
+    }
+
+    /// Decrypts a private key bundle.
+    /// Bundles are JSON encoded strings, e.g. "{\"version\":\"v1.0.0\",\"data\":\"7b22656e63617070656450...\"}"
+    /// This function returns the mnemonic phrase as a string.
+    pub fn decrypt_wallet_mnemonic_phrase<S: AsRef<str>, T: AsRef<str>>(
+        &mut self,
+        export_bundle: S,
+        organization_id: T,
+    ) -> Result<String, EnclaveEncryptError> {
+        let decrypted_bytes = self
+            .encrypt_client
+            .decrypt(export_bundle.as_ref().as_bytes(), organization_id.as_ref())?;
+        // The text should be "whatever word goes here etc..." (valid UTF-8 bytes)
+        let phrase = from_utf8(&decrypted_bytes)
+            .map_err(|e| EnclaveEncryptError::InvalidUtf8Bytes(e.to_string()))?;
+        Ok(phrase.to_string())
+    }
+}
+
+/// Abstraction over `EnclaveEncryptClient` for private key or wallet import flows.
+pub struct ImportClient {
+    encrypt_client: EnclaveEncryptClient,
+}
+
+impl ImportClient {
+    /// Creates a new Export client. Takes in a Quorum public key (use `QuorumPublicKey::production_signer()`)
+    ///
+    /// # Panics
+    /// Not expected, unless you are using an invalid quorum key
+    #[must_use]
+    pub fn new(quorum_public_key: &QuorumPublicKey) -> Self {
+        let verifying_key = quorum_public_key
+            .verifying_key()
+            .expect("quorum public key should yield a valid verifying key");
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key(verifying_key);
+        Self { encrypt_client }
+    }
+
+    /// Note that these private bytes are NOT the same as the private key bytes of the target key pair.
+    /// The private bytes are used as ikm (input key material) and used to derive a key pair.
+    ///
+    /// The size of the input key material SHOULD be >=32 bytes, so we enforce this here and return an error if the ikm is not long enough.
+    ///
+    /// WARNING: This interface can be misused if the same key material is provided over and over.
+    /// Indeed, enclave-to-end-user secure channels assume that encryption is "one-shot". After decryption is done, the key should not be reused.
+    /// You may use this interface to allow for ikm persistence and loading if it's not realistic or convenient to hold ikm in memory between initialization and decryption.
+    ///
+    /// # Panics
+    /// Not expected, unless you are using an invalid quorum key
+    pub fn dangerous_from_bytes<B: AsRef<[u8]>>(
+        private: B,
+        quorum_public_key: &QuorumPublicKey,
+    ) -> Self {
+        let (pair_private_key, pair_public_key) = Kem::derive_keypair(private.as_ref());
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            quorum_public_key
+                .verifying_key()
+                .expect("quorum public key should yield a valid verifying key"),
+            pair_public_key,
+            pair_private_key,
+        );
+        Self { encrypt_client }
+    }
+
+    /// Encrypts a private key to the public key contained in an import bundle.
+    ///
+    /// - `private_key` is the key material (bytes) to import. Must be 32 bytes in length.
+    /// - `import_bundle` is the import bundle as a string. Bundles are JSON-encoded strings (e.g ""{\"version\":\"v1.0.0\", ....")
+    ///    bundles contain a signed public key. The signature over this public key is from Turnkey's signer enclave.
+    /// - `organization_id` is the expected organization ID. This will be checked against the content of the bundle, which contains the organization ID where the import flow started (`INIT_IMPORT` activity)
+    /// - `user_id` is the expected user ID. This will be checked against the content of the bundle, which contains the user ID who initiated import (`INIT_IMPORT`)
+    ///
+    /// Returns a string containing the JSON-encoded value, ready-to-use in an `IMPORT_PRIVATE_KEY` activity
+    pub fn encrypt_private_key_with_bundle<
+        B: AsRef<[u8]>,
+        S: AsRef<str>,
+        T: AsRef<str>,
+        U: AsRef<str>,
+    >(
+        &mut self,
+        private_key: B,
+        import_bundle: S,
+        organization_id: T,
+        user_id: U,
+    ) -> Result<String, EnclaveEncryptError> {
+        if private_key.as_ref().len() != EXPECTED_PRIVATE_KEY_BYTE_LENGTH {
+            return Err(EnclaveEncryptError::InvalidPrivateKeyByteLength);
+        }
+
+        let encrypted = self.encrypt_client.encrypt(
+            private_key.as_ref(),
+            import_bundle.as_ref().as_bytes(),
+            organization_id.as_ref(),
+            user_id.as_ref(),
+        )?;
+
+        serde_json::to_string(&encrypted)
+            .map_err(|e| EnclaveEncryptError::CannotSerializeBundle(e.to_string()))
+    }
+
+    /// Encrypts a wallet mnemonic phrase to the public key contained in an import bundle.
+    ///
+    /// - `mnemonic_phrase` is the wallet mnemonic phrase to import, as a string.
+    /// - `import_bundle` is the import bundle as a string. Bundles are JSON-encoded strings (e.g ""{\"version\":\"v1.0.0\", ....")
+    ///    bundles contain a signed public key. The signature over this public key is from Turnkey's signer enclave.
+    /// - `organization_id` is the expected organization ID. This will be checked against the content of the bundle, which contains the organization ID where the import flow started (`INIT_IMPORT` activity)
+    /// - `user_id` is the expected user ID. This will be checked against the content of the bundle, which contains the user ID who initiated import (`INIT_IMPORT`)
+    ///
+    /// Returns a string containing the JSON-encoded value, ready-to-use in an `IMPORT_WALLET` activity
+    pub fn encrypt_wallet_with_bundle<
+        S: AsRef<str>,
+        T: AsRef<str>,
+        U: AsRef<str>,
+        V: AsRef<str>,
+    >(
+        &mut self,
+        mnemonic_phrase: S,
+        import_bundle: T,
+        organization_id: U,
+        user_id: V,
+    ) -> Result<String, EnclaveEncryptError> {
+        let encrypted = self.encrypt_client.encrypt(
+            mnemonic_phrase.as_ref().as_bytes(),
+            import_bundle.as_ref().as_bytes(),
+            organization_id.as_ref(),
+            user_id.as_ref(),
+        )?;
+
+        serde_json::to_string(&encrypted)
+            .map_err(|e| EnclaveEncryptError::CannotSerializeBundle(e.to_string()))
+    }
+}
 
 /// An instance of the client side for `EnclaveEncrypt`. This should only be used for either
 /// a SINGLE send or a single receive.
@@ -53,6 +321,15 @@ impl EnclaveEncryptClient {
     pub fn target(&self) -> Result<P256Public, EnclaveEncryptError> {
         if let Some(target_public) = self.target_public.as_ref() {
             target_public.to_bytes().to_vec().try_into()
+        } else {
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        }
+    }
+
+    /// Get the encryption target bytes for this client
+    pub fn target_bytes(&self) -> Result<Vec<u8>, EnclaveEncryptError> {
+        if let Some(target_public) = self.target_public.as_ref() {
+            Ok(target_public.to_bytes().to_vec())
         } else {
             Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
         }
@@ -264,5 +541,382 @@ impl EnclaveEncryptClient {
         } else {
             Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::server::EnclaveEncryptServer;
+
+    use super::*;
+
+    fn example_credential() -> Vec<u8> {
+        hex::decode("67ee05fc3bdf4161bc70701c221d8d77180294cefcfcea64ba83c4d4c732fcb9").unwrap()
+    }
+
+    // Sample Quorum private key which we use to simulate enclave signatures on bundles for tests below
+    fn test_quorum_private_key() -> SigningKey {
+        SigningKey::from_bytes(
+            &hex::decode("28ebf311b27f34cdf078489584d336423e09c522342f5b067dea36823c2cc5ed")
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn test_quorum_public_key() -> QuorumPublicKey {
+        let quorum_public_key = concat!(
+            // first key -- does not matter
+            "04", // uncompressed prefix
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899", // x
+            "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa", // y
+            // our _actual_ signing key
+            // generated with https://r-n-o.github.io/p256-keygen/
+            "04", // uncompressed prefix
+            "8ee67fa8ae8e5fac0e343c84fa0921ecb3a31a67aee2e6a0880a09072eaaf2ae", // x
+            "ffa43f73fa021fa4d0b550072ba1f9011ff7cf917e4bf2708670e5ac57a81c78"  // y
+        );
+        QuorumPublicKey::from_string(quorum_public_key).unwrap()
+    }
+
+    #[test]
+    fn test_test_quorum_key() {
+        // Sanity check: are test_quorum_private_key and test_quorum_public_key consistent?
+        let derived_public_key = test_quorum_private_key()
+            .verifying_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        let public_key = test_quorum_public_key()
+            .verifying_key()
+            .unwrap()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        assert_eq!(derived_public_key, public_key);
+    }
+
+    #[test]
+    fn produce_and_decrypt_auth_bundle() {
+        let mut customer = AuthenticationClient::new();
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let auth_bundle = EnclaveEncryptServer::auth_encrypt(
+            &customer_target.try_into().unwrap(),
+            &example_credential(),
+        )
+        .unwrap();
+
+        let decrypted = customer.decrypt(auth_bundle).unwrap();
+        assert_eq!(decrypted, example_credential());
+    }
+
+    // This test shows how to decrypt an auth bundle.
+    // We simulate the case of a client with no access to encryption keys who receives a bundle
+    // encrypted to their public key.
+    #[test]
+    fn static_auth_bundle_decrypt() {
+        // Hardcode a random client IKM to get stable test vectors across runs.
+        let client_ikm =
+            hex::decode("c8e5d3ccbf8c4e62e3bcb984681ce6dda950939905754902a394c1fc2b5c6a9e")
+                .unwrap();
+        let (client_private_key, client_public_key) = Kem::derive_keypair(&client_ikm);
+
+        // Unlikely but check just in case: same IKM should result in the same private key
+        assert_eq!(
+            hex::encode(client_private_key.to_bytes()),
+            "d2d9239a4bb25d09a6d91822e1d0991f0b21a63b102191bb98b6b77ac6fc6c91"
+        );
+        // And the same public key
+        let expected_target_public_key = "0406f6d27ae62d66358b2b5888a8ccb2a0f4f1f86a5d2e9683b61c418b49e57df446b1518cb1c370e30ee80c61266a56b342b424b26c6b86419001a404d1d5fcc5";
+        assert_eq!(
+            hex::encode(client_public_key.to_bytes()),
+            expected_target_public_key
+        );
+        assert_eq!(
+            AuthenticationClient::dangerous_from_bytes(&client_ikm)
+                .target_public_key()
+                .unwrap(),
+            expected_target_public_key
+        );
+
+        // We fix the bundle to a static value, to simulate the case where it's e.g. coming from an activity result or an email
+        // This also ensures that future updates to this crate don't break old bundles!
+        let bundle = "skr1QFHrNyL7xcvzRpU4t9yhL8rEVPZgDcFM5YW8S1YwLYjedoagnNZwMCyJsxNYzuphKHqQBkZxt4fLWSVsMqnW9XdmLBsK2MhwC5WxuxZD9xE8ezQ";
+        let decrypted = AuthenticationClient::dangerous_from_bytes(client_ikm)
+            .decrypt(bundle)
+            .expect("decryption should succeed");
+
+        // Assert that what we decrypted is what was originally encrypted: our "example_credential"
+        assert_eq!(decrypted, example_credential());
+    }
+
+    #[test]
+    fn produce_and_decrypt_private_key_export_bundle() {
+        let mut customer = ExportClient::new(&test_quorum_public_key());
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+
+        let encrypt_bundle = enclave
+            .encrypt(&customer_target.try_into().unwrap(), &example_credential())
+            .unwrap();
+
+        // This is what is sent over the wire to the customer
+        let encoded_bundle = serde_json::to_string(&encrypt_bundle).unwrap();
+
+        // Decrypt the private key and get the same bytes than encrypted earlier
+        assert_eq!(
+            customer
+                .decrypt_private_key(encoded_bundle, "org-id")
+                .unwrap(),
+            example_credential()
+        );
+    }
+
+    #[test]
+    fn produce_and_decrypt_wallet_export_bundle() {
+        let mut customer = ExportClient::new(&test_quorum_public_key());
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let mnemonic = "remember wallet wallet remember";
+        let encrypt_bundle = enclave
+            .encrypt(&customer_target.try_into().unwrap(), mnemonic.as_bytes())
+            .unwrap();
+
+        // This is what is sent over the wire to the customer
+        let encoded_bundle = serde_json::to_string(&encrypt_bundle).unwrap();
+
+        // Decrypt the private key and get the same bytes than encrypted earlier
+        assert_eq!(
+            customer
+                .decrypt_wallet_mnemonic_phrase(encoded_bundle, "org-id")
+                .unwrap(),
+            mnemonic
+        );
+    }
+
+    #[test]
+    fn bad_private_key_export_bundles_fail_decryption() {
+        let mut customer = ExportClient::new(&test_quorum_public_key());
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+
+        let encrypt_bundle = enclave
+            .encrypt(
+                &customer_target.try_into().unwrap(),
+                &hex::decode("12345678").unwrap(),
+            )
+            .unwrap();
+
+        // Trying to decrypt a private key, but we only have 4 bytes. Not 32!
+        assert_eq!(
+            customer
+                .decrypt_private_key(serde_json::to_string(&encrypt_bundle).unwrap(), "org-id")
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidPrivateKeyByteLength,
+        );
+    }
+
+    #[test]
+    fn bad_private_wallet_bundles_fail_decryption() {
+        let mut customer = ExportClient::new(&test_quorum_public_key());
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let encrypt_bundle = enclave
+            .encrypt(&customer_target.try_into().unwrap(), &example_credential())
+            .unwrap();
+
+        // Trying to decrypt a wallet, but we have non-utf8 bytes (we encrypted private key bytes!)
+        assert_eq!(
+            customer
+                .decrypt_wallet_mnemonic_phrase(
+                    serde_json::to_string(&encrypt_bundle).unwrap(),
+                    "org-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidUtf8Bytes(
+                "invalid utf-8 sequence of 1 bytes from index 1".to_string()
+            ),
+        );
+    }
+
+    #[test]
+    fn export_bundle_decryption_fails_with_incorrect_org_id() {
+        let mut customer = ExportClient::new(&test_quorum_public_key());
+        let customer_target = hex::decode(customer.target_public_key().unwrap()).unwrap();
+
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+
+        let encrypt_bundle = enclave
+            .encrypt(&customer_target.try_into().unwrap(), &example_credential())
+            .unwrap();
+
+        assert_eq!(
+            customer
+                .decrypt_private_key(
+                    serde_json::to_string(&encrypt_bundle).unwrap(),
+                    "wrong-org-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidOrganization,
+        );
+        assert_eq!(
+            customer
+                .decrypt_wallet_mnemonic_phrase(
+                    serde_json::to_string(&encrypt_bundle).unwrap(),
+                    "wrong-org-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidOrganization,
+        );
+    }
+
+    #[test]
+    fn import_private_key() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            Some("user-id".to_string()),
+        );
+        let import_bundle = enclave.publish_target().unwrap();
+        let encoded_bundle = serde_json::to_string(&import_bundle).unwrap();
+
+        let mut customer = ImportClient::new(&test_quorum_public_key());
+        let encrypted_key = customer
+            .encrypt_private_key_with_bundle(
+                example_credential(),
+                encoded_bundle,
+                "org-id",
+                "user-id",
+            )
+            .unwrap();
+
+        let mut enclave_receiver = enclave.into_recv();
+        assert_eq!(
+            enclave_receiver
+                .decrypt(&serde_json::from_str(&encrypted_key).unwrap())
+                .unwrap(),
+            example_credential(),
+        );
+    }
+
+    #[test]
+    fn import_private_key_fails_with_incorrect_metadata_or_bad_bytes() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            Some("user-id".to_string()),
+        );
+        let import_bundle = enclave.publish_target().unwrap();
+        let encoded_bundle = serde_json::to_string(&import_bundle).unwrap();
+
+        let mut customer = ImportClient::new(&test_quorum_public_key());
+        assert_eq!(
+            customer
+                .encrypt_private_key_with_bundle(
+                    example_credential(),
+                    &encoded_bundle,
+                    "wrong-org-id",
+                    "user-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidOrganization,
+        );
+        assert_eq!(
+            customer
+                .encrypt_private_key_with_bundle(
+                    example_credential(),
+                    &encoded_bundle,
+                    "org-id",
+                    "wrong-user-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidUser,
+        );
+        assert_eq!(
+            customer
+                .encrypt_private_key_with_bundle(
+                    hex::decode("0123").unwrap(),
+                    &encoded_bundle,
+                    "org-id",
+                    "user-id"
+                )
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidPrivateKeyByteLength,
+        );
+    }
+
+    #[test]
+    fn import_wallet() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            Some("user-id".to_string()),
+        );
+        let import_bundle = enclave.publish_target().unwrap();
+        let encoded_bundle = serde_json::to_string(&import_bundle).unwrap();
+
+        let mut customer = ImportClient::new(&test_quorum_public_key());
+        let mnemonic = "remember wallet wallet remember";
+        let encrypted_key = customer
+            .encrypt_wallet_with_bundle(mnemonic, encoded_bundle, "org-id", "user-id")
+            .unwrap();
+
+        let mut enclave_receiver = enclave.into_recv();
+        assert_eq!(
+            enclave_receiver
+                .decrypt(&serde_json::from_str(&encrypted_key).unwrap())
+                .unwrap(),
+            mnemonic.as_bytes(),
+        );
+    }
+
+    #[test]
+    fn import_wallet_fails_with_incorrect_metadata() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            Some("user-id".to_string()),
+        );
+        let import_bundle = enclave.publish_target().unwrap();
+        let encoded_bundle = serde_json::to_string(&import_bundle).unwrap();
+
+        let mut customer = ImportClient::new(&test_quorum_public_key());
+        let mnemonic = "wallet remember remember wallet";
+        assert_eq!(
+            customer
+                .encrypt_wallet_with_bundle(mnemonic, &encoded_bundle, "wrong-org-id", "user-id")
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidOrganization,
+        );
+        assert_eq!(
+            customer
+                .encrypt_wallet_with_bundle(mnemonic, &encoded_bundle, "org-id", "wrong-user-id")
+                .unwrap_err(),
+            EnclaveEncryptError::InvalidUser,
+        );
     }
 }

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -32,7 +32,7 @@ impl AuthenticationClient {
     /// Creates a new `AuthenticationClient` with a fresh target key pair.
     pub fn new() -> Self {
         // A VerifyingKey is required to construct `EnclaveEncryptClient`, but unused when decrypting auth bundles.
-        // This is safe not to verify auth bundles authenticity, because this bundles contain credential private key material.
+        // This is safe not to verify auth bundles authenticity, because these bundles contain credential private key material.
         // If these bundles are bogus or tampered with they would contain "bad" bytes, which implies the decrypted bytes would either not result in a valid credential, or result in a credential that is not capable to sign Turnkey activities.
         let random_key = SigningKey::random(&mut OsRng);
         let encrypt_client =
@@ -172,7 +172,7 @@ pub struct ImportClient {
 }
 
 impl ImportClient {
-    /// Creates a new Export client. Takes in a Quorum public key (use `QuorumPublicKey::production_signer()`)
+    /// Creates a new Import client. Takes in a Quorum public key (use `QuorumPublicKey::production_signer()`)
     ///
     /// # Panics
     /// Not expected, unless you are using an invalid quorum key

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -1,0 +1,268 @@
+//! Enclave Encrypt Client
+use hpke::{Deserializable, Kem as KemTrait, Serializable};
+use p256::{
+    ecdsa::{signature::Verifier, DerSignature, VerifyingKey},
+    PublicKey,
+};
+use rand_core::OsRng;
+
+use crate::{
+    decompress_p256_public, decrypt, encrypt, errors::EnclaveEncryptError, ClientSendMsg, Kem,
+    P256Public, ServerSendData, ServerSendMsg, ServerSendMsgV0, ServerSendMsgV1, ServerTargetData,
+    ServerTargetMsg, ServerTargetMsgV0, ServerTargetMsgV1, DATA_VERSION, TURNKEY_HPKE_INFO,
+};
+
+/// An instance of the client side for `EnclaveEncrypt`. This should only be used for either
+/// a SINGLE send or a single receive.
+///
+/// Use `AuthenticationClient`, `ExportClient` or `ImportClient` for safer interfaces.
+pub struct EnclaveEncryptClient {
+    enclave_auth_key: VerifyingKey,
+    target_public: Option<<Kem as KemTrait>::PublicKey>,
+    // The underlying type is zero on drop
+    target_private: Option<<Kem as KemTrait>::PrivateKey>,
+}
+
+impl EnclaveEncryptClient {
+    /// Create a client from the quorum public key.
+    #[must_use]
+    pub fn from_enclave_auth_key(enclave_auth_key: VerifyingKey) -> Self {
+        let (target_private, target_public) = Kem::gen_keypair(&mut OsRng);
+        Self {
+            enclave_auth_key,
+            target_public: Some(target_public),
+            target_private: Some(target_private),
+        }
+    }
+
+    /// Create a client from the quorum public key and the target key.
+    #[must_use]
+    pub fn from_enclave_auth_key_and_target_key(
+        enclave_auth_key: VerifyingKey,
+        target_public_key: <Kem as KemTrait>::PublicKey,
+        target_private_key: <Kem as KemTrait>::PrivateKey,
+    ) -> Self {
+        Self {
+            enclave_auth_key,
+            target_public: Some(target_public_key),
+            target_private: Some(target_private_key),
+        }
+    }
+
+    /// Get the encryption target of the client
+    pub fn target(&self) -> Result<P256Public, EnclaveEncryptError> {
+        if let Some(target_public) = self.target_public.as_ref() {
+            target_public.to_bytes().to_vec().try_into()
+        } else {
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        }
+    }
+
+    /// Encrypt a message to the given server target.
+    #[allow(clippy::unused_self)]
+    pub fn encrypt(
+        &self,
+        plaintext: &[u8],
+        msg_bytes: &[u8],
+        organization_id: &str,
+        user_id: &str,
+    ) -> Result<ClientSendMsg, EnclaveEncryptError> {
+        let ciphertext;
+        let encapped_public: <Kem as KemTrait>::EncappedKey;
+
+        let msg: ServerTargetMsg = serde_json::from_slice(msg_bytes)
+            .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+        match msg.version.as_ref() {
+            None => {
+                let msg_v0: ServerTargetMsgV0 = serde_json::from_slice(msg_bytes)
+                    .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+                let signature = DerSignature::try_from(&msg_v0.target_public_signature[..])
+                    .map_err(|_| EnclaveEncryptError::InvalidServerTargetSignature)?;
+
+                self.enclave_auth_key
+                    .verify(&*msg_v0.target_public, &signature)
+                    .map_err(|_| EnclaveEncryptError::ServerTargetSignatureVerificationFail)?;
+
+                let receiver_public =
+                    <Kem as KemTrait>::PublicKey::from_bytes(&*msg_v0.target_public)
+                        .map_err(EnclaveEncryptError::InvalidServerTarget)?;
+                (ciphertext, encapped_public) =
+                    encrypt(&receiver_public, plaintext, TURNKEY_HPKE_INFO)?;
+            }
+            Some(s) if s.as_str() == DATA_VERSION => {
+                let msg_v1: ServerTargetMsgV1 = serde_json::from_slice(msg_bytes)
+                    .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+                let signature = DerSignature::try_from(&msg_v1.data_signature[..])
+                    .map_err(|_| EnclaveEncryptError::InvalidServerTargetSignature)?;
+
+                let enclave_quorum_public = {
+                    let public = PublicKey::from_sec1_bytes(&*msg_v1.enclave_quorum_public)
+                        .map_err(|_| EnclaveEncryptError::InvalidEnclaveQuorumPublicKey)?;
+                    VerifyingKey::from(public)
+                };
+
+                if !enclave_quorum_public.eq(&self.enclave_auth_key) {
+                    return Err(EnclaveEncryptError::InvalidEnclaveQuorumPublicKey);
+                }
+
+                let parsed_data = serde_json::from_slice::<ServerTargetData>(&msg_v1.data)
+                    .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+                enclave_quorum_public
+                    .verify(&msg_v1.data, &signature)
+                    .map_err(|_| EnclaveEncryptError::ServerTargetSignatureVerificationFail)?;
+
+                if !parsed_data.organization_id.eq(organization_id) {
+                    return Err(EnclaveEncryptError::InvalidOrganization);
+                }
+
+                if !parsed_data.user_id.eq(user_id) {
+                    return Err(EnclaveEncryptError::InvalidUser);
+                }
+
+                let receiver_public =
+                    <Kem as KemTrait>::PublicKey::from_bytes(&*parsed_data.target_public)
+                        .map_err(EnclaveEncryptError::InvalidServerTarget)?;
+                (ciphertext, encapped_public) =
+                    encrypt(&receiver_public, plaintext, TURNKEY_HPKE_INFO)?;
+            }
+            Some(_) => return Err(EnclaveEncryptError::InvalidDataVersion),
+        }
+
+        Ok(ClientSendMsg {
+            encapped_public: encapped_public.to_bytes().to_vec().try_into()?,
+            ciphertext,
+        })
+    }
+
+    /// Decrypt a message from the server targeted at this client.
+    pub fn decrypt(
+        &mut self,
+        msg_bytes: &[u8],
+        organization_id: &str,
+    ) -> Result<Vec<u8>, EnclaveEncryptError> {
+        let ciphertext;
+        let encapped_public: <Kem as KemTrait>::EncappedKey;
+
+        let msg: ServerSendMsg = serde_json::from_slice(msg_bytes)
+            .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+        match msg.version.as_ref() {
+            None => {
+                let msg_v0: ServerSendMsgV0 = serde_json::from_slice(msg_bytes)
+                    .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+                let signature = DerSignature::try_from(&msg_v0.encapped_public_signature[..])
+                    .map_err(|_| EnclaveEncryptError::InvalidSeverEncappedKeySignature)?;
+
+                self.enclave_auth_key
+                    .verify(&*msg_v0.encapped_public, &signature)
+                    .map_err(|_| EnclaveEncryptError::ServerEncappedKeySignatureVerificationFail)?;
+
+                encapped_public =
+                    <Kem as KemTrait>::EncappedKey::from_bytes(&*msg_v0.encapped_public)
+                        .map_err(EnclaveEncryptError::InvalidEncappedKey)?;
+
+                ciphertext = msg_v0.ciphertext;
+            }
+            Some(s) if s.as_str() == DATA_VERSION => {
+                let msg_v1: ServerSendMsgV1 = serde_json::from_slice(msg_bytes)
+                    .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+
+                let signature = DerSignature::try_from(&msg_v1.data_signature[..])
+                    .map_err(|_| EnclaveEncryptError::InvalidSeverEncappedKeySignature)?;
+
+                let enclave_quorum_public = {
+                    let public = PublicKey::from_sec1_bytes(&*msg_v1.enclave_quorum_public)
+                        .map_err(|_| EnclaveEncryptError::InvalidEnclaveQuorumPublicKey)?;
+                    VerifyingKey::from(public)
+                };
+
+                if !enclave_quorum_public.eq(&self.enclave_auth_key) {
+                    return Err(EnclaveEncryptError::InvalidEnclaveQuorumPublicKey);
+                }
+
+                let parsed_data = serde_json::from_slice::<ServerSendData>(&msg_v1.data)
+                    .map_err(|_| EnclaveEncryptError::FailedToSerializeData)?;
+                enclave_quorum_public
+                    .verify(&msg_v1.data, &signature)
+                    .map_err(|_| EnclaveEncryptError::ServerEncappedKeySignatureVerificationFail)?;
+
+                if !parsed_data.organization_id.eq(organization_id) {
+                    return Err(EnclaveEncryptError::InvalidOrganization);
+                }
+
+                encapped_public =
+                    <Kem as KemTrait>::EncappedKey::from_bytes(&*parsed_data.encapped_public)
+                        .map_err(EnclaveEncryptError::InvalidEncappedKey)?;
+
+                ciphertext = parsed_data.ciphertext;
+            }
+            Some(_) => return Err(EnclaveEncryptError::InvalidDataVersion),
+        }
+
+        if let (Some(target_private), Some(target_public)) =
+            (self.target_private.as_ref(), self.target_public.as_ref())
+        {
+            let result = decrypt(
+                &encapped_public,
+                target_private,
+                target_public,
+                &ciphertext,
+                TURNKEY_HPKE_INFO,
+            );
+
+            self.target_public = None;
+            self.target_private = None;
+
+            result
+        } else {
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        }
+    }
+
+    /// Decrypt a base64 serialized email recovery or auth payload.
+    pub fn auth_decrypt(&mut self, payload: &str) -> Result<Vec<u8>, EnclaveEncryptError> {
+        let payload_bytes = bs58::decode(payload)
+            .with_check(None)
+            .into_vec()
+            .map_err(|e| {
+                EnclaveEncryptError::FailedToBase58Decode(format!(
+                    "error when decoding payload: {e:?}"
+                ))
+            })?;
+        let raw_encapped = payload_bytes
+            .get(0..33)
+            .ok_or(EnclaveEncryptError::InvalidEmailRecoveryPayload)?;
+        let ciphertext = payload_bytes
+            .get(33..)
+            .ok_or(EnclaveEncryptError::InvalidEmailRecoveryPayload)?;
+
+        let encapped_public = {
+            let encapped_public_bytes = decompress_p256_public(raw_encapped)?;
+            <Kem as KemTrait>::EncappedKey::from_bytes(&encapped_public_bytes)
+                .map_err(EnclaveEncryptError::InvalidEncappedKey)?
+        };
+
+        if let (Some(target_private), Some(target_public)) =
+            (self.target_private.as_ref(), self.target_public.as_ref())
+        {
+            let result = decrypt(
+                &encapped_public,
+                target_private,
+                target_public,
+                ciphertext,
+                TURNKEY_HPKE_INFO,
+            );
+
+            self.target_public = None;
+            self.target_private = None;
+
+            result
+        } else {
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        }
+    }
+}

--- a/enclave_encrypt/src/errors.rs
+++ b/enclave_encrypt/src/errors.rs
@@ -1,71 +1,102 @@
 //! errors for this crate
+use thiserror::Error;
 
 /// Errors for enclave encryption
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(missing_docs)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum EnclaveEncryptError {
     /// Receiver or Encap key is likely wrong.
+    #[error("Failed to set up receiver context")]
     ReceiveCtxSetupFail,
+
     /// Something is likely wrong with the receiver public key.
+    #[error("Failed to set up receiver context")]
     FailedToSetupSendCtx,
-    /// Failed to encrypt the given plaintext.
+
+    #[error("Failed to encrypt plaintext")]
     FailedToEncrypt,
-    /// Failed to decrypt the given ciphertext.
+
+    #[error("Failed to decrypt ciphertext")]
     FailedToDecrypt,
-    /// Failed to serialize the data from the server.
+
+    #[error("Failed to serialize data")]
     FailedToSerializeData,
-    /// Failed to deserialize the data from the server.
+
+    #[error("Failed to deserialize data")]
     FailedToDeserializeData,
-    /// Could not verify the quorum key signature over the servers given
-    /// target public key.
+
+    #[error("Could not verify the quorum key signature over the servers given the target public")]
     ServerTargetSignatureVerificationFail,
-    /// Could not verify the quorum key signature over the encapsulation key.
+
+    #[error("Could not verify the quorum key signature over the encapsulation key")]
     ServerEncappedKeySignatureVerificationFail,
-    /// Encapsulation key could not be deserialized.
+
+    #[error("Error while deserializing encapped key")]
     InvalidEncappedKey(hpke::HpkeError),
-    /// Could not deserialize server's target key.
+
+    #[error("Error while deserializing the server target key")]
     InvalidServerTarget(hpke::HpkeError),
-    /// Could not deserialize client target key.
+
+    #[error("Error while deserializing the client target key")]
     InvalidClientTarget(hpke::HpkeError),
-    /// Could not deserialize server's encapsulated key.
+
+    #[error("Error while deserializing the server encapsulated key")]
     InvalidSeverEncappedKeySignature,
-    /// Could not deserialize signature over server target key.
+
+    #[error("Error while deserializing signature over the server target key")]
     InvalidServerTargetSignature,
-    /// Could not use secret as signing key.
+
+    #[error("Count not use quorum secret as a valid signing key")]
     InvalidQuorumSecret,
-    /// Server target key has already been used to decrypt a message.
+
+    #[error("This server has already been used to decrypt a message")]
     ServerAlreadyUsedToDecrypt,
-    /// Client target key has already been used to decrypt a message.
+
+    #[error("This client has already been used to decrypt a message")]
     ClientAlreadyUsedToDecrypt,
-    /// P256 public key could not be coerced into fixed length array.
+
+    #[error("P256 public key could not be coerced into fixed length array")]
     InvalidP256PublicKeyLength,
-    /// P256 signature could not be coerced into fixed length array.
+
+    #[error("P256 signature could not be coerced into fixed length array")]
     InvalidP256SignatureLength,
-    /// Could not deserialize p256 public key as sec1 encoded.
+
+    #[error("Could not deserialize P-256 public key: invalid SEC1 encoding")]
     InvalidP256PublicKeySec1Encoding(String),
-    /// Failed to decode a base58-encoded string.
+
+    #[error("Invalid base58 encoding")]
     FailedToBase58Decode(String),
-    /// Email recovery payload was shorter then expected.
+
+    #[error("Email recovery payload is shorter than")]
     InvalidEmailRecoveryPayload,
-    /// Invalid enclave quorum public key.
+
+    #[error("Invalid enclave quorum public key")]
     InvalidEnclaveQuorumPublicKey,
-    /// Invalid version of the data object sent from the server.
+
+    #[error("Invalid data version")]
     InvalidDataVersion,
-    /// Invalid organization ID in the data object sent from the server.
+
+    #[error("Organization from bundle does not match the expected organization ID")]
     InvalidOrganization,
-    /// Invalid user ID in the data object sent from the server.
+
+    #[error("User from bundle does not match the expected user ID")]
     InvalidUser,
-    /// The provided public key bytes aren't sized correctly.
+
+    #[error("Provided public key bytes are not sized correctly for a Quorum public key")]
     IncorrectQuorumPublicKeyBytesLength(usize),
-    /// Error while decoding hex bytes
+
+    #[error("Error while decoding hex-encoded string: {0}")]
     HexDecode(String),
-    /// Invalid bytes were used to create a `VerifyingKey`
+
+    #[error("Cannot create a verifying key from invalid")]
     InvalidVerifyingKeyBytes,
-    /// Invalid Utf8 bytes
+
+    #[error("Bytes contain invalid UTF-8")]
     InvalidUtf8Bytes(String),
-    /// Invalid exported private key -- does not start with 0x...
-    InvalidExportedPrivateKey,
-    /// Invalid private key length
+
+    #[error("Invalid byte length for private key")]
     InvalidPrivateKeyByteLength,
-    /// Unable to serialize encrypted bundle (JSON serialization)
+
+    #[error("Cannot JSON-serialize bundle: {0}")]
     CannotSerializeBundle(String),
 }

--- a/enclave_encrypt/src/errors.rs
+++ b/enclave_encrypt/src/errors.rs
@@ -1,0 +1,57 @@
+//! errors for this crate
+
+/// Errors for enclave encryption
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnclaveEncryptError {
+    /// Receiver or Encap key is likely wrong.
+    ReceiveCtxSetupFail,
+    /// Something is likely wrong with the receiver public key.
+    FailedToSetupSendCtx,
+    /// Failed to encrypt the given plaintext.
+    FailedToEncrypt,
+    /// Failed to decrypt the given ciphertext.
+    FailedToDecrypt,
+    /// Failed to serialize the data from the server.
+    FailedToSerializeData,
+    /// Failed to deserialize the data from the server.
+    FailedToDeserializeData,
+    /// Could not verify the quorum key signature over the servers given
+    /// target public key.
+    ServerTargetSignatureVerificationFail,
+    /// Could not verify the quorum key signature over the encapsulation key.
+    ServerEncappedKeySignatureVerificationFail,
+    /// Encapsulation key could not be deserialized.
+    InvalidEncappedKey(hpke::HpkeError),
+    /// Could not deserialize server's target key.
+    InvalidServerTarget(hpke::HpkeError),
+    /// Could not deserialize client target key.
+    InvalidClientTarget(hpke::HpkeError),
+    /// Could not deserialize server's encapsulated key.
+    InvalidSeverEncappedKeySignature,
+    /// Could not deserialize signature over server target key.
+    InvalidServerTargetSignature,
+    /// Could not use secret as signing key.
+    InvalidQuorumSecret,
+    /// Server target key has already been used to decrypt a message.
+    ServerAlreadyUsedToDecrypt,
+    /// Client target key has already been used to decrypt a message.
+    ClientAlreadyUsedToDecrypt,
+    /// P256 public key could not be coerced into fixed length array.
+    InvalidP256PublicKeyLength,
+    /// P256 signature could not be coerced into fixed length array.
+    InvalidP256SignatureLength,
+    /// Could not deserialize p256 public key as sec1 encoded.
+    InvalidP256PublicKeySec1Encoding(String),
+    /// Failed to decode a base58-encoded string.
+    FailedToBase58Decode(String),
+    /// Email recovery payload was shorter then expected.
+    InvalidEmailRecoveryPayload,
+    /// Invalid enclave quorum public key.
+    InvalidEnclaveQuorumPublicKey,
+    /// Invalid version of the data object sent from the server.
+    InvalidDataVersion,
+    /// Invalid organization ID in the data object sent from the server.
+    InvalidOrganization,
+    /// Invalid user ID in the data object sent from the server.
+    InvalidUser,
+}

--- a/enclave_encrypt/src/errors.rs
+++ b/enclave_encrypt/src/errors.rs
@@ -10,7 +10,7 @@ pub enum EnclaveEncryptError {
     ReceiveCtxSetupFail,
 
     /// Something is likely wrong with the receiver public key.
-    #[error("Failed to set up receiver context")]
+    #[error("Failed to set up sender context")]
     FailedToSetupSendCtx,
 
     #[error("Failed to encrypt plaintext")]
@@ -46,7 +46,7 @@ pub enum EnclaveEncryptError {
     #[error("Error while deserializing signature over the server target key")]
     InvalidServerTargetSignature,
 
-    #[error("Count not use quorum secret as a valid signing key")]
+    #[error("Could not use quorum secret as a valid signing key")]
     InvalidQuorumSecret,
 
     #[error("This server has already been used to decrypt a message")]
@@ -67,7 +67,7 @@ pub enum EnclaveEncryptError {
     #[error("Invalid base58 encoding")]
     FailedToBase58Decode(String),
 
-    #[error("Email recovery payload is shorter than")]
+    #[error("Email recovery payload is shorter than expected")]
     InvalidEmailRecoveryPayload,
 
     #[error("Invalid enclave quorum public key")]
@@ -88,7 +88,7 @@ pub enum EnclaveEncryptError {
     #[error("Error while decoding hex-encoded string: {0}")]
     HexDecode(String),
 
-    #[error("Cannot create a verifying key from invalid")]
+    #[error("Cannot create a verifying key from invalid bytes")]
     InvalidVerifyingKeyBytes,
 
     #[error("Bytes contain invalid UTF-8")]

--- a/enclave_encrypt/src/errors.rs
+++ b/enclave_encrypt/src/errors.rs
@@ -54,4 +54,18 @@ pub enum EnclaveEncryptError {
     InvalidOrganization,
     /// Invalid user ID in the data object sent from the server.
     InvalidUser,
+    /// The provided public key bytes aren't sized correctly.
+    IncorrectQuorumPublicKeyBytesLength(usize),
+    /// Error while decoding hex bytes
+    HexDecode(String),
+    /// Invalid bytes were used to create a `VerifyingKey`
+    InvalidVerifyingKeyBytes,
+    /// Invalid Utf8 bytes
+    InvalidUtf8Bytes(String),
+    /// Invalid exported private key -- does not start with 0x...
+    InvalidExportedPrivateKey,
+    /// Invalid private key length
+    InvalidPrivateKeyByteLength,
+    /// Unable to serialize encrypted bundle (JSON serialization)
+    CannotSerializeBundle(String),
 }

--- a/enclave_encrypt/src/lib.rs
+++ b/enclave_encrypt/src/lib.rs
@@ -16,8 +16,13 @@ use rand_core::OsRng;
 
 pub mod client;
 pub mod errors;
-pub mod quorum_public_key;
+mod quorum_public_key;
 pub mod server;
+
+pub use client::AuthenticationClient;
+pub use client::ExportClient;
+pub use client::ImportClient;
+pub use quorum_public_key::QuorumPublicKey;
 
 /// See the [readme](README.md#hpke-configuration) for how to configure these value.
 /// HPKE Key encapsulation mechanism

--- a/enclave_encrypt/src/lib.rs
+++ b/enclave_encrypt/src/lib.rs
@@ -1,0 +1,570 @@
+//! Primitives to support one shot enclave encryption protocol described in this
+//! crate's readme.
+
+#![forbid(unsafe_code)]
+#![deny(clippy::all, clippy::unwrap_used)]
+#![warn(missing_docs, clippy::pedantic)]
+#![allow(clippy::missing_errors_doc, clippy::module_name_repetitions)]
+
+use crate::errors::EnclaveEncryptError;
+
+use std::ops::Deref;
+
+use hpke::{Kem as KemTrait, OpModeR, OpModeS, Serializable};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use rand_core::OsRng;
+
+pub mod client;
+pub mod errors;
+pub mod server;
+
+/// See the [readme](README.md#hpke-configuration) for how to configure these value.
+/// HPKE Key encapsulation mechanism
+type Kem = hpke::kem::DhP256HkdfSha256;
+/// HPKE Authenticated Encryption Scheme
+type Aead = hpke::aead::AesGcm256;
+/// HPKE Key Derivation Function
+type Kdf = hpke::kdf::HkdfSha256;
+/// HPKE info
+const TURNKEY_HPKE_INFO: &[u8] = b"turnkey_hpke";
+/// Version of data sent in messages from server.
+const DATA_VERSION: &str = "v1.0.0";
+
+fn compress_p256_public(uncompressed_public: &[u8]) -> Result<Box<[u8]>, EnclaveEncryptError> {
+    Ok(p256::PublicKey::from_sec1_bytes(uncompressed_public)
+        .map_err(|e| EnclaveEncryptError::InvalidP256PublicKeySec1Encoding(e.to_string()))?
+        .to_encoded_point(true)
+        .to_bytes())
+}
+
+fn decompress_p256_public(compressed_public: &[u8]) -> Result<Box<[u8]>, EnclaveEncryptError> {
+    Ok(p256::PublicKey::from_sec1_bytes(compressed_public)
+        .map_err(|e| EnclaveEncryptError::InvalidP256PublicKeySec1Encoding(e.to_string()))?
+        .to_encoded_point(false)
+        .to_bytes())
+}
+
+/// Typed wrapper for p256 uncompressed public key bytes.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library by serializing/deserializing
+/// between a hex-encoded string and public key bytes.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct P256Public(#[serde(with = "hex::serde")] pub [u8; 65]);
+impl TryFrom<Vec<u8>> for P256Public {
+    type Error = EnclaveEncryptError;
+    fn try_from(vec: Vec<u8>) -> Result<Self, EnclaveEncryptError> {
+        let inner = vec
+            .try_into()
+            .map_err(|_| EnclaveEncryptError::InvalidP256PublicKeyLength)?;
+        Ok(Self(inner))
+    }
+}
+impl Deref for P256Public {
+    type Target = [u8; 65];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Typed wrapper for p256 signature bytes.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library by serializing/deserializing
+/// between a hex-encoded string and signature bytes.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct P256Signature(#[serde(with = "hex::serde")] pub Vec<u8>);
+impl From<Vec<u8>> for P256Signature {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(vec)
+    }
+}
+impl Deref for P256Signature {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Message from the server.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSendMsg {
+    /// Version of the data.
+    version: Option<String>,
+}
+
+/// Message from the server with encapsulated key, quorum key signature over
+/// encapsulated key and ciphertext.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSendMsgV0 {
+    /// Encapsulation key used to generate the ciphertext.
+    encapped_public: P256Public,
+    /// Quorum key signature over the encapsulation key.
+    encapped_public_signature: P256Signature,
+    /// Ciphertext from the server.
+    /// This attribute serializes/deserializes between a hex-encoded string and bytes.
+    #[serde(with = "hex::serde")]
+    ciphertext: Vec<u8>,
+}
+
+/// Message from the server with data, the data's version, enclave quorum key, and the enclave
+/// quorum key signature over the data.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSendMsgV1 {
+    /// Version of the data.
+    version: String,
+    /// Data sent by the enclave server. This is also the message used to produce `data_signature`.
+    #[serde(with = "hex::serde")]
+    data: Vec<u8>,
+    /// Enclave quorum key signature over the data.
+    data_signature: P256Signature,
+    /// Enclave quorum key public key.
+    enclave_quorum_public: P256Public,
+}
+
+/// Data object from the server with the encapsulated public key, ciphertext,
+/// and an organization ID.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSendData {
+    /// Encapsulation key used to generate the ciphertext.
+    encapped_public: P256Public,
+    /// Ciphertext from the server.
+    /// This attribute serializes/deserializes between a hex-encoded string and bytes.
+    #[serde(with = "hex::serde")]
+    ciphertext: Vec<u8>,
+    /// Organization making the request
+    organization_id: String,
+}
+
+/// Message from the server.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTargetMsg {
+    /// Version of the data.
+    version: Option<String>,
+}
+
+/// Message from the server with a encryption target key  and a quorum key
+/// signature over it.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTargetMsgV0 {
+    /// Target public key for client to encrypt to.
+    pub target_public: P256Public,
+    /// Signature over the servers public target key.
+    pub target_public_signature: P256Signature,
+}
+
+/// Message from the server with data, the data's version, enclave quorum key, and the enclave
+/// quorum key signature over the data.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTargetMsgV1 {
+    /// Version of the data.
+    pub version: String,
+    /// Data sent by the enclave server.
+    #[serde(with = "hex::serde")]
+    pub data: Vec<u8>,
+    /// Enclave quorum key signature over the data.
+    pub data_signature: P256Signature,
+    /// Enclave quorum key public key.
+    pub enclave_quorum_public: P256Public,
+}
+
+/// Data object from the server with the target public key, organization ID,
+/// and a user ID field.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerTargetData {
+    /// Target public key for client to encrypt to.
+    pub target_public: P256Public,
+    /// Organization making the request
+    pub organization_id: String,
+    /// User making the request
+    pub user_id: String,
+}
+
+/// Message from the client containing ciphertext and the associated
+/// encapsulated key.
+/// These attributes make the struct interoperable with JSON objects created
+/// by the Go implementation of this library.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientSendMsg {
+    /// We assume this public key can be trusted because the request went through
+    /// checks in the policy engine.
+    encapped_public: P256Public,
+    /// The encrypted message from the client.
+    /// This attribute serializes/deserializes between a hex-encoded string and bytes.
+    #[serde(with = "hex::serde")]
+    ciphertext: Vec<u8>,
+}
+
+fn encrypt(
+    receiver_public: &<Kem as KemTrait>::PublicKey,
+    plaintext: &[u8],
+    info_string: &[u8],
+) -> Result<(Vec<u8>, <Kem as KemTrait>::EncappedKey), EnclaveEncryptError> {
+    let (encapped_public, mut sender_ctx) = hpke::setup_sender::<Aead, Kdf, Kem, _>(
+        &OpModeS::Base,
+        receiver_public,
+        info_string,
+        &mut OsRng,
+    )
+    .map_err(|_| EnclaveEncryptError::FailedToSetupSendCtx)?;
+
+    let aad = additional_associated_data(receiver_public, &encapped_public);
+    let ciphertext = sender_ctx
+        .seal(plaintext, &aad)
+        .map_err(|_| EnclaveEncryptError::FailedToEncrypt)?;
+
+    Ok((ciphertext, encapped_public))
+}
+
+fn decrypt(
+    encapped_public: &<Kem as KemTrait>::EncappedKey,
+    receiver_private: &<Kem as KemTrait>::PrivateKey,
+    receiver_public: &<Kem as KemTrait>::PublicKey,
+    ciphertext: &[u8],
+    info_string: &[u8],
+) -> Result<Vec<u8>, EnclaveEncryptError> {
+    let mut receiver_ctx = hpke::setup_receiver::<Aead, Kdf, Kem>(
+        &OpModeR::Base,
+        receiver_private,
+        encapped_public,
+        info_string,
+    )
+    .map_err(|_| EnclaveEncryptError::ReceiveCtxSetupFail)?;
+
+    let aad = additional_associated_data(receiver_public, encapped_public);
+    receiver_ctx
+        .open(ciphertext, &aad)
+        .map_err(|_| EnclaveEncryptError::FailedToDecrypt)
+}
+
+fn additional_associated_data(
+    receiver_public: &<Kem as KemTrait>::PublicKey,
+    sender_public: &<Kem as KemTrait>::EncappedKey,
+) -> Vec<u8> {
+    sender_public
+        .to_bytes()
+        .iter()
+        .chain(receiver_public.to_bytes().iter())
+        .copied()
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+pub mod test {
+    use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
+
+    use crate::{client::EnclaveEncryptClient, server::EnclaveEncryptServer};
+
+    use super::*;
+    const FAKE_SEED: &[u8] = &[42; 32];
+
+    fn quorum_pub() -> VerifyingKey {
+        *SigningKey::from_bytes(FAKE_SEED).unwrap().verifying_key()
+    }
+
+    fn quorum_priv() -> SigningKey {
+        SigningKey::from_bytes(FAKE_SEED).unwrap()
+    }
+    fn random_signature() -> P256Signature {
+        let key = quorum_priv();
+        let signature: Signature = key.sign(b"random");
+        signature.to_der().to_bytes().to_vec().into()
+    }
+
+    // Returns a realistic secret byte vec: an API private key (P256)
+    fn example_credential() -> Vec<u8> {
+        hex::decode("67ee05fc3bdf4161bc70701c221d8d77180294cefcfcea64ba83c4d4c732fcb9").unwrap()
+    }
+
+    #[test]
+    fn client_to_server_e2e() {
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let user_id = "ef7e305c-f085-4a32-accf-939d8373f2ac";
+        let server = EnclaveEncryptServer::from_enclave_auth_key(
+            quorum_priv(),
+            organization_id.to_string(),
+            Some(user_id.to_string()),
+        );
+        // Message with the servers encryption target
+        let server_target = server.publish_target().unwrap();
+        let server_target_bytes = serde_json::to_vec(&server_target).unwrap();
+        // Persist server receiving side
+        let mut server_recv = server.into_recv();
+
+        let client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        let client_ciphertext = client
+            .encrypt(
+                &example_credential(),
+                &server_target_bytes,
+                organization_id,
+                user_id,
+            )
+            .unwrap();
+
+        assert_eq!(
+            server_recv.decrypt(&client_ciphertext).unwrap(),
+            example_credential()
+        );
+        assert_eq!(
+            server_recv.decrypt(&client_ciphertext),
+            Err(EnclaveEncryptError::ServerAlreadyUsedToDecrypt)
+        );
+    }
+
+    #[test]
+    fn client_to_server_e2e_existing_target_key() {
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let user_id = "ef7e305c-f085-4a32-accf-939d8373f2ac";
+        let server = EnclaveEncryptServer::from_enclave_auth_key(
+            quorum_priv(),
+            organization_id.to_string(),
+            Some(user_id.to_string()),
+        );
+        // Message with the servers encryption target
+        let server_target = server.publish_target().unwrap();
+        let server_target_bytes = serde_json::to_vec(&server_target).unwrap();
+        // Persist server receiving side
+        let mut server_recv = server.into_recv();
+
+        let (target_private, target_public) = Kem::gen_keypair(&mut OsRng);
+        let client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            quorum_pub(),
+            target_public,
+            target_private,
+        );
+        let client_ciphertext = client
+            .encrypt(
+                &example_credential(),
+                &server_target_bytes,
+                organization_id,
+                user_id,
+            )
+            .unwrap();
+
+        assert_eq!(
+            server_recv.decrypt(&client_ciphertext).unwrap(),
+            example_credential()
+        );
+        assert_eq!(
+            server_recv.decrypt(&client_ciphertext),
+            Err(EnclaveEncryptError::ServerAlreadyUsedToDecrypt)
+        );
+    }
+
+    #[test]
+    fn client_to_server_reject_bad_server_target_signature() {
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let user_id = "ef7e305c-f085-4a32-accf-939d8373f2ac";
+        let server = EnclaveEncryptServer::from_enclave_auth_key(
+            quorum_priv(),
+            organization_id.to_string(),
+            Some(user_id.to_string()),
+        );
+
+        let mut server_target = server.publish_target().unwrap();
+        server_target.data_signature = random_signature();
+        let server_target_bytes = serde_json::to_vec(&server_target).unwrap();
+
+        let client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        assert_eq!(
+            client.encrypt(
+                &example_credential(),
+                &server_target_bytes,
+                organization_id,
+                user_id
+            ),
+            Err(EnclaveEncryptError::ServerTargetSignatureVerificationFail),
+        );
+    }
+
+    #[test]
+    fn server_to_client_e2e() {
+        let mut client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        let client_target = client.target().unwrap();
+
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let (target_private, target_public) = Kem::gen_keypair(&mut OsRng);
+        let server = EnclaveEncryptServer::from_enclave_auth_key_and_target_key(
+            quorum_priv(),
+            target_public,
+            target_private,
+            organization_id.to_string(),
+            None,
+        );
+        let server_ciphertext = server
+            .encrypt(&client_target, &example_credential())
+            .unwrap();
+        let server_ciphertext_bytes = serde_json::to_vec(&server_ciphertext).unwrap();
+        assert_eq!(
+            client
+                .decrypt(&server_ciphertext_bytes, organization_id)
+                .unwrap(),
+            example_credential()
+        );
+
+        assert_eq!(
+            client.decrypt(&server_ciphertext_bytes, organization_id),
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        );
+    }
+
+    #[test]
+    fn server_to_client_e2e_existing_target_key() {
+        let mut client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        let client_target = client.target().unwrap();
+
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let server = EnclaveEncryptServer::from_enclave_auth_key(
+            quorum_priv(),
+            organization_id.to_string(),
+            None,
+        );
+        let server_ciphertext = server
+            .encrypt(&client_target, &example_credential())
+            .unwrap();
+        let server_ciphertext_bytes = serde_json::to_vec(&server_ciphertext).unwrap();
+
+        assert_eq!(
+            client
+                .decrypt(&server_ciphertext_bytes, organization_id)
+                .unwrap(),
+            example_credential()
+        );
+
+        assert_eq!(
+            client.decrypt(&server_ciphertext_bytes, organization_id),
+            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
+        );
+    }
+
+    #[test]
+    fn server_to_client_reject_bad_encapped_public_siganture() {
+        let mut client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        let client_target = client.target().unwrap();
+
+        let organization_id = "b676ee7c-7eb4-47f1-8e1c-ff0e68e376cd";
+        let server = EnclaveEncryptServer::from_enclave_auth_key(
+            quorum_priv(),
+            organization_id.to_string(),
+            None,
+        );
+        let mut server_ciphertext = server
+            .encrypt(&client_target, &example_credential())
+            .unwrap();
+        server_ciphertext.data_signature = random_signature();
+        let server_ciphertext_bytes = serde_json::to_vec(&server_ciphertext).unwrap();
+
+        assert_eq!(
+            client.decrypt(&server_ciphertext_bytes, organization_id),
+            Err(EnclaveEncryptError::ServerEncappedKeySignatureVerificationFail)
+        );
+    }
+
+    // This test helps with debugging iframe code as well as isolating encrypt functionality.
+    // If you need a recovery or auth bundle, place your public key in here and print the payload.
+    #[test]
+    fn produce_valid_base58check_auth_bundles() {
+        let target_public_key = P256Public(hex::decode("04e866df39454a9942a110834b42d7ef50c2442bd625aa3b99af8fb665039d91e885a731d75f2f8cf1c9cc0e0e6720cf632e1a85182d39ac48f6efa551d5250733").unwrap().try_into().unwrap());
+        let payload =
+            EnclaveEncryptServer::auth_encrypt(&target_public_key, &example_credential()).unwrap();
+        assert!(bs58::decode(payload).with_check(None).into_vec().is_ok());
+    }
+
+    #[test]
+    fn auth_encrypt_e2e() {
+        let mut client = EnclaveEncryptClient::from_enclave_auth_key(quorum_pub());
+        let client_target = client.target().unwrap();
+
+        let payload =
+            EnclaveEncryptServer::auth_encrypt(&client_target, &example_credential()).unwrap();
+        println!("{}", payload);
+        assert_eq!(client.auth_decrypt(&payload).unwrap(), example_credential());
+    }
+
+    // This test shows how to decrypt an auth bundle.
+    // We simulate the case of a client with no access to encryption keys who receives a bundle
+    // encrypted to their public key.
+    #[test]
+    fn static_auth_bundle_decrypt() {
+        // This is a "noop" key which is required to construct EnclaveEncryptClient, but unused when decrypting auth bundles.
+        let noop_verify_key = *SigningKey::random(&mut OsRng).verifying_key();
+
+        // Hardcode a random client IKM to get stable test vectors across runs.
+        let client_ikm =
+            hex::decode("c8e5d3ccbf8c4e62e3bcb984681ce6dda950939905754902a394c1fc2b5c6a9e")
+                .unwrap();
+        let (client_private_key, client_public_key) = Kem::derive_keypair(&client_ikm);
+
+        // Unlikely but check just in case: same IKM should result in the same public key
+        assert_eq!(
+            hex::encode(client_private_key.to_bytes()),
+            "d2d9239a4bb25d09a6d91822e1d0991f0b21a63b102191bb98b6b77ac6fc6c91"
+        );
+
+        // Create a new `EnclaveEncryptClient` bound to the client's private/public key
+        let mut client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            noop_verify_key,
+            client_public_key.clone(),
+            client_private_key,
+        );
+
+        // We can generate new auth bundles by:
+        // - converting the client public key into the proper type
+        // let target_public_key = P256Public::try_from(client_public_key.to_bytes().to_vec()).unwrap();
+        // - using the target_public key to encrypt our "example_credential"
+        // let bundle = EnclaveEncryptServer::auth_encrypt(&target_public_key, &example_credential()).unwrap();
+        // - now we can print our bundle and capture it
+        // println!("generated bundle: {}", bundle);
+
+        // But instead we fix the bundle to a static value, to simulate the case where it's e.g. coming from an activity result or an email
+        // This also ensures that future updates to this crate don't break old bundles!
+        let bundle = "skr1QFHrNyL7xcvzRpU4t9yhL8rEVPZgDcFM5YW8S1YwLYjedoagnNZwMCyJsxNYzuphKHqQBkZxt4fLWSVsMqnW9XdmLBsK2MhwC5WxuxZD9xE8ezQ";
+        let decrypted = client
+            .auth_decrypt(bundle)
+            .expect("decryption should succeed");
+
+        // Assert that what we decrypted is what was originally encrypted: our "example_credential"
+        assert_eq!(decrypted, example_credential());
+    }
+
+    // This might seem too specific but is necessary to test the base58 encoder we use.
+    // If something changes when the crate is updated, affecting the payload, we should know about it.
+    // It ensures the crate returns sane results for known test vectors.
+    #[test]
+    fn base58_payload_encoding() {
+        assert_eq!(
+            bs58::encode(hex::decode("04305e2b2473f058").unwrap()).into_string(),
+            // Test vector obtained from https://www.better-converter.com/Encoders-Decoders/Base58Check-to-Hexadecimal-Decoder
+            "he11owor1d".to_string(),
+        );
+        assert_eq!(
+            bs58::encode(
+                hex::decode("0062E907B15CBF27D5425399EBF6F0FB50EBB88F18C29B7D93").unwrap()
+            )
+            .into_string(),
+            // Satoshi's wallet
+            // Test vector obtained from http://lenschulwitz.com/base58
+            "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".to_string(),
+        );
+    }
+}

--- a/enclave_encrypt/src/quorum_public_key.rs
+++ b/enclave_encrypt/src/quorum_public_key.rs
@@ -1,0 +1,137 @@
+//! Contains the definition and data for Turnkey Quorum key public keys.
+use p256::ecdsa::VerifyingKey;
+
+use crate::errors::EnclaveEncryptError;
+
+/// Turnkey's production signer quorum public key
+/// Key export/import bundles are signed by this key.
+pub const TURNKEY_PRODUCTION_SIGNER_QUORUM_PUBLIC_KEY: &str = "04ca7c0d624c75de6f34af342e87a21e0d8c83efd1bd5b5da0c0177c147f744fba6f01f9f37356f9c617659aafa55f6e0af8d169a8f054d153ab3201901fb63ecb04cf288fe433cc4e1aa0ce1632feac4ea26bf2f5a09dcfe5a42c398e06898710330f0572882f4dbdf0f5304b8fc8703acd69adca9a4bbf7f5d00d20a5e364b2569";
+
+/// Turnkey's preprod signer quorum public key
+/// We check it in here for convenience, for internal Turnkey employees. Goes without saying: do not use in production code!
+pub const TURNKEY_PREPROD_SIGNER_QUORUM_PUBLIC_KEY: &str = "048e92f6cdcc0b375505980a298d9b79201db1f08b1f135360d2864af1a67186ec0dbeb570d396a456226b0844be93dbc0180abbf7e2e4c9cfde8d5da4e3f8a49004f3422b8afbe425d6ece77b8d2469954715a2ff273ab7ac89f1ed70e0a9325eaa1698b4351fd1b23734e65c0b6a86b62dd49d70b37c94606aac402cbd84353212";
+
+/// Expected Quorum public key length: twice the length of a SEC1 uncompressed public key (65 * 2)
+pub const QUORUM_PUBLIC_KEY_BYTE_LENGTH: usize = 130;
+
+/// Represents a Quorum key public key component.
+#[derive(Debug, PartialEq, Eq)]
+pub struct QuorumPublicKey {
+    bytes: Vec<u8>,
+}
+
+impl QuorumPublicKey {
+    /// Create a new `QuorumPublicKey` from an array of bytes
+    pub fn from_bytes<B: AsRef<[u8]>>(b: B) -> Result<Self, EnclaveEncryptError> {
+        if b.as_ref().len() != QUORUM_PUBLIC_KEY_BYTE_LENGTH {
+            return Err(EnclaveEncryptError::IncorrectQuorumPublicKeyBytesLength(
+                b.as_ref().len(),
+            ));
+        }
+        Ok(Self {
+            bytes: b.as_ref().to_vec(),
+        })
+    }
+
+    /// Create a new `QuorumPublicKey` from a str
+    pub fn from_string<S: AsRef<str>>(s: S) -> Result<Self, EnclaveEncryptError> {
+        let b =
+            hex::decode(s.as_ref()).map_err(|e| EnclaveEncryptError::HexDecode(e.to_string()))?;
+        Self::from_bytes(b)
+    }
+
+    /// Quorum Public Key for Turnkey's production signer.
+    ///
+    /// # Panics
+    /// Not expected given the public keys are static and valid
+    #[must_use]
+    pub fn production_signer() -> Self {
+        Self::from_string(TURNKEY_PRODUCTION_SIGNER_QUORUM_PUBLIC_KEY)
+            .expect("static public key should be valid")
+    }
+
+    /// Quorum Public Key for Turnkey's preprod signer. Do not use in production code. See `production_signer`
+    ///
+    /// # Panics
+    /// Not expected given the public keys are static and valid
+    #[must_use]
+    pub fn preprod_signer() -> Self {
+        Self::from_string(TURNKEY_PREPROD_SIGNER_QUORUM_PUBLIC_KEY)
+            .expect("static public key should be valid")
+    }
+
+    /// Returns a `VerifyingKey` for this `QuorumPublicKey`
+    pub fn verifying_key(&self) -> Result<VerifyingKey, EnclaveEncryptError> {
+        // Quorum public keys are actually 2 keys concatenated together
+        // The first key is the encryption key, used to encrypt data to the enclave.
+        // The second public key is the signing key, used to sign data coming out of the enclave, for authenticity.
+        // The verifying key thus only uses the second part of the public key,
+        VerifyingKey::from_sec1_bytes(&self.bytes[65..])
+            .map_err(|_| EnclaveEncryptError::InvalidVerifyingKeyBytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_bytes_and_from_str_valid() {
+        let prod_pub1 = QuorumPublicKey::from_bytes(
+            &hex::decode(TURNKEY_PRODUCTION_SIGNER_QUORUM_PUBLIC_KEY).unwrap(),
+        )
+        .unwrap();
+        let prod_pub2 =
+            QuorumPublicKey::from_string(TURNKEY_PRODUCTION_SIGNER_QUORUM_PUBLIC_KEY).unwrap();
+        let prod_pub3 = QuorumPublicKey::production_signer();
+        assert!(prod_pub1.verifying_key().is_ok());
+        assert_eq!(prod_pub1, prod_pub2);
+        assert_eq!(prod_pub2, prod_pub3);
+
+        let preprod_pub1 = QuorumPublicKey::from_bytes(
+            &hex::decode(TURNKEY_PREPROD_SIGNER_QUORUM_PUBLIC_KEY).unwrap(),
+        )
+        .unwrap();
+        let preprod_pub2 =
+            QuorumPublicKey::from_string(TURNKEY_PREPROD_SIGNER_QUORUM_PUBLIC_KEY).unwrap();
+        let preprod_pub3 = QuorumPublicKey::preprod_signer();
+        assert!(preprod_pub1.verifying_key().is_ok());
+        assert_eq!(preprod_pub1, preprod_pub2);
+        assert_eq!(preprod_pub2, preprod_pub3);
+    }
+
+    #[test]
+    fn from_bytes_invalid_length() {
+        let bytes = vec![0u8; 64]; // too short
+        assert_eq!(
+            QuorumPublicKey::from_bytes(&bytes).unwrap_err(),
+            EnclaveEncryptError::IncorrectQuorumPublicKeyBytesLength(64)
+        )
+    }
+
+    #[test]
+    fn from_str_valid() {
+        const VALID_HEX_KEY: &str = concat!(
+            "04",                                                               // uncompressed prefix
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899", // x
+            "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa", // y
+            // second key
+            "04", // uncompressed prefix
+            "11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff", // x
+            "ffeeddccbbaa00998877665544332211ffeeddccbbaa00998877665544332211"  // y
+        );
+        let quorum_pub = QuorumPublicKey::from_string(VALID_HEX_KEY).unwrap();
+        assert_eq!(
+            quorum_pub.verifying_key().unwrap_err(),
+            EnclaveEncryptError::InvalidVerifyingKeyBytes
+        );
+    }
+
+    #[test]
+    fn from_str_invalid_hex() {
+        assert_eq!(
+            QuorumPublicKey::from_string("not hex!").unwrap_err(),
+            EnclaveEncryptError::HexDecode("Invalid character 'n' at position 0".to_string()),
+        );
+    }
+}

--- a/enclave_encrypt/src/server.rs
+++ b/enclave_encrypt/src/server.rs
@@ -1,0 +1,208 @@
+//! Enclave Encryption Server
+use hpke::{Deserializable, Kem as KemTrait, Serializable};
+use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+use rand_core::OsRng;
+
+use crate::{
+    compress_p256_public, decrypt, encrypt, errors::EnclaveEncryptError, ClientSendMsg, Kem,
+    P256Public, ServerSendData, ServerSendMsgV1, ServerTargetData, ServerTargetMsgV1, DATA_VERSION,
+    TURNKEY_HPKE_INFO,
+};
+
+/// An instance of the server side for `EnclaveEncrypt`. This should only be used for either
+/// a SINGLE send or a single receive.
+pub struct EnclaveEncryptServer {
+    // The underlying type is zero on drop
+    enclave_auth_key: SigningKey,
+    // The underlying type is zero on drop
+    target_public: <Kem as KemTrait>::PublicKey,
+    target_private: <Kem as KemTrait>::PrivateKey,
+    // Organization
+    organization_id: String,
+    // User
+    user_id: Option<String>,
+}
+
+impl EnclaveEncryptServer {
+    /// This should be the quorum signing secret derived from the quorum
+    /// master seed.
+    #[must_use]
+    pub fn from_enclave_auth_key(
+        enclave_auth_key: SigningKey,
+        organization_id: String,
+        user_id: Option<String>,
+    ) -> Self {
+        let (target_private, target_public) = Kem::gen_keypair(&mut OsRng);
+        Self {
+            enclave_auth_key,
+            target_public,
+            target_private,
+            organization_id,
+            user_id,
+        }
+    }
+
+    /// Create a server from the enclave quorum public key and the target key.
+    #[must_use]
+    pub fn from_enclave_auth_key_and_target_key(
+        enclave_auth_key: SigningKey,
+        target_public_key: <Kem as KemTrait>::PublicKey,
+        target_private_key: <Kem as KemTrait>::PrivateKey,
+        organization_id: String,
+        user_id: Option<String>,
+    ) -> Self {
+        Self {
+            enclave_auth_key,
+            target_public: target_public_key,
+            target_private: target_private_key,
+            organization_id,
+            user_id,
+        }
+    }
+
+    /// Encrypt a message to the `client_target_public` key.
+    pub fn encrypt(
+        &self,
+        client_target: &P256Public,
+        plaintext: &[u8],
+    ) -> Result<ServerSendMsgV1, EnclaveEncryptError> {
+        let client_target = <Kem as KemTrait>::PublicKey::from_bytes(&**client_target)
+            .map_err(EnclaveEncryptError::InvalidClientTarget)?;
+        let (ciphertext, encapped_public) = encrypt(&client_target, plaintext, TURNKEY_HPKE_INFO)?;
+
+        let data = ServerSendData {
+            encapped_public: encapped_public.to_bytes().to_vec().try_into()?,
+            ciphertext,
+            organization_id: self.organization_id.clone(),
+        };
+        let data_bytes = serde_json::to_string(&data)
+            .map_err(|_| EnclaveEncryptError::FailedToSerializeData)?
+            .into_bytes();
+        let data_signature: Signature = self.enclave_auth_key.sign(&data_bytes);
+        let enclave_quorum_public_bytes = self
+            .enclave_auth_key
+            .verifying_key()
+            .to_encoded_point(false)
+            .to_bytes()
+            .to_vec();
+        Ok(ServerSendMsgV1 {
+            version: DATA_VERSION.to_string(),
+            data: data_bytes,
+            data_signature: data_signature.to_der().to_bytes().to_vec().into(),
+            enclave_quorum_public: enclave_quorum_public_bytes.try_into()?,
+        })
+    }
+
+    /// Encrypt `plaintext`, returning a payload that omits the enclave auth key signature. This
+    /// should only be used for email recovery and auth since other use cases will want to verify enclave
+    /// authentication. Enclave authentication doesn't matter for email recovery or auth because an
+    /// inauthentic ciphertext will just result in being unable to register a new authenticator.
+    ///
+    /// The returned payload has has the goal of minimizing payload size.
+    /// In email recovery and auth we don't need to verify the payload came from the
+    /// enclave, so we forego the enclave auth signature. Additionally we use base64 encoding.
+    ///
+    /// The payload is in the format of `CompressedEncappedPublicKey||Ciphertext`.
+    pub fn auth_encrypt(
+        client_target: &P256Public,
+        plaintext: &[u8],
+    ) -> Result<String, EnclaveEncryptError> {
+        let client_target = <Kem as KemTrait>::PublicKey::from_bytes(&**client_target)
+            .map_err(EnclaveEncryptError::InvalidClientTarget)?;
+        let (ciphertext, encapped_public) = encrypt(&client_target, plaintext, TURNKEY_HPKE_INFO)?;
+
+        let encapped_public_bytes = encapped_public.to_bytes().to_vec();
+        let compressed_encapped_public = compress_p256_public(&encapped_public_bytes)?;
+
+        let payload_bytes: Vec<_> = compressed_encapped_public
+            .iter()
+            .copied()
+            .chain(ciphertext)
+            .collect();
+
+        Ok(bs58::encode(&payload_bytes).with_check().into_string())
+    }
+
+    /// Return the servers encryption target key and a signature over it from
+    /// the quorum key.
+    pub fn publish_target(&self) -> Result<ServerTargetMsgV1, EnclaveEncryptError> {
+        let user_id = self
+            .user_id
+            .as_ref()
+            .ok_or(EnclaveEncryptError::InvalidUser)?
+            .to_string();
+        let data = ServerTargetData {
+            target_public: self.target_public.to_bytes().to_vec().try_into()?,
+            organization_id: self.organization_id.clone(),
+            user_id,
+        };
+        let data_bytes = serde_json::to_string(&data)
+            .map_err(|_| EnclaveEncryptError::FailedToSerializeData)?
+            .into_bytes();
+        let data_signature: Signature = self.enclave_auth_key.sign(&data_bytes);
+        let enclave_quorum_public_bytes = self
+            .enclave_auth_key
+            .verifying_key()
+            .to_encoded_point(false)
+            .to_bytes()
+            .to_vec();
+        Ok(ServerTargetMsgV1 {
+            version: DATA_VERSION.to_string(),
+            data: data_bytes,
+            data_signature: data_signature.to_der().to_bytes().to_vec().into(),
+            enclave_quorum_public: enclave_quorum_public_bytes.try_into()?,
+        })
+    }
+
+    /// Convert into `EnclaveEncryptServerRecv`. We expect `EnclaveEncryptServerRecv` will be serialized,
+    /// encrypted, and persisted in org data while waiting for the client to send a message.
+    #[must_use]
+    pub fn into_recv(self) -> EnclaveEncryptServerRecv {
+        EnclaveEncryptServerRecv {
+            target_private: Some(self.target_private),
+            target_public: Some(self.target_public),
+        }
+    }
+}
+
+/// The receiving side of the server. After the server published its target key,
+/// this should be serialized & encrypted; later being decrypted and used to
+/// decrypt the clients message.
+///
+/// N.B. Encrypt may only be called once; after encrypt is called the target key pair is wiped.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct EnclaveEncryptServerRecv {
+    // The underlying type is zero on drop
+    target_private: Option<<Kem as KemTrait>::PrivateKey>,
+    target_public: Option<<Kem as KemTrait>::PublicKey>,
+}
+
+impl EnclaveEncryptServerRecv {
+    /// Decrypt a message from a client.
+    ///
+    /// *N.B.* We assume the authenticity of the message contents is verified
+    /// out of band in the Ump policy engine.
+    pub fn decrypt(&mut self, msg: &ClientSendMsg) -> Result<Vec<u8>, EnclaveEncryptError> {
+        let encapped_public = <Kem as KemTrait>::EncappedKey::from_bytes(&*msg.encapped_public)
+            .map_err(EnclaveEncryptError::InvalidEncappedKey)?;
+
+        if let (Some(target_private), Some(target_public)) =
+            (self.target_private.as_ref(), self.target_public.as_ref())
+        {
+            let result = decrypt(
+                &encapped_public,
+                target_private,
+                target_public,
+                &msg.ciphertext,
+                TURNKEY_HPKE_INFO,
+            );
+
+            self.target_public = None;
+            self.target_private = None;
+
+            result
+        } else {
+            Err(EnclaveEncryptError::ServerAlreadyUsedToDecrypt)
+        }
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 tkhq_api_key_stamper = { path = "../api_key_stamper" }
+tkhq_enclave_encrypt = { path = "../enclave_encrypt" }
 tkhq_client = { path = "../client" }
 dotenvy = { version = "0.15.0" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ This crate contains example programs to interact with Turnkey.
 
 * [`whoami.rs`](./src/bin/whoami.rs) shows how to authenticate to the Turnkey API for the simplest endpoint we have.
 * [`sub_organization.rs`](./src/bin/sub_organization.rs) shows the creation and deletion of sub-organizations.
-* [`wallet.rs`](./src/bin/wallet.rs) shows basic wallet management (creation, signature, deletion).
+* [`wallet.rs`](./src/bin/wallet.rs) shows basic wallet management (creation, signature, export, deletion).
 
 
 ## Running examples

--- a/examples/src/bin/wallet.rs
+++ b/examples/src/bin/wallet.rs
@@ -5,7 +5,10 @@ use tkhq_client::generated::{
     immutable::common::v1::{AddressFormat, Curve, PathFormat},
     WalletAccountParams,
 };
-use tkhq_client::generated::{CreateWalletIntent, DeleteWalletsIntent, SignRawPayloadIntentV2};
+use tkhq_client::generated::{
+    CreateWalletIntent, DeleteWalletsIntent, ExportWalletIntent, SignRawPayloadIntentV2,
+};
+use tkhq_enclave_encrypt::{ExportClient, QuorumPublicKey};
 use tkhq_examples::{current_time_ms, load_api_key_from_env};
 
 // See <https://docs.turnkey.com/api-reference/organizations/create-sub-organization> for documentation
@@ -23,25 +26,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create our Turnkey client
     let client = tkhq_client::TurnkeyClient::new(TURNKEY_API_HOST, api_key, None);
 
-    // Create the activity intent
-    let intent = CreateWalletIntent {
-        wallet_name: "New wallet".to_string(),
-        accounts: vec![WalletAccountParams {
-            curve: Curve::Secp256k1,
-            path_format: PathFormat::Bip32,
-            path: "m/44'/60'/0'/0".to_string(),
-            address_format: AddressFormat::Ethereum,
-        }],
-        mnemonic_length: None, // Let that be the default
-    };
-
-    let res = client
-        .create_wallet(organization_id.clone(), current_time_ms(), intent)
+    // Create a new wallet in the organization
+    let create_wallet_result = client
+        .create_wallet(
+            organization_id.clone(),
+            current_time_ms(),
+            CreateWalletIntent {
+                wallet_name: "New wallet".to_string(),
+                accounts: vec![WalletAccountParams {
+                    curve: Curve::Secp256k1,
+                    path_format: PathFormat::Bip32,
+                    path: "m/44'/60'/0'/0".to_string(),
+                    address_format: AddressFormat::Ethereum,
+                }],
+                mnemonic_length: None, // Let that be the default
+            },
+        )
         .await?;
 
-    assert_eq!(res.addresses.len(), 1);
-    let eth_address = res.addresses.first().unwrap();
-    let wallet_id = res.wallet_id;
+    assert_eq!(create_wallet_result.addresses.len(), 1);
+    let eth_address = create_wallet_result.addresses.first().unwrap();
+    let wallet_id = create_wallet_result.wallet_id;
 
     println!(
         "New ETH address created: {} (wallet ID: {})",
@@ -49,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Now we can sign something
-    let signature_activity_result = client
+    let signature_result = client
         .sign_raw_payload(
             organization_id.clone(),
             current_time_ms(),
@@ -60,13 +65,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 hash_function: HashFunction::Keccak256,
             },
         )
-        .await;
-
-    let signature = signature_activity_result.unwrap();
+        .await?;
 
     println!(
         "Produced a new signature: r={}, s={}, v={}",
-        signature.r, signature.s, signature.v,
+        signature_result.r, signature_result.s, signature_result.v,
+    );
+
+    // Export our wallet using `ExportClient`
+    let mut export_client = ExportClient::new(&QuorumPublicKey::production_signer());
+    let export_wallet_result = client
+        .export_wallet(
+            organization_id.clone(),
+            current_time_ms(),
+            ExportWalletIntent {
+                wallet_id: wallet_id.clone(),
+                target_public_key: export_client.target_public_key()?,
+                language: None,
+            },
+        )
+        .await?;
+
+    let export_bundle = export_wallet_result.export_bundle;
+    let mnemonic_phrase =
+        export_client.decrypt_wallet_mnemonic_phrase(export_bundle, organization_id.clone())?;
+
+    assert_eq!(export_wallet_result.wallet_id, wallet_id);
+    println!(
+        "Wallet successfully exported: {} (Mnemonic phrase: {})",
+        export_wallet_result.wallet_id,
+        first_and_last_word(&mnemonic_phrase)
     );
 
     // Finally, delete the wallet. We don't need it, let's clean up!
@@ -76,7 +104,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             current_time_ms(),
             DeleteWalletsIntent {
                 wallet_ids: vec![wallet_id.clone()],
-                delete_without_export: Some(true),
+                delete_without_export: Some(false),
             },
         )
         .await;
@@ -88,4 +116,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Deleted wallet {}", wallet_id);
 
     Ok(())
+}
+
+// Simple convenience function to display the first and last word of a mnemonic phrase
+// Technically we could just print the whole mnemonic out...but something about that feels wrong. I'm coy.
+fn first_and_last_word(s: &str) -> String {
+    let words: Vec<&str> = s.split_whitespace().collect();
+    format!("{} ... {}", words.first().unwrap(), words.last().unwrap())
 }


### PR DESCRIPTION
## What is this change about?
This PR introduces a new `enclave_encrypt` crate to facilitate interaction with Auth, Export, and Import bundles. This resolves #9.

This crate was not written from scratch. Most of it was written (and is currently in use) in Turnkey's monorepo. The commit where the code is ported over is the first one, https://github.com/tkhq/rust-sdk/commit/d4538c54d5eade1405463da2986a799315c937cd.

The new abstractions which are more user-friendly (`AuthenticationClient`, `ExportClient`, `ImportClient`) were introduced in https://github.com/tkhq/rust-sdk/commit/4266a5a6f4b9c1bacb2286cf50a9625ed1dd3550.

## Testing
- [x] added a lot of unit tests to `enclave_encrypt`. See https://github.com/tkhq/rust-sdk/commit/4266a5a6f4b9c1bacb2286cf50a9625ed1dd3550 for the modifications I made on top of the version we've always had internally
- [x] added an example to the `examples` folder to make sure it works end-to-end 
