### PR TITLE
Tweak release-plz release job to trigger on release PR merging

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,8 +15,13 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    environment: release # access to CARGO_REGISTRY_TOKEN, requires approval
-    if: ${{ github.repository_owner == 'tkhq' }}
+    # This environment gives access to CARGO_REGISTRY_TOKEN, and requires approval
+    environment: release 
+    # only trigger this job if the push to main is from a merged PR with a "release" label
+    if: >
+      github.repository_owner == 'tkhq' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Simple change to ensure approvals aren't requested for every PR merged into main! Let's stop the spam.

We should see this in action when this very PR is merged 🤞 