### PR TITLE
Add `issues:write` to release-plz workflow permissions

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -2,6 +2,7 @@ name: Release-plz
 
 permissions:
   pull-requests: write
+  issues: write # needed for labels
   contents: write
 
 on:


### PR DESCRIPTION
See this: https://github.com/tkhq/rust-sdk/actions/runs/16755050859/job/47435449075

```
0: Failed to add labels
    1: Response body:
       {
         "documentation_url": "https://docs.github.com/v3/issues/labels/",
         "errors": [
           {
             "code": "unauthorized",
             "field": "label",
             "resource": "Repository"
           }
         ],
         "message": "You do not have permission to create labels on this repository.",
         "status": "403"
       }
    2: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/tkhq/rust-sdk/issues/38/labels)
```