### PR TITLE
Switch CI to trigger on `pull_request_target`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,24 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: checkout PR code (if PR)
+        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: checkout pushed code (if push)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+      - name: install Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: clippy,rustfmt


### PR DESCRIPTION
PRs from fork can't use secrets. This is an attempt to address this. `pull_request_target` runs in the context of `rust-sdk`, hence has access to the secrets needed to run integration tests. That's what we want.

We do not want malicious PRs to be able to steal secrets, hence we still have a manual approval step for first-time contributor. This is the current setting:

<img width="520" alt="image" src="https://github.com/user-attachments/assets/ee99f5ee-5777-4f48-a961-7a894acb2b0c" />


In the worst case (contributor turned malicious) the creds in CI are simply API keys which give access to a Turnkey org with no funds on wallets or keys:
* there is no value to attack
* we can roll the API key trivially if leaked

Bonus: upgraded from actions/checkout v3 to v4 🎉 