### PR TITLE
Remove reference to unmaintained project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       - name: install protoc
         uses: arduino/setup-protoc@v3
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: "21.4"
       - name: Ensure checked-in client is up-to-date
         run: make check-generate

--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ This project uses [`cargo-release`](https://github.com/crate-ci/cargo-release). 
 cargo install cargo-release
 ```
 
-## Related projects
-
-There is another Rust client available, maintained by [@Eliascm17](https://github.com/Eliascm17): [Eliascm17/turnkey](https://github.com/Eliascm17/turnkey). This client offers some structure around API requests/responses on top of bare request signing.
-
 ## Feature requests and support
 
 If you are working on a project in Rust and would benefit from improvements to this SDK, please open an issue or get in touch with us (hello@turnkey.com) and we can discuss prioritizing this.


### PR DESCRIPTION
This reference was useful a year ago when we had our Rust SDK not fully built out, but now it's a liability: we don't want users to _actually_ use this related project given it's not maintained by Turnkey and seems severely out of date.

I've also resolved a rate limiting issue in the "install protoc" build step:
<img width="1075" height="184" alt="image" src="https://github.com/user-attachments/assets/4215dd39-8f39-4bdd-b94b-5e3b2421ec05" />

Solution is quite simple (add the right GH token).