### PR TITLE
Use workspace defined deps & update some deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,6 @@ dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
  "rfc6979 0.3.1",
- "serdect",
  "signature",
 ]
 
@@ -763,7 +762,9 @@ dependencies = [
  "digest",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect",
  "signature",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -790,7 +791,6 @@ dependencies = [
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1 0.3.0",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -810,6 +810,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1087,25 +1088,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
@@ -1287,17 +1269,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1315,7 +1286,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1333,30 +1304,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.8",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -1364,9 +1311,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.9",
+ "h2",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1383,7 +1330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1401,7 +1348,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1421,14 +1368,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -2010,7 +1957,6 @@ dependencies = [
  "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
  "primeorder 0.12.1",
- "serdect",
  "sha2",
 ]
 
@@ -2023,6 +1969,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder 0.13.6",
+ "serdect",
  "sha2",
 ]
 
@@ -2188,6 +2135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
+ "serdect",
 ]
 
 [[package]]
@@ -2524,42 +2472,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
@@ -2570,12 +2482,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.9",
+ "h2",
  "hickory-resolver",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -2592,7 +2504,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -2787,7 +2699,6 @@ dependencies = [
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2801,6 +2712,8 @@ dependencies = [
  "base16ct 0.2.0",
  "der 0.7.9",
  "generic-array",
+ "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2964,11 +2877,11 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fce1bf4d74b9b30ea7dcd59df75ba8ec669a5dcb3cc64fbfcef7334ced32c"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -3059,6 +2972,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
+ "base64ct",
  "der 0.7.9",
 ]
 
@@ -3104,12 +3018,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3142,34 +3050,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -3393,7 +3280,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3409,7 +3296,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3491,7 +3378,7 @@ dependencies = [
  "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "reqwest 0.12.22",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with 3.14.0",
@@ -3525,7 +3412,7 @@ dependencies = [
  "bs58",
  "hex",
  "hpke",
- "p256 0.12.0",
+ "p256 0.13.2",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -3538,7 +3425,7 @@ version = "0.0.1"
 dependencies = [
  "dotenvy",
  "hex",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -4049,7 +3936,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "ecdsa 0.15.1",
  "hex",
  "p256 0.12.0",
- "p384",
+ "p384 0.12.0",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -1986,6 +1986,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,7 +3459,7 @@ dependencies = [
  "coset",
  "hex",
  "hex-literal",
- "p384",
+ "p384 0.13.1",
  "rand 0.8.5",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_with = { version = "3.14.0", default-features = false, features = ["macros
 hpke = { version = "0.10", features = ["alloc", "p256", "serde_impls"], default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8"] }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.12", features = ["sha384", "ecdsa", "ecdsa-core", "std"], default-features = false }
+p384 = { version = "0.13", features = ["sha384", "ecdsa", "ecdsa-core", "std"], default-features = false }
 rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
 sha2 = { version = "0.10", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,81 @@ members = [
   "proofs",
 ]
 resolver = "2"
+
+[workspace.dependencies]
+# Encoding and serialization
+base64 = { version = "0.22.0", default-features = false, features = ["std"] }
+bs58 = { version = "0.5.0", features = ["std", "check"], default-features = false }
+hex = { version = "0.4.3", default-features = false, features = ["std"] }
+serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
+serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
+serde_bytes = { version = "0.11", default-features = false }
+serde_cbor = { version = "0.11", default-features = false }
+serde_with = { version = "3.14.0", default-features = false, features = ["macros"] }
+
+# Cryptography
+hpke = { version = "0.10", features = ["alloc", "p256", "serde_impls"], default-features = false }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8"] }
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.12", features = ["sha384", "ecdsa", "ecdsa-core", "std"], default-features = false }
+rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
+sha2 = { version = "0.10", default-features = false }
+
+# Error handling
+thiserror = { version = "2.0.12", default-features = false }
+
+# Web/HTTP
+mime = { version = "0.3.17", default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"] }
+
+# Async runtime
+tokio = { version = "1.44.2", default-features = false }
+
+# Protocol buffers
+prost = { version = "0.12", default-features = false, features = ["std"] }
+prost-types = { version = "0.12", default-features = false }
+prost-build = { version = "0.12.6", default-features = false }
+
+# AWS Nitro enclaves
+attestation-doc-validation = { version = "0.8.0", default-features = false }
+aws-nitro-enclaves-nsm-api = { version = "0.3", features = ["nix"], default-features = false }
+aws-nitro-enclaves-cose = { version = "0.5", default-features = false }
+
+# CBOR and COSE
+ciborium = { version = "0.2", default-features = false }
+coset = { version = "0.3.7", default-features = false }
+
+# Certificate handling
+webpki = { version = "0.22.4", default-features = false }
+x509-cert = { version = "=0.1.0", features = ["pem"], default-features = false }
+x509-parser = { version = "0.14.0", default-features = false }
+
+# Serialization formats
+borsh = { version = "1.0", features = ["std", "derive"], default-features = false }
+
+# Code generation and parsing
+heck = { version = "0.5.0", default-features = false }
+prettyplease = { version = "0.2", default-features = false }
+proc-macro2 = { version = "1.0.95", default-features = false }
+quote = { version = "1.0", default-features = false }
+regex = { version = "1", default-features = false, features = ["unicode-perl"] }
+syn = { version = "2.0", features = ["full", "extra-traits"], default-features = false }
+tonic-build = { version = "0.13", default-features = false, features = ["prost"] }
+walkdir = { version = "2.5", default-features = false }
+
+# Environment and configuration
+dotenvy = { version = "0.15.0", default-features = false }
+
+# Development dependencies
+tempfile = { version = "3.19.1", default-features = false }
+signature = "2"
+wiremock = { version = "0.6", default-features = false }
+http = { version = "0.2", default-features = false }
+hex-literal = { version = "0.4", default-features = false }
+rand = { version = "0.8", default-features = false }
+
+# Workspace crates
+turnkey_api_key_stamper = { path = "api_key_stamper", version = "0.3.0" }
+turnkey_client = { path = "client", version = "0.3.0" }
+turnkey_enclave_encrypt = { path = "enclave_encrypt", version = "0.3.0" }
+turnkey_proofs = { path = "proofs", version = "0.3.0" }

--- a/api_key_stamper/Cargo.toml
+++ b/api_key_stamper/Cargo.toml
@@ -11,15 +11,15 @@ keywords = ["turnkey", "api-key", "stamp", "signature", "p256"]
 categories = ["cryptography", "authentication", "api-bindings"]
 
 [dependencies]
-base64 = { version = "0.22.0", default-features = false, features = ["std"] }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
-k256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8"] }
-rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
-serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
-serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
-thiserror = { version = "2.0.12", default-features = false }
+base64.workspace = true
+hex.workspace = true
+p256.workspace = true
+k256.workspace = true
+rand_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-tempfile = { version = "3.19.1", default-features = false }
-signature = "2"
+tempfile.workspace = true
+signature.workspace = true

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,16 +12,16 @@ keywords = ["turnkey", "api", "client", "cryptography"]
 categories = ["api-bindings"]
 
 [dependencies]
-mime = { version = "0.3.17", default-features = false }
-prost = { version = "0.12", default-features = false, features = ["std"] }
-prost-types = { version = "0.12", default-features = false }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"] }
-serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
-serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
-serde_with = { version = "3.14.0", default-features = false, features = ["macros"] }
-thiserror = { version = "2.0.12", default-features = false }
-tokio = { version = "1.44.2", default-features = false }
-turnkey_api_key_stamper = { path = "../api_key_stamper", version = "0.3.0" }
+mime.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+turnkey_api_key_stamper.workspace = true
 
 [features]
 reqwest_native_tls = ["reqwest/native-tls-vendored", "reqwest/native-tls-alpn"]
@@ -30,6 +30,6 @@ reqwest_zstd = ["reqwest/zstd"]
 reqwest_hickory_dns = ["reqwest/hickory-dns"]
 
 [dev-dependencies]
-wiremock = { version = "0.6", default-features = false }
-http = { version = "0.2", default-features = false }
-base64 = { version = "0.22", default-features = false, features = ["std"] }
+wiremock.workspace = true
+http.workspace = true
+base64.workspace = true

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -9,14 +9,14 @@ repository = "https://github.com/tkhq/rust-sdk"
 publish = false
 
 [dependencies]
-heck = { version = "0.5.0", default-features = false }
-prettyplease = {version = "0.2", default-features = false }
-proc-macro2 = { version = "1.0.95", default-features = false }
-prost-build = { version = "0.12.6", default-features = false }
-quote = { version = "1.0", default-features = false }
-regex = { version = "1", default-features = false, features=["unicode-perl"] }
-serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
-serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
-syn = { version = "2.0", features = ["full", "extra-traits"], default-features = false}
-tonic-build = { version = "0.13", default-features = false, features = ["prost"] }
-walkdir = { version = "2.5", default-features = false }
+heck.workspace = true
+prettyplease.workspace = true
+proc-macro2.workspace = true
+prost-build.workspace = true
+quote.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+syn.workspace = true
+tonic-build.workspace = true
+walkdir.workspace = true

--- a/enclave_encrypt/Cargo.toml
+++ b/enclave_encrypt/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["turnkey", "enclave", "hpke", "encryption"]
 categories = ["cryptography", "encoding"]
 
 [dependencies]
-bs58 = { version = "0.5.0", features = ["std", "check"], default-features = false }
-hex = { version = "0.4.3", features = ["serde", "alloc"], default-features = false}
-hpke = { version = "0.10", features = ["alloc", "p256", "serde_impls"], default-features = false }
-p256 = { version = "0.12", features = ["ecdsa", "ecdsa-core", "std", "serde"], default-features = false }
-rand_core = { version = "0.6.4", default-features = false }
-serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.140", default-features = false, features = ["alloc"] }
-thiserror = { version = "2.0.12", default-features = false}
+bs58.workspace = true
+hex = { workspace = true, features = ["serde", "alloc"] }
+hpke.workspace = true
+p256 = { workspace = true, features = ["ecdsa", "ecdsa-core", "std", "serde"] }
+rand_core = { workspace = true, default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["alloc"] }
+thiserror.workspace = true

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -556,7 +556,7 @@ mod test {
 
     // Sample Quorum private key which we use to simulate enclave signatures on bundles for tests below
     fn test_quorum_private_key() -> SigningKey {
-        SigningKey::from_bytes(
+        SigningKey::from_slice(
             &hex::decode("28ebf311b27f34cdf078489584d336423e09c522342f5b067dea36823c2cc5ed")
                 .unwrap(),
         )

--- a/enclave_encrypt/src/lib.rs
+++ b/enclave_encrypt/src/lib.rs
@@ -283,11 +283,11 @@ mod tests {
     const FAKE_SEED: &[u8] = &[42; 32];
 
     fn quorum_pub() -> VerifyingKey {
-        *SigningKey::from_bytes(FAKE_SEED).unwrap().verifying_key()
+        *SigningKey::from_slice(FAKE_SEED).unwrap().verifying_key()
     }
 
     fn quorum_priv() -> SigningKey {
-        SigningKey::from_bytes(FAKE_SEED).unwrap()
+        SigningKey::from_slice(FAKE_SEED).unwrap()
     }
     fn random_signature() -> P256Signature {
         let key = quorum_priv();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,12 +7,12 @@ description = "Examples using the Turnkey Rust SDK"
 publish = false
 
 [dependencies]
-dotenvy = { version = "0.15.0", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
-serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
-serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-tokio = { version = "1.44.1", default-features = false, features = ["full"] }
-turnkey_enclave_encrypt = { path = "../enclave_encrypt" }
-turnkey_client = { path = "../client" }
-turnkey_proofs = { path = "../proofs" }
+dotenvy.workspace = true
+hex.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+turnkey_enclave_encrypt.workspace = true
+turnkey_client.workspace = true
+turnkey_proofs.workspace = true

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -12,23 +12,23 @@ keywords = ["turnkey", "nitro", "enclaves", "attestation", "cryptography"]
 categories = ["cryptography", "hardware-support"]
 
 [dependencies]
-attestation-doc-validation = { version = "0.8.0", default-features = false }
-aws-nitro-enclaves-nsm-api = { version = "0.3", features = ["nix"], default-features = false }
-aws-nitro-enclaves-cose = { version = "0.5", default-features = false }
+attestation-doc-validation.workspace = true
+aws-nitro-enclaves-nsm-api.workspace = true
+aws-nitro-enclaves-cose.workspace = true
 base64 = { version = "0.13", default-features = false }
-borsh = { version = "1.0", features = ["std", "derive"] , default-features = false}
-ciborium = { version = "0.2", default-features = false }
-coset = { version = "0.3.7", default-features = false }
-p384 = { version = "0.12", features = ["sha384", "ecdsa", "ecdsa-core", "std"], default-features = false }
-serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
-serde_bytes = { version = "0.11", default-features = false }
-serde_cbor = { version = "0.11", default-features = false }
-sha2 = { version = "0.10", default-features = false }
-webpki = { version =  "0.22.4", default-features = false }
-x509-cert = { version = "=0.1.0", features = ["pem"], default-features = false }
-x509-parser = { version = "0.14.0", default-features = false }
+borsh.workspace = true
+ciborium.workspace = true
+coset.workspace = true
+p384.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+serde_cbor.workspace = true
+sha2.workspace = true
+webpki.workspace = true
+x509-cert.workspace = true
+x509-parser.workspace = true
 
 [dev-dependencies]
-hex = { version = "0.4.3", default-features = false, features = ["std"] }
-hex-literal = { version = "0.4", default-features = false }
-rand = { version = "0.8", default-features = false }
+hex.workspace = true
+hex-literal.workspace = true
+rand.workspace = true


### PR DESCRIPTION
Changes
- Use workspace defined deps to make it easier to keep dep versions in sync across workspace crates. I did not explicitly bump deps, just tried to use the latest version
- Explicitly bump p384 to latest (we are already be using latest of other rust crypto deps)

Note: since the crypto crates went up a minor version version and the major is 0, this indicates they had a breaking api change. If our api is dependent on their api (which based on diff in tests it is), we should mark this as a breaking change
Dependency review: https://docs.google.com/spreadsheets/d/1Cy_3xR2vz8tW62PabjD5qClma3eVnzxZID6VsxGY7Cs/edit?usp=sharing