### PR TITLE
Release SDK with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,68 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'tkhq' }}
+    permissions:
+      contents: write
+    steps:
+      - name: git checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # `fetch-depth: 0` is needed to clone all the git history, which is necessary to
+          # release from the latest commit of the release PR.
+          fetch-depth: 0
+      - name: install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+      - name: Run release-plz
+        uses: release-plz/action@dde7b63054529c440305a924e5849c68318bcc9a #v0.5.107
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'tkhq' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: git checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # `fetch-depth: 0` is needed to clone all the git history, which is necessary to
+          # determine the next version and build the changelog.
+          fetch-depth: 0
+      - name: install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+      - name: Run release-plz
+        uses: release-plz/action@dde7b63054529c440305a924e5849c68318bcc9a #v0.5.107
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,7 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
+    environment: release # access to CARGO_REGISTRY_TOKEN, requires approval
     if: ${{ github.repository_owner == 'tkhq' }}
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -27,10 +27,16 @@ This project uses `make` to encapsulate common tasks:
 
 ## Releases
 
-This project uses [`cargo-release`](https://github.com/crate-ci/cargo-release). Install it with:
+This project uses [`release-plz`](https://github.com/release-plz/release-plz). Install it with:
 
 ```sh
-cargo install cargo-release
+cargo install --locked release-plz
+```
+
+Once you have it installed you can try a release locally, to see what the release PR would be:
+
+```
+release-plz update
 ```
 
 ## Feature requests and support

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,7 @@
 [workspace]
 pr_labels = ["release"]
+# See https://release-plz.dev/docs/config#the-release_always-field
+release_always = false
 
 [[package]]
 name = "turnkey_api_key_stamper"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,33 @@
+[workspace]
+pr_labels = ["release"]
+
+[[package]]
+name = "turnkey_api_key_stamper"
+changelog_update = true
+publish = true
+version_group = "rust-sdk"
+
+[[package]]
+name = "turnkey_client"
+changelog_update = true
+version_group = "rust-sdk"
+
+[[package]]
+name = "turnkey_codegen"
+publish = false
+release = false
+
+[[package]]
+name = "turnkey_enclave_encrypt"
+changelog_update = true
+version_group = "rust-sdk"
+
+[[package]]
+name = "turnkey_examples"
+publish = false
+release = false
+
+[[package]]
+name = "turnkey_proofs"
+changelog_update = true
+version_group = "rust-sdk"


### PR DESCRIPTION
I've changed my mind: after trying to use `cargo-release` for a bit I don't think it's the right fit for us. I'm a fan of `release-plz` because it's very simple, [well-documented](https://release-plz.dev/docs), and seems to do exactly what it says.

This PR adds a new workflow to allow release-plz to open release PRs, then, on merge, release-plz will trigger a release, subject to human approval (because that workflow runs within a new "release" environment requiring approvals)

Another big decision is consolidation of versions: I think we should mirror what other monorepos do, and have a consistent semver across all `turnkey_*` crates. It'll be a lot easier to reason about for users if api_key_stamper and client are the same version (similar to what tokio or rust-crypto orgs do)