### PR TITLE
Update crate names from `tkhq_*` to `turnkey_*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,82 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tkhq_api_key_stamper"
-version = "0.0.2"
-dependencies = [
- "base64 0.22.0",
- "hex",
- "p256 0.13.2",
- "rand_core",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "tkhq_client"
-version = "0.0.2"
-dependencies = [
- "http 0.2.12",
- "mime",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tkhq_api_key_stamper",
- "tokio",
- "wiremock",
-]
-
-[[package]]
-name = "tkhq_codegen"
-version = "0.1.0"
-dependencies = [
- "heck 0.4.1",
- "prettyplease",
- "proc-macro2",
- "prost-build 0.12.6",
- "quote",
- "regex",
- "serde",
- "serde_json",
- "syn",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "tkhq_enclave_encrypt"
-version = "0.1.0"
-dependencies = [
- "bs58",
- "hex",
- "hpke",
- "p256 0.12.0",
- "rand_core",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "tkhq_examples"
-version = "0.0.1"
-dependencies = [
- "dotenvy",
- "hex",
- "reqwest",
- "serde_json",
- "tkhq_api_key_stamper",
- "tkhq_client",
- "tkhq_enclave_encrypt",
- "tokio",
-]
-
-[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2228,82 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "turnkey_api_key_stamper"
+version = "0.0.2"
+dependencies = [
+ "base64 0.22.0",
+ "hex",
+ "p256 0.13.2",
+ "rand_core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "turnkey_client"
+version = "0.0.2"
+dependencies = [
+ "http 0.2.12",
+ "mime",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "turnkey_api_key_stamper",
+ "wiremock",
+]
+
+[[package]]
+name = "turnkey_codegen"
+version = "0.1.0"
+dependencies = [
+ "heck 0.4.1",
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.12.6",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "turnkey_enclave_encrypt"
+version = "0.1.0"
+dependencies = [
+ "bs58",
+ "hex",
+ "hpke",
+ "p256 0.12.0",
+ "rand_core",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "turnkey_examples"
+version = "0.0.1"
+dependencies = [
+ "dotenvy",
+ "hex",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "turnkey_api_key_stamper",
+ "turnkey_client",
+ "turnkey_enclave_encrypt",
+]
 
 [[package]]
 name = "typenum"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: generate
 generate:
-	cargo run -p tkhq_codegen
+	cargo run -p turnkey_codegen
 	cargo fmt --
 
 .PHONY: check-generate
@@ -29,6 +29,6 @@ test: build
 
 .PHONY: examples
 examples: build
-	cargo run -p tkhq_examples --bin whoami
-	cargo run -p tkhq_examples --bin sub_organization
-	cargo run -p tkhq_examples --bin wallet
+	cargo run -p turnkey_examples --bin whoami
+	cargo run -p turnkey_examples --bin sub_organization
+	cargo run -p turnkey_examples --bin wallet

--- a/api_key_stamper/Cargo.toml
+++ b/api_key_stamper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tkhq_api_key_stamper"
+name = "turnkey_api_key_stamper"
 version = "0.0.2"
 edition = "2021"
 publish = false

--- a/api_key_stamper/README.md
+++ b/api_key_stamper/README.md
@@ -1,11 +1,11 @@
-# tkhq_api_key_stamper
+# turnkey_api_key_stamper
 
 This crate contains structs and utilities to work with P-256 keys, which [Turnkey](https://docs.turnkey.com/) uses as a primary way of authentication.
 
 ## Creating a new P-256 API key
 
 ```rust
-use tkhq_api_key_stamper::TurnkeyP256ApiKey
+use turnkey_api_key_stamper::TurnkeyP256ApiKey
 
 let api_key = TurnkeyP256ApiKey::generate();
 ```
@@ -16,7 +16,7 @@ If you keep API keys in env vars, load it with `from_bytes` or `from_strings`:
 
 ```rust
 use std::env;
-use tkhq_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 
 // Assuming the env var is a hex-encoded string
 let api_private_key = env::var("TURNKEY_API_PRIVATE_KEY").expect("cannot load TURNKEY_API_PRIVATE_KEY");
@@ -31,7 +31,7 @@ If you want to store API keys in `.env` files, use [`dotenvy`](https://docs.rs/d
 If you have generated API keys with Turnkey's [command-line tool](https://github.com/tkhq/tkcli) you can load them with:
 
 ```rust
-use tkhq_api_key_stamper::TurnkeyP256ApiKey
+use turnkey_api_key_stamper::TurnkeyP256ApiKey
 
 let api_key = TurnkeyP256ApiKey::from_files(
     "/home/user/.config/turnkey/keys/key.priv",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tkhq_client"
+name = "turnkey_client"
 version = "0.0.2"
 edition = "2021"
 publish = false
@@ -11,7 +11,7 @@ doctest = false
 [dependencies]
 mime = { version = "0.3.17" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
-tkhq_api_key_stamper = { path = "../api_key_stamper" }
+turnkey_api_key_stamper = { path = "../api_key_stamper" }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
 serde = { version = "1.0", features = ["derive"] }

--- a/client/README.md
+++ b/client/README.md
@@ -1,4 +1,6 @@
-# Turnkey Client
+# `turnkey_client`
+
+This crate contains an HTTP client to interact with the Turnkey API ([documentation](https://docs.turnkey.com/api-reference/overview)).
 
 ## Usage
 
@@ -10,7 +12,7 @@ To make a request to Turnkey:
   ```
 * Create a new client:
   ```rust
-  let client = tkhq_client::TurnkeyClient::builder().api_key(api_key).build().expect("client builder failed");
+  let client = turnkey_client::TurnkeyClient::builder().api_key(api_key).build().expect("client builder failed");
   ```
 * Make a request (for example, a signature request)
   ```rust
@@ -30,7 +32,7 @@ To make a request to Turnkey:
 
 The Turnkey client uses `reqwest` under the hood. To access the `reqwest` builder, use the following:
 ```rust
-tkhq_client::TurnkeyClient::builder()
+turnkey_client::TurnkeyClient::builder()
     .api_key(api_key)
     .with_reqwest_builder(|b| b.connection_verbose(true))
 ```

--- a/client/src/generated/mod.rs
+++ b/client/src/generated/mod.rs
@@ -76,7 +76,7 @@ pub mod services {
     }
 }
 
-// Added by tkhq_codegen
+// Added by turnkey_codegen
 mod client;
 pub use external::activity::v1::*;
 pub use immutable::activity::v1::*;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,8 +12,8 @@ use generated::Activity;
 use generated::ActivityResponse;
 use generated::ActivityStatus;
 
-use tkhq_api_key_stamper::StamperError;
-use tkhq_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_api_key_stamper::StamperError;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 
 #[cfg_attr(doc, doc(hidden))]
 pub mod generated;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tkhq_codegen"
+name = "turnkey_codegen"
 version = "0.1.0"
 edition = "2021"
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -238,7 +238,7 @@ fn main() {
         .unwrap();
 
     // This will append new lines to the end of the mod.rs file
-    writeln!(mod_rs, "\n// Added by tkhq_codegen").unwrap();
+    writeln!(mod_rs, "\n// Added by turnkey_codegen").unwrap();
     writeln!(mod_rs, "mod client;").unwrap();
     writeln!(mod_rs, "pub use services::coordinator::public::v1::*;").unwrap();
     writeln!(mod_rs, "pub use external::activity::v1::*;").unwrap();

--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tkhq_enclave_encrypt"
+name = "turnkey_enclave_encrypt"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/enclave_encrypt/README.md
+++ b/enclave_encrypt/README.md
@@ -1,4 +1,4 @@
-# tkhq_enclave_encrypt
+# turnkey_enclave_encrypt
 
 This repository contains primitives to encrypt and decrypt data, sent to and from Turnkey secure enclaves (see Enclave to [end-user secure channels](https://docs.turnkey.com/security/enclave-secure-channels)).
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tkhq_examples"
+name = "turnkey_examples"
 version = "0.0.1"
 edition = "2021"
 license = "Apache-2.0"
@@ -7,9 +7,9 @@ description = "Examples using the Turnkey Rust SDK"
 publish = false
 
 [dependencies]
-tkhq_api_key_stamper = { path = "../api_key_stamper" }
-tkhq_enclave_encrypt = { path = "../enclave_encrypt" }
-tkhq_client = { path = "../client" }
+turnkey_api_key_stamper = { path = "../api_key_stamper" }
+turnkey_enclave_encrypt = { path = "../enclave_encrypt" }
+turnkey_client = { path = "../client" }
 dotenvy = { version = "0.15.0" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 reqwest = { version = "0.11", features = ["json"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,11 +18,11 @@ Populate your `.env` file with your own organization ID, public key and private 
 
 Run the examples with:
 ```
-cargo run -p tkhq_examples --bin
+cargo run -p turnkey_examples --bin
 ```
 
 or
 
 ```
-cargo run -p tkhq_examples --bin sub_organization
+cargo run -p turnkey_examples --bin sub_organization
 ```

--- a/examples/src/bin/sub_organization.rs
+++ b/examples/src/bin/sub_organization.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 use std::{env, vec};
-use tkhq_api_key_stamper::TurnkeyP256ApiKey;
-use tkhq_client::generated::DeleteSubOrganizationIntent;
-use tkhq_client::generated::{
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::DeleteSubOrganizationIntent;
+use turnkey_client::generated::{
     immutable::common::v1::{AddressFormat, ApiKeyCurve, Curve, PathFormat},
     ApiKeyParamsV2, CreateSubOrganizationIntentV7, RootUserParamsV4, WalletAccountParams,
     WalletParams,
 };
-use tkhq_examples::load_api_key_from_env;
+use turnkey_examples::load_api_key_from_env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let organization_id =
         env::var("TURNKEY_ORGANIZATION_ID").expect("cannot load TURNKEY_ORGANIZATION_ID");
 
-    let client = tkhq_client::TurnkeyClient::builder()
+    let client = turnkey_client::TurnkeyClient::builder()
         .api_key(api_key)
         .build()?;
     let intent = CreateSubOrganizationIntentV7 {
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Now let's cleanup and delete our sub-organization
     // This needs to be done by the sub-organization user, authenticated by our fresh API key
-    let sub_organization_client = tkhq_client::TurnkeyClient::builder()
+    let sub_organization_client = turnkey_client::TurnkeyClient::builder()
         .api_key(sub_organization_api_key)
         .build()?;
     let delete_res = sub_organization_client

--- a/examples/src/bin/wallet.rs
+++ b/examples/src/bin/wallet.rs
@@ -1,15 +1,15 @@
 use std::error::Error;
 use std::{env, vec};
-use tkhq_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
-use tkhq_client::generated::{
+use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
+use turnkey_client::generated::{
     immutable::common::v1::{AddressFormat, Curve, PathFormat},
     WalletAccountParams,
 };
-use tkhq_client::generated::{
+use turnkey_client::generated::{
     CreateWalletIntent, DeleteWalletsIntent, ExportWalletIntent, SignRawPayloadIntentV2,
 };
-use tkhq_enclave_encrypt::{ExportClient, QuorumPublicKey};
-use tkhq_examples::load_api_key_from_env;
+use turnkey_enclave_encrypt::{ExportClient, QuorumPublicKey};
+use turnkey_examples::load_api_key_from_env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         env::var("TURNKEY_ORGANIZATION_ID").expect("cannot load TURNKEY_ORGANIZATION_ID");
 
     // Create our Turnkey client
-    let client = tkhq_client::TurnkeyClient::builder()
+    let client = turnkey_client::TurnkeyClient::builder()
         .api_key(api_key)
         .build()?;
 

--- a/examples/src/bin/whoami.rs
+++ b/examples/src/bin/whoami.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::error::Error;
-use tkhq_client::generated::GetWhoamiRequest;
-use tkhq_examples::load_api_key_from_env;
+use turnkey_client::generated::GetWhoamiRequest;
+use turnkey_examples::load_api_key_from_env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let api_key = load_api_key_from_env()?;
-    let client = tkhq_client::TurnkeyClient::builder()
+    let client = turnkey_client::TurnkeyClient::builder()
         .api_key(api_key)
         .build()?;
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::error::Error;
-use tkhq_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 
 // Convenience function shared across examples to load a Turnkey API key from the local `examples/.env` file, or from env vars.
 pub fn load_api_key_from_env() -> Result<TurnkeyP256ApiKey, Box<dyn Error>> {


### PR DESCRIPTION
This is in preparation for publishing on crates.io, we want the crate names to be `turnkey_*` instead of `tkhq_*`.