### PR TITLE
Handle HTTP errors, and use Rust generics to DRY codegen'd client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,6 +2141,7 @@ name = "tkhq_client"
 version = "0.0.2"
 dependencies = [
  "http 0.2.12",
+ "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -3,35 +3,9 @@
 This repository contains tooling to interact with the Turnkey API using Rust, and is organized as a collection of Rust crates.
 
 The two user-facing crates are:
-* [`client`](./client/): fully typed client to send requests to Turnkey
-* [`api_key_stamper`](./api_key_stamper/): used by `client` to stamp requests before they're sent to Turnkey
-* [`enclave_encrypt`](./enclave_encrypt/): used in the context of features which leverage enclave [secure channels](https://docs.turnkey.com/security/enclave-secure-channels) ([Social Logins](https://docs.turnkey.com/authentication/social-logins), [Export](https://docs.turnkey.com/wallets/export-wallets), [Import](https://docs.turnkey.com/wallets/import-wallets))
-
-## Usage
-
-To make a request to Turnkey:
-* Load an API key:
-  ```rust
-  // You can load your API key from a file or from env
-  let api_key = TurnkeyP256ApiKey::from_strings(private_key: "<private key hex>", None).expect("api key creation failed");
-  ```
-* Create a new client:
-  ```rust
-  let client = tkhq_client::TurnkeyClient::new("https://api.turnkey.com", api_key, RetryConfig::default());
-  ```
-* Make a request (for example, a signature request)
-  ```rust
-  let signature_result = client.sign_raw_payload(
-    organization_id, // your organization ID
-    timestamp_ms, // time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_millis();
-    SignRawPayloadIntentV2 {
-        sign_with: address, // any Turnkey-generated address
-        payload: "hello from TKHQ".to_string(),
-        encoding: PayloadEncoding::TextUtf8,
-        hash_function: HashFunction::Keccak256,
-    },
-  ).await;
-  ```
+* [`client`](./client/README.md): fully typed client to send requests to Turnkey
+* [`api_key_stamper`](./api_key_stamper/README.md): used by `client` to stamp requests before they're sent to Turnkey
+* [`enclave_encrypt`](./enclave_encrypt/README.md): used in the context of features which leverage enclave [secure channels](https://docs.turnkey.com/security/enclave-secure-channels) ([Social Logins](https://docs.turnkey.com/authentication/social-logins), [Export](https://docs.turnkey.com/wallets/export-wallets), [Import](https://docs.turnkey.com/wallets/import-wallets))
 
 ## Examples
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 doctest = false
 
 [dependencies]
+mime = { version = "0.3.17" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 tkhq_api_key_stamper = { path = "../api_key_stamper" }
 prost = { version = "0.12" }

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,36 @@
+# Turnkey Client
+
+## Usage
+
+To make a request to Turnkey:
+* Load an API key:
+  ```rust
+  // You can load your API key from a file or from env
+  let api_key = TurnkeyP256ApiKey::from_strings(private_key: "<private key hex>", None).expect("api key creation failed");
+  ```
+* Create a new client:
+  ```rust
+  let client = tkhq_client::TurnkeyClient::builder().api_key(api_key).build().expect("client builder failed");
+  ```
+* Make a request (for example, a signature request)
+  ```rust
+  let signature_result = client.sign_raw_payload(
+    organization_id, // your organization ID
+    client.current_timestamp(),
+    SignRawPayloadIntentV2 {
+        sign_with: address, // any Turnkey-generated address
+        payload: "hello from TKHQ".to_string(),
+        encoding: PayloadEncoding::TextUtf8,
+        hash_function: HashFunction::Keccak256,
+    },
+  ).await;
+  ```
+
+## Advanced usage
+
+The Turnkey client uses `reqwest` under the hood. To access the `reqwest` builder, use the following:
+```rust
+tkhq_client::TurnkeyClient::builder()
+    .api_key(api_key)
+    .with_reqwest_builder(|b| b.connection_verbose(true))
+```

--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -9,91 +9,39 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetWhoamiRequest,
     ) -> Result<coordinator::GetWhoamiResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/whoami");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetWhoamiResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/whoami".to_string())
+            .await
     }
     pub async fn get_sub_org_ids(
         &self,
         request: coordinator::GetSubOrgIdsRequest,
     ) -> Result<coordinator::GetSubOrgIdsResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_suborgs");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetSubOrgIdsResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_suborgs".to_string())
+            .await
     }
     pub async fn get_verified_sub_org_ids(
         &self,
         request: coordinator::GetVerifiedSubOrgIdsRequest,
     ) -> Result<coordinator::GetVerifiedSubOrgIdsResponse, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/query/list_verified_suborgs"
-        );
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res
-            .json::<coordinator::GetVerifiedSubOrgIdsResponse>()
-            .await?;
-        Ok(parsed)
+        self.process_request(
+            &request,
+            "/public/v1/query/list_verified_suborgs".to_string(),
+        )
+        .await
     }
     pub async fn get_activity(
         &self,
         request: coordinator::GetActivityRequest,
     ) -> Result<coordinator::ActivityResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_activity");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::ActivityResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_activity".to_string())
+            .await
     }
     pub async fn get_activities(
         &self,
         request: coordinator::GetActivitiesRequest,
     ) -> Result<coordinator::GetActivitiesResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_activities");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetActivitiesResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_activities".to_string())
+            .await
     }
     pub async fn approve_activity(
         &self,
@@ -101,16 +49,14 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ApproveActivityIntent,
     ) -> Result<external_activity::Activity, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/approve_activity");
         let request = external_activity::ApproveActivityRequest {
             r#type: "ACTIVITY_TYPE_APPROVE_ACTIVITY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request).unwrap();
-        let stamp = self.api_key.stamp(post_body.clone()).unwrap();
-        self.process_activity(url, stamp, post_body).await
+        self.process_activity(&request, "/public/v1/submit/approve_activity".to_string())
+            .await
     }
     pub async fn reject_activity(
         &self,
@@ -118,50 +64,28 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::RejectActivityIntent,
     ) -> Result<external_activity::Activity, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/reject_activity");
         let request = external_activity::RejectActivityRequest {
             r#type: "ACTIVITY_TYPE_REJECT_ACTIVITY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request).unwrap();
-        let stamp = self.api_key.stamp(post_body.clone()).unwrap();
-        self.process_activity(url, stamp, post_body).await
+        self.process_activity(&request, "/public/v1/submit/reject_activity".to_string())
+            .await
     }
     pub async fn get_user(
         &self,
         request: coordinator::GetUserRequest,
     ) -> Result<coordinator::GetUserResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_user");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetUserResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_user".to_string())
+            .await
     }
     pub async fn get_users(
         &self,
         request: coordinator::GetUsersRequest,
     ) -> Result<coordinator::GetUsersResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_users");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetUsersResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_users".to_string())
+            .await
     }
     pub async fn delete_users(
         &self,
@@ -169,16 +93,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteUsersIntent,
     ) -> Result<immutable_activity::DeleteUsersResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_users");
         let request = external_activity::DeleteUsersRequest {
             r#type: "ACTIVITY_TYPE_DELETE_USERS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_users".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -197,16 +120,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreatePolicyIntentV3,
     ) -> Result<immutable_activity::CreatePolicyResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_policy");
         let request = external_activity::CreatePolicyRequest {
             r#type: "ACTIVITY_TYPE_CREATE_POLICY_V3".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_policy".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -225,16 +147,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreatePoliciesIntent,
     ) -> Result<immutable_activity::CreatePoliciesResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_policies");
         let request = external_activity::CreatePoliciesRequest {
             r#type: "ACTIVITY_TYPE_CREATE_POLICIES".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_policies".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -253,16 +174,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdatePolicyIntentV2,
     ) -> Result<immutable_activity::UpdatePolicyResultV2, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/update_policy");
         let request = external_activity::UpdatePolicyRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_POLICY_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/update_policy".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -281,16 +201,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeletePolicyIntent,
     ) -> Result<immutable_activity::DeletePolicyResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_policy");
         let request = external_activity::DeletePolicyRequest {
             r#type: "ACTIVITY_TYPE_DELETE_POLICY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_policy".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -307,35 +226,15 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetPoliciesRequest,
     ) -> Result<coordinator::GetPoliciesResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_policies");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetPoliciesResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_policies".to_string())
+            .await
     }
     pub async fn get_policy(
         &self,
         request: coordinator::GetPolicyRequest,
     ) -> Result<coordinator::GetPolicyResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_policy");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetPolicyResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_policy".to_string())
+            .await
     }
     pub async fn create_read_only_session(
         &self,
@@ -343,19 +242,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateReadOnlySessionIntent,
     ) -> Result<immutable_activity::CreateReadOnlySessionResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_read_only_session"
-        );
         let request = external_activity::CreateReadOnlySessionRequest {
             r#type: "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_read_only_session".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -374,19 +272,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateReadWriteSessionIntentV2,
     ) -> Result<immutable_activity::CreateReadWriteSessionResultV2, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_read_write_session"
-        );
         let request = external_activity::CreateReadWriteSessionRequest {
             r#type: "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_read_write_session".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -405,19 +302,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreatePrivateKeysIntentV2,
     ) -> Result<immutable_activity::CreatePrivateKeysResultV2, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_private_keys"
-        );
         let request = external_activity::CreatePrivateKeysRequest {
             r#type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_private_keys".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -434,35 +330,15 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetPrivateKeyRequest,
     ) -> Result<coordinator::GetPrivateKeyResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_private_key");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetPrivateKeyResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_private_key".to_string())
+            .await
     }
     pub async fn get_private_keys(
         &self,
         request: coordinator::GetPrivateKeysRequest,
     ) -> Result<coordinator::GetPrivateKeysResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_private_keys");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetPrivateKeysResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_private_keys".to_string())
+            .await
     }
     pub async fn create_api_keys(
         &self,
@@ -470,16 +346,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateApiKeysIntentV2,
     ) -> Result<immutable_activity::CreateApiKeysResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_api_keys");
         let request = external_activity::CreateApiKeysRequest {
             r#type: "ACTIVITY_TYPE_CREATE_API_KEYS_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_api_keys".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -498,16 +373,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteApiKeysIntent,
     ) -> Result<immutable_activity::DeleteApiKeysResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_api_keys");
         let request = external_activity::DeleteApiKeysRequest {
             r#type: "ACTIVITY_TYPE_DELETE_API_KEYS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_api_keys".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -524,55 +398,22 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetOauthProvidersRequest,
     ) -> Result<coordinator::GetOauthProvidersResponse, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/query/get_oauth_providers"
-        );
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetOauthProvidersResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_oauth_providers".to_string())
+            .await
     }
     pub async fn get_api_keys(
         &self,
         request: coordinator::GetApiKeysRequest,
     ) -> Result<coordinator::GetApiKeysResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_api_keys");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetApiKeysResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_api_keys".to_string())
+            .await
     }
     pub async fn get_api_key(
         &self,
         request: coordinator::GetApiKeyRequest,
     ) -> Result<coordinator::GetApiKeyResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_api_key");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetApiKeyResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_api_key".to_string())
+            .await
     }
     pub async fn create_authenticators(
         &self,
@@ -580,19 +421,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateAuthenticatorsIntentV2,
     ) -> Result<immutable_activity::CreateAuthenticatorsResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_authenticators"
-        );
         let request = external_activity::CreateAuthenticatorsRequest {
             r#type: "ACTIVITY_TYPE_CREATE_AUTHENTICATORS_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_authenticators".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -611,19 +451,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteAuthenticatorsIntent,
     ) -> Result<immutable_activity::DeleteAuthenticatorsResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/delete_authenticators"
-        );
         let request = external_activity::DeleteAuthenticatorsRequest {
             r#type: "ACTIVITY_TYPE_DELETE_AUTHENTICATORS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/delete_authenticators".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -640,35 +479,15 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetAuthenticatorsRequest,
     ) -> Result<coordinator::GetAuthenticatorsResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_authenticators");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetAuthenticatorsResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_authenticators".to_string())
+            .await
     }
     pub async fn get_authenticator(
         &self,
         request: coordinator::GetAuthenticatorRequest,
     ) -> Result<coordinator::GetAuthenticatorResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_authenticator");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetAuthenticatorResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_authenticator".to_string())
+            .await
     }
     pub async fn create_invitations(
         &self,
@@ -676,19 +495,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateInvitationsIntent,
     ) -> Result<immutable_activity::CreateInvitationsResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_invitations"
-        );
         let request = external_activity::CreateInvitationsRequest {
             r#type: "ACTIVITY_TYPE_CREATE_INVITATIONS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_invitations".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -707,16 +522,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteInvitationIntent,
     ) -> Result<immutable_activity::DeleteInvitationResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_invitation");
         let request = external_activity::DeleteInvitationRequest {
             r#type: "ACTIVITY_TYPE_DELETE_INVITATION".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_invitation".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -735,16 +549,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateUsersIntentV3,
     ) -> Result<immutable_activity::CreateUsersResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_users");
         let request = external_activity::CreateUsersRequest {
             r#type: "ACTIVITY_TYPE_CREATE_USERS_V3".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_users".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -763,16 +576,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdateUserIntent,
     ) -> Result<immutable_activity::UpdateUserResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/update_user");
         let request = external_activity::UpdateUserRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_USER".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/update_user".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -791,16 +603,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateUserTagIntent,
     ) -> Result<immutable_activity::CreateUserTagResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_user_tag");
         let request = external_activity::CreateUserTagRequest {
             r#type: "ACTIVITY_TYPE_CREATE_USER_TAG".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_user_tag".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -819,19 +630,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreatePrivateKeyTagIntent,
     ) -> Result<immutable_activity::CreatePrivateKeyTagResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_private_key_tag"
-        );
         let request = external_activity::CreatePrivateKeyTagRequest {
             r#type: "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_private_key_tag".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -850,16 +660,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdateUserTagIntent,
     ) -> Result<immutable_activity::UpdateUserTagResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/update_user_tag");
         let request = external_activity::UpdateUserTagRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_USER_TAG".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/update_user_tag".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -876,18 +685,8 @@ impl TurnkeyClient {
         &self,
         request: coordinator::ListUserTagsRequest,
     ) -> Result<coordinator::ListUserTagsResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_user_tags");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::ListUserTagsResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_user_tags".to_string())
+            .await
     }
     pub async fn delete_user_tags(
         &self,
@@ -895,16 +694,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteUserTagsIntent,
     ) -> Result<immutable_activity::DeleteUserTagsResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_user_tags");
         let request = external_activity::DeleteUserTagsRequest {
             r#type: "ACTIVITY_TYPE_DELETE_USER_TAGS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_user_tags".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -923,19 +721,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdatePrivateKeyTagIntent,
     ) -> Result<immutable_activity::UpdatePrivateKeyTagResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/update_private_key_tag"
-        );
         let request = external_activity::UpdatePrivateKeyTagRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_PRIVATE_KEY_TAG".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/update_private_key_tag".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -952,23 +749,11 @@ impl TurnkeyClient {
         &self,
         request: coordinator::ListPrivateKeyTagsRequest,
     ) -> Result<coordinator::ListPrivateKeyTagsResponse, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/query/list_private_key_tags"
-        );
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res
-            .json::<coordinator::ListPrivateKeyTagsResponse>()
-            .await?;
-        Ok(parsed)
+        self.process_request(
+            &request,
+            "/public/v1/query/list_private_key_tags".to_string(),
+        )
+        .await
     }
     pub async fn delete_private_key_tags(
         &self,
@@ -976,19 +761,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeletePrivateKeyTagsIntent,
     ) -> Result<immutable_activity::DeletePrivateKeyTagsResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/delete_private_key_tags"
-        );
         let request = external_activity::DeletePrivateKeyTagsRequest {
             r#type: "ACTIVITY_TYPE_DELETE_PRIVATE_KEY_TAGS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/delete_private_key_tags".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1007,16 +791,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::SignRawPayloadIntentV2,
     ) -> Result<immutable_activity::SignRawPayloadResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/sign_raw_payload");
         let request = external_activity::SignRawPayloadRequest {
             r#type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/sign_raw_payload".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1035,16 +818,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::SignRawPayloadsIntent,
     ) -> Result<immutable_activity::SignRawPayloadsResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/sign_raw_payloads");
         let request = external_activity::SignRawPayloadsRequest {
             r#type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/sign_raw_payloads".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1063,16 +845,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::SignTransactionIntentV2,
     ) -> Result<immutable_activity::SignTransactionResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/sign_transaction");
         let request = external_activity::SignTransactionRequest {
             r#type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/sign_transaction".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1091,19 +872,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdateRootQuorumIntent,
     ) -> Result<immutable_activity::UpdateRootQuorumResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/update_root_quorum"
-        );
         let request = external_activity::UpdateRootQuorumRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_ROOT_QUORUM".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/update_root_quorum".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1122,16 +899,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateWalletIntent,
     ) -> Result<immutable_activity::CreateWalletResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/create_wallet");
         let request = external_activity::CreateWalletRequest {
             r#type: "ACTIVITY_TYPE_CREATE_WALLET".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_wallet".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1148,35 +924,15 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetWalletsRequest,
     ) -> Result<coordinator::GetWalletsResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/list_wallets");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetWalletsResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/list_wallets".to_string())
+            .await
     }
     pub async fn get_wallet(
         &self,
         request: coordinator::GetWalletRequest,
     ) -> Result<coordinator::GetWalletResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_wallet");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetWalletResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_wallet".to_string())
+            .await
     }
     pub async fn create_wallet_accounts(
         &self,
@@ -1184,19 +940,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateWalletAccountsIntent,
     ) -> Result<immutable_activity::CreateWalletAccountsResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_wallet_accounts"
-        );
         let request = external_activity::CreateWalletAccountsRequest {
             r#type: "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_wallet_accounts".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1213,38 +968,18 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetWalletAccountsRequest,
     ) -> Result<coordinator::GetWalletAccountsResponse, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/query/list_wallet_accounts"
-        );
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetWalletAccountsResponse>().await?;
-        Ok(parsed)
+        self.process_request(
+            &request,
+            "/public/v1/query/list_wallet_accounts".to_string(),
+        )
+        .await
     }
     pub async fn get_wallet_account(
         &self,
         request: coordinator::GetWalletAccountRequest,
     ) -> Result<coordinator::GetWalletAccountResponse, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/query/get_wallet_account");
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res.json::<coordinator::GetWalletAccountResponse>().await?;
-        Ok(parsed)
+        self.process_request(&request, "/public/v1/query/get_wallet_account".to_string())
+            .await
     }
     pub async fn create_sub_organization(
         &self,
@@ -1252,19 +987,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateSubOrganizationIntentV7,
     ) -> Result<immutable_activity::CreateSubOrganizationResultV7, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_sub_organization"
-        );
         let request = external_activity::CreateSubOrganizationRequest {
             r#type: "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V7".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_sub_organization".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1283,19 +1017,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::InitUserEmailRecoveryIntent,
     ) -> Result<immutable_activity::InitUserEmailRecoveryResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/init_user_email_recovery"
-        );
         let request = external_activity::InitUserEmailRecoveryRequest {
             r#type: "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/init_user_email_recovery".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1314,16 +1047,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::RecoverUserIntent,
     ) -> Result<immutable_activity::RecoverUserResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/recover_user");
         let request = external_activity::RecoverUserRequest {
             r#type: "ACTIVITY_TYPE_RECOVER_USER".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/recover_user".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1342,19 +1074,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::SetOrganizationFeatureIntent,
     ) -> Result<immutable_activity::SetOrganizationFeatureResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/set_organization_feature"
-        );
         let request = external_activity::SetOrganizationFeatureRequest {
             r#type: "ACTIVITY_TYPE_SET_ORGANIZATION_FEATURE".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/set_organization_feature".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1373,19 +1104,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::RemoveOrganizationFeatureIntent,
     ) -> Result<immutable_activity::RemoveOrganizationFeatureResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/remove_organization_feature"
-        );
         let request = external_activity::RemoveOrganizationFeatureRequest {
             r#type: "ACTIVITY_TYPE_REMOVE_ORGANIZATION_FEATURE".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/remove_organization_feature".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1404,19 +1134,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ExportPrivateKeyIntent,
     ) -> Result<immutable_activity::ExportPrivateKeyResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/export_private_key"
-        );
         let request = external_activity::ExportPrivateKeyRequest {
             r#type: "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/export_private_key".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1435,16 +1161,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ExportWalletIntent,
     ) -> Result<immutable_activity::ExportWalletResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/export_wallet");
         let request = external_activity::ExportWalletRequest {
             r#type: "ACTIVITY_TYPE_EXPORT_WALLET".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/export_wallet".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1463,16 +1188,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::EmailAuthIntentV2,
     ) -> Result<immutable_activity::EmailAuthResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/email_auth");
         let request = external_activity::EmailAuthRequest {
             r#type: "ACTIVITY_TYPE_EMAIL_AUTH_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/email_auth".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1491,19 +1215,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ExportWalletAccountIntent,
     ) -> Result<immutable_activity::ExportWalletAccountResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/export_wallet_account"
-        );
         let request = external_activity::ExportWalletAccountRequest {
             r#type: "ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/export_wallet_account".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1522,19 +1245,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::InitImportWalletIntent,
     ) -> Result<immutable_activity::InitImportWalletResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/init_import_wallet"
-        );
         let request = external_activity::InitImportWalletRequest {
             r#type: "ACTIVITY_TYPE_INIT_IMPORT_WALLET".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/init_import_wallet".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1553,16 +1272,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ImportWalletIntent,
     ) -> Result<immutable_activity::ImportWalletResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/import_wallet");
         let request = external_activity::ImportWalletRequest {
             r#type: "ACTIVITY_TYPE_IMPORT_WALLET".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/import_wallet".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1581,19 +1299,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::InitImportPrivateKeyIntent,
     ) -> Result<immutable_activity::InitImportPrivateKeyResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/init_import_private_key"
-        );
         let request = external_activity::InitImportPrivateKeyRequest {
             r#type: "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/init_import_private_key".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1612,19 +1329,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::ImportPrivateKeyIntent,
     ) -> Result<immutable_activity::ImportPrivateKeyResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/import_private_key"
-        );
         let request = external_activity::ImportPrivateKeyRequest {
             r#type: "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/import_private_key".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1643,16 +1356,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::OauthIntent,
     ) -> Result<immutable_activity::OauthResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/oauth");
         let request = external_activity::OauthRequest {
             r#type: "ACTIVITY_TYPE_OAUTH".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/oauth".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1671,16 +1383,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::InitOtpAuthIntentV2,
     ) -> Result<immutable_activity::InitOtpAuthResultV2, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/init_otp_auth");
         let request = external_activity::InitOtpAuthRequest {
             r#type: "ACTIVITY_TYPE_INIT_OTP_AUTH_V2".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/init_otp_auth".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1699,16 +1410,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::OtpAuthIntent,
     ) -> Result<immutable_activity::OtpAuthResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/otp_auth");
         let request = external_activity::OtpAuthRequest {
             r#type: "ACTIVITY_TYPE_OTP_AUTH".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/otp_auth".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1727,19 +1437,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::CreateOauthProvidersIntent,
     ) -> Result<immutable_activity::CreateOauthProvidersResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/create_oauth_providers"
-        );
         let request = external_activity::CreateOauthProvidersRequest {
             r#type: "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/create_oauth_providers".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1758,19 +1467,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteOauthProvidersIntent,
     ) -> Result<immutable_activity::DeleteOauthProvidersResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/delete_oauth_providers"
-        );
         let request = external_activity::DeleteOauthProvidersRequest {
             r#type: "ACTIVITY_TYPE_DELETE_OAUTH_PROVIDERS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/delete_oauth_providers".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1787,23 +1495,11 @@ impl TurnkeyClient {
         &self,
         request: coordinator::GetOrganizationConfigsRequest,
     ) -> Result<coordinator::GetOrganizationConfigsResponse, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/query/get_organization_configs"
-        );
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let res = self
-            .http
-            .post(url)
-            .header("X-Stamp", stamp)
-            .body(post_body)
-            .send()
-            .await?;
-        let parsed = res
-            .json::<coordinator::GetOrganizationConfigsResponse>()
-            .await?;
-        Ok(parsed)
+        self.process_request(
+            &request,
+            "/public/v1/query/get_organization_configs".to_string(),
+        )
+        .await
     }
     pub async fn delete_private_keys(
         &self,
@@ -1811,19 +1507,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeletePrivateKeysIntent,
     ) -> Result<immutable_activity::DeletePrivateKeysResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/delete_private_keys"
-        );
         let request = external_activity::DeletePrivateKeysRequest {
             r#type: "ACTIVITY_TYPE_DELETE_PRIVATE_KEYS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/delete_private_keys".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1842,16 +1537,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::UpdateWalletIntent,
     ) -> Result<immutable_activity::UpdateWalletResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/update_wallet");
         let request = external_activity::UpdateWalletRequest {
             r#type: "ACTIVITY_TYPE_UPDATE_WALLET".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/update_wallet".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1870,16 +1564,15 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteWalletsIntent,
     ) -> Result<immutable_activity::DeleteWalletsResult, TurnkeyClientError> {
-        let url = format!("{}{}", self.base_url, "/public/v1/submit/delete_wallets");
         let request = external_activity::DeleteWalletsRequest {
             r#type: "ACTIVITY_TYPE_DELETE_WALLETS".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/delete_wallets".to_string())
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?
@@ -1898,19 +1591,18 @@ impl TurnkeyClient {
         timestamp_ms: u128,
         params: immutable_activity::DeleteSubOrganizationIntent,
     ) -> Result<immutable_activity::DeleteSubOrganizationResult, TurnkeyClientError> {
-        let url = format!(
-            "{}{}",
-            self.base_url, "/public/v1/submit/delete_sub_organization"
-        );
         let request = external_activity::DeleteSubOrganizationRequest {
             r#type: "ACTIVITY_TYPE_DELETE_SUB_ORGANIZATION".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
         };
-        let post_body = serde_json::to_string(&request)?;
-        let stamp = self.api_key.stamp(post_body.clone())?;
-        let activity = self.process_activity(url, stamp, post_body).await?;
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/delete_sub_organization".to_string(),
+            )
+            .await?;
         let inner = activity
             .result
             .ok_or_else(|| TurnkeyClientError::MissingResult)?

--- a/examples/src/bin/sub_organization.rs
+++ b/examples/src/bin/sub_organization.rs
@@ -7,11 +7,7 @@ use tkhq_client::generated::{
     ApiKeyParamsV2, CreateSubOrganizationIntentV7, RootUserParamsV4, WalletAccountParams,
     WalletParams,
 };
-use tkhq_client::TurnkeyClient;
 use tkhq_examples::load_api_key_from_env;
-
-// See <https://docs.turnkey.com/api-reference/organizations/create-sub-organization> for documentation
-const TURNKEY_API_HOST: &str = "https://api.turnkey.com";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -25,7 +21,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let organization_id =
         env::var("TURNKEY_ORGANIZATION_ID").expect("cannot load TURNKEY_ORGANIZATION_ID");
 
-    let client = tkhq_client::TurnkeyClient::new(TURNKEY_API_HOST, api_key, None);
+    let client = tkhq_client::TurnkeyClient::builder()
+        .api_key(api_key)
+        .build()?;
     let intent = CreateSubOrganizationIntentV7 {
         sub_organization_name: "New sub-organization".to_string(),
         root_users: vec![RootUserParamsV4 {
@@ -73,8 +71,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Now let's cleanup and delete our sub-organization
     // This needs to be done by the sub-organization user, authenticated by our fresh API key
-    let sub_organization_client =
-        TurnkeyClient::new(TURNKEY_API_HOST, sub_organization_api_key, None);
+    let sub_organization_client = tkhq_client::TurnkeyClient::builder()
+        .api_key(sub_organization_api_key)
+        .build()?;
     let delete_res = sub_organization_client
         .delete_sub_organization(
             create_res.sub_organization_id.clone(),

--- a/examples/src/bin/sub_organization.rs
+++ b/examples/src/bin/sub_organization.rs
@@ -8,7 +8,7 @@ use tkhq_client::generated::{
     WalletParams,
 };
 use tkhq_client::TurnkeyClient;
-use tkhq_examples::{current_time_ms, load_api_key_from_env};
+use tkhq_examples::load_api_key_from_env;
 
 // See <https://docs.turnkey.com/api-reference/organizations/create-sub-organization> for documentation
 const TURNKEY_API_HOST: &str = "https://api.turnkey.com";
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let create_res = client
-        .create_sub_organization(organization_id, current_time_ms(), intent)
+        .create_sub_organization(organization_id, client.current_timestamp(), intent)
         .await?;
 
     assert_eq!(create_res.root_user_ids.len(), 1);
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let delete_res = sub_organization_client
         .delete_sub_organization(
             create_res.sub_organization_id.clone(),
-            current_time_ms(),
+            client.current_timestamp(),
             DeleteSubOrganizationIntent {
                 delete_without_export: Some(true),
             },

--- a/examples/src/bin/wallet.rs
+++ b/examples/src/bin/wallet.rs
@@ -11,9 +11,6 @@ use tkhq_client::generated::{
 use tkhq_enclave_encrypt::{ExportClient, QuorumPublicKey};
 use tkhq_examples::load_api_key_from_env;
 
-// See <https://docs.turnkey.com/api-reference/organizations/create-sub-organization> for documentation
-const TURNKEY_API_HOST: &str = "https://api.turnkey.com";
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Load API key
@@ -24,7 +21,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         env::var("TURNKEY_ORGANIZATION_ID").expect("cannot load TURNKEY_ORGANIZATION_ID");
 
     // Create our Turnkey client
-    let client = tkhq_client::TurnkeyClient::new(TURNKEY_API_HOST, api_key, None);
+    let client = tkhq_client::TurnkeyClient::builder()
+        .api_key(api_key)
+        .build()?;
 
     // Create a new wallet in the organization
     let create_wallet_result = client

--- a/examples/src/bin/wallet.rs
+++ b/examples/src/bin/wallet.rs
@@ -9,7 +9,7 @@ use tkhq_client::generated::{
     CreateWalletIntent, DeleteWalletsIntent, ExportWalletIntent, SignRawPayloadIntentV2,
 };
 use tkhq_enclave_encrypt::{ExportClient, QuorumPublicKey};
-use tkhq_examples::{current_time_ms, load_api_key_from_env};
+use tkhq_examples::load_api_key_from_env;
 
 // See <https://docs.turnkey.com/api-reference/organizations/create-sub-organization> for documentation
 const TURNKEY_API_HOST: &str = "https://api.turnkey.com";
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let create_wallet_result = client
         .create_wallet(
             organization_id.clone(),
-            current_time_ms(),
+            client.current_timestamp(),
             CreateWalletIntent {
                 wallet_name: "New wallet".to_string(),
                 accounts: vec![WalletAccountParams {
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let signature_result = client
         .sign_raw_payload(
             organization_id.clone(),
-            current_time_ms(),
+            client.current_timestamp(),
             SignRawPayloadIntentV2 {
                 sign_with: eth_address.to_string(),
                 payload: "hello from TKHQ".to_string(),
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let export_wallet_result = client
         .export_wallet(
             organization_id.clone(),
-            current_time_ms(),
+            client.current_timestamp(),
             ExportWalletIntent {
                 wallet_id: wallet_id.clone(),
                 target_public_key: export_client.target_public_key()?,
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let delete_wallet_result = client
         .delete_wallets(
             organization_id,
-            current_time_ms(),
+            client.current_timestamp(),
             DeleteWalletsIntent {
                 wallet_ids: vec![wallet_id.clone()],
                 delete_without_export: Some(false),

--- a/examples/src/bin/whoami.rs
+++ b/examples/src/bin/whoami.rs
@@ -2,13 +2,13 @@ use std::env;
 use std::error::Error;
 use tkhq_client::generated::GetWhoamiRequest;
 use tkhq_examples::load_api_key_from_env;
-// See <https://docs.turnkey.com/api-reference/sessions/who-am-i> for documentation
-const TURNKEY_API_HOST: &str = "https://api.turnkey.com";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = load_api_key_from_env()?;
-    let client = tkhq_client::TurnkeyClient::new(TURNKEY_API_HOST, api_key, None);
+    let client = tkhq_client::TurnkeyClient::builder()
+        .api_key(api_key)
+        .build()?;
 
     let req = GetWhoamiRequest {
         organization_id: env::var("TURNKEY_ORGANIZATION_ID").unwrap(),

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,14 +1,6 @@
 use std::env;
 use std::error::Error;
-use std::time;
 use tkhq_api_key_stamper::TurnkeyP256ApiKey;
-
-pub fn current_time_ms() -> u128 {
-    time::SystemTime::now()
-        .duration_since(time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis()
-}
 
 // Convenience function shared across examples to load a Turnkey API key from the local `examples/.env` file, or from env vars.
 pub fn load_api_key_from_env() -> Result<TurnkeyP256ApiKey, Box<dyn Error>> {


### PR DESCRIPTION
## Goals & motivation

The primary motivation for this PR is to address #12, where a 401 was surfaced as a `MissingActivity` error. While doing this I realized I'd have to add this new status-checking logic to 3 places, so I tried to DRY up the request logic in a single place: `process_request`, used by generated query client methods, and `process_activity`, which is used by generated activity client methods. Result? 300 lines of code gone 🎉 
<img width="136" alt="image" src="https://github.com/user-attachments/assets/88271d28-a35e-4a7b-b266-48f449af1f8f" />

Added a test to show the new status error check. It should now be much nicer for debugging: you get a proper `TurnkeyClientError::UnexpectedHttpStatus`, with the offending status code and associated HTTP response body!