### PR TITLE
Add license file to Cargo.toml, and add `publish=false` for codegen

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.219", default-features = false, features = ["std", "der
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.12", default-features = false }
 tokio = { version = "1.44.2", default-features = false }
-turnkey_api_key_stamper = { path = "../api_key_stamper" }
+turnkey_api_key_stamper = { path = "../api_key_stamper", version = "0.0.2" }
 
 [dev-dependencies]
 wiremock = { version = "0.6", default-features = false }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,6 +2,11 @@
 name = "turnkey_codegen"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+description = "Generates code for the turnkey_client crate."
+readme = "README.md"
+repository = "https://github.com/tkhq/rust-sdk"
+publish = false
 
 [dependencies]
 heck = { version = "0.5.0", default-features = false }

--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -2,6 +2,7 @@
 name = "turnkey_enclave_encrypt"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = "Utilities to encrypt and decrypt data sent to and from Turnkey secure enclaves, using HPKE (RFC 9180). Used in authentication, export, and import flows."
 repository = "https://github.com/tkhq/rust-sdk"
 homepage = "https://turnkey.com"

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "turnkey_proofs"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 description = "Utilities to parse and verify Turnkey secure enclave proofs"
 repository = "https://github.com/tkhq/rust-sdk"
 homepage = "https://turnkey.com"


### PR DESCRIPTION
Another quick set of tweaks related to publishing crates:
* there was no license field set on some of the crates
* missing `publish=false` on codegen which meant we could have published it on accident (no big deal I guess)
* `version` was missing when importing `turnkey_api_key_stamper` from `turnkey_client`