### PR TITLE
Re-export TurnkeyP256ApiKey from client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "turnkey_api_key_stamper",
  "turnkey_client",
  "turnkey_enclave_encrypt",
  "turnkey_proofs",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-<!-- Add unreleased changes here -->
+
+* Re-export `turnkey_api_key_stamper::TurnkeyP256ApiKey` from `turnkey_client`
 
 ## turnkey_client-v0.0.2
 

--- a/client/README.md
+++ b/client/README.md
@@ -7,13 +7,12 @@ This crate contains an HTTP client to interact with the Turnkey API ([documentat
 To make a request to Turnkey:
 
 ```rust,no_run
-use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::SignRawPayloadIntentV2;
 use turnkey_client::generated::immutable::common::v1::HashFunction;
 use turnkey_client::generated::immutable::common::v1::PayloadEncoding;
 
 // You can load your API key from a file or from env
-let api_key = TurnkeyP256ApiKey::from_strings("<private key hex>", None).expect("api key creation failed");
+let api_key = turnkey_client::TurnkeyP256ApiKey::from_strings("<private key hex>", None).expect("api key creation failed");
 
 // Create a new client:
 let client = turnkey_client::TurnkeyClient::builder().api_key(api_key).build().expect("client builder failed");
@@ -37,9 +36,7 @@ let request = client.sign_raw_payload(
 
 The Turnkey client uses `reqwest` under the hood. To access the `reqwest` builder, use the following:
 ```rust
-use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-
-let api_key = TurnkeyP256ApiKey::generate();
+let api_key = turnkey_client::TurnkeyP256ApiKey::generate();
 
 let client = turnkey_client::TurnkeyClient::builder()
     .api_key(api_key)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,7 +12,8 @@ use generated::ActivityResponse;
 use generated::ActivityStatus;
 
 use turnkey_api_key_stamper::StamperError;
-use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+// Re-export this for convenience
+pub use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 
 pub mod generated;
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,6 @@ reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 tokio = { version = "1.44.1", default-features = false, features = ["full"] }
-turnkey_api_key_stamper = { path = "../api_key_stamper" }
 turnkey_enclave_encrypt = { path = "../enclave_encrypt" }
 turnkey_client = { path = "../client" }
 turnkey_proofs = { path = "../proofs" }

--- a/examples/src/bin/sub_organization.rs
+++ b/examples/src/bin/sub_organization.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::{env, vec};
-use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::TurnkeyP256ApiKey;
 use turnkey_client::generated::DeleteSubOrganizationIntent;
 use turnkey_client::generated::{
     immutable::common::v1::{AddressFormat, ApiKeyCurve, Curve, PathFormat},

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::error::Error;
-use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::TurnkeyP256ApiKey;
 
 // Convenience function shared across examples to load a Turnkey API key from the local `examples/.env` file, or from env vars.
 pub fn load_api_key_from_env() -> Result<TurnkeyP256ApiKey, Box<dyn Error>> {


### PR DESCRIPTION
Minor change for convenience: re-export TurnkeyP256ApiKey from our client, because they're often used together, and the turnkey_client crate already depends on turnkey_api_key_stamper.

See the example update, that's one dependency gone, and people won't have to think about the fact that API key stuff lives in a separate crate.

Addresses #22 