### PR TITLE
Add alloc feature to hex crate

### DIFF
--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "encoding"]
 
 [dependencies]
 bs58 = { version = "0.5.0", features = ["std", "check"], default-features = false }
-hex = { version = "0.4.3", features = ["serde"], default-features = false}
+hex = { version = "0.4.3", features = ["serde", "alloc"], default-features = false}
 hpke = { version = "0.10", features = ["alloc", "p256", "serde_impls"], default-features = false }
 p256 = { version = "0.12", features = ["ecdsa", "ecdsa-core", "std", "serde"], default-features = false }
 rand_core = { version = "0.6.4", default-features = false }


### PR DESCRIPTION
Don't know why this wasn't surfaced in the `cargo release` dry-run, but I'm able to reproduce with `cargo publish --dry-run` (inside of the `src/enclave_encrypt` directory):
```
error[E0425]: cannot find function `encode` in crate `hex`
   --> src/client.rs:67:17
    |
67  |         Ok(hex::encode(self.encrypt_client.target_bytes()?))
    |                 ^^^^^^ not found in `hex`
    |
note: found an item that was configured out
   --> /Users/rno/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hex-0.4.3/src/lib.rs:259:8
    |
259 | pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
    |        ^^^^^^
note: the item is gated behind the `alloc` feature
   --> /Users/rno/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hex-0.4.3/src/lib.rs:258:7
    |
258 | #[cfg(feature = "alloc")]
    |       ^^^^^^^^^^^^^^^^^
help: consider importing this function
    |
2   + use bs58::encode;
    |
help: if you import `encode`, refer to it directly
    |
67  -         Ok(hex::encode(self.encrypt_client.target_bytes()?))
67  +         Ok(encode(self.encrypt_client.target_bytes()?))
    |
```

Adding the `alloc` feature fixes this.