### PR TITLE
Trigger release workflow on closed pull requests instead of pushes to main

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,9 +6,9 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [ main ]
 
 jobs:
   # Release unpublished packages.


### PR DESCRIPTION
This should work because the [Github docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) say:
```
The value of GITHUB_REF varies for a closed pull request depending on whether the pull request has been merged or not. If a pull request was closed but not merged, it will be refs/pull/PULL_REQUEST_NUMBER/merge. If a pull request was closed as a result of being merged, it will be the fully qualified ref of the branch it was merged into, for example /refs/heads/main.
```