### PR TITLE
Add timeout-minutes to CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: checkout PR code (if PR)
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,6 +15,7 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # This environment gives access to CARGO_REGISTRY_TOKEN, and requires approval
     environment: release 
     # only trigger this job if the push to main is from a merged PR with a "release" label
@@ -48,6 +49,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'tkhq' }}
     permissions:
       contents: write


### PR DESCRIPTION
To avoid cases like [these](https://github.com/tkhq/rust-sdk/actions/runs/16999780832):
<img width="720" alt="OMG wat how is there no timeout?!" src="https://github.com/user-attachments/assets/0bb92c4c-1905-4fa1-a724-a348ee09e0f2" />

😮‍💨 