### PR TITLE
Add `CHANGELOG`s to published crates

### DIFF
--- a/api_key_stamper/CHANGELOG.md
+++ b/api_key_stamper/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+<!-- Add unreleased changes here -->
+
+## turnkey_api_key_stamper-v0.0.2
+
+Initial release of this crate.

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+<!-- Add unreleased changes here -->
+
+## turnkey_client-v0.0.2
+
+Initial release of this crate.

--- a/enclave_encrypt/CHANGELOG.md
+++ b/enclave_encrypt/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+<!-- Add unreleased changes here -->
+
+## turnkey_enclave_encrypt-v0.1.0
+
+Initial release of this crate.

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+<!-- Add unreleased changes here -->
+
+## turnkey_proofs-v0.1.0
+
+Initial release of this crate.


### PR DESCRIPTION
Adding basic changelogs to published crates, which we'll use going forward for release automation with `cargo release`