### PR TITLE
PR 2: Remove --dangerous-skip-interactive, use --no-input for non-interactive approval

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -24,7 +24,9 @@ impl Cli {
 
         match args.command {
             Commands::Deploy { command } => match command {
-                DeployCommands::Approve(args) => commands::deploy::approve::run(args).await,
+                DeployCommands::Approve(args) => {
+                    commands::deploy::approve::run(args, no_input).await
+                }
                 DeployCommands::Status(args) => commands::deploy::status::run(args).await,
                 DeployCommands::Create(args) => commands::deploy::create::run(args).await,
                 DeployCommands::Init(args) => commands::deploy::init::run(args).await,

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -61,10 +61,6 @@ pub struct Args {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// DANGEROUS: skip interactive prompts for approving each aspect of manifest.
-    #[arg(long)]
-    pub dangerous_skip_interactive: bool,
-
     /// Write approval to file instead of stdout.
     #[arg(short, long, value_name = "PATH")]
     pub output: Option<PathBuf>,
@@ -75,7 +71,7 @@ pub struct Args {
 }
 
 /// Run the approve deploy command.
-pub async fn run(args: Args) -> anyhow::Result<()> {
+pub async fn run(args: Args, no_input: bool) -> anyhow::Result<()> {
     // Fetch manifest - track manifest_id if fetched from API
     let (manifest, fetched_manifest_id) = match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => (read_manifest_from_path(path).await?, None),
@@ -86,7 +82,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         (None, None) => bail!("a manifest source is required"),
     };
 
-    if !args.dangerous_skip_interactive {
+    // Skip interactive approval in non-interactive mode
+    if !no_input {
         interactive_approve(&manifest)?;
     }
 

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -4,28 +4,30 @@ use predicates::prelude::*;
 #[test]
 fn approve_requires_source() {
     cargo_bin_cmd!("tvc")
+        .arg("--no-input")
         .arg("deploy")
         .arg("approve")
         .arg("--dry-run")
-        .arg("--dangerous-skip-interactive")
         .assert()
         .failure()
         .stderr(predicate::str::contains("manifest source is required"));
 }
 
 #[test]
-fn dangerous_approve_with_file() {
+fn approve_no_input_skips_interactive() {
     cargo_bin_cmd!("tvc")
+        .arg("--no-input")
         .arg("deploy")
         .arg("approve")
         .arg("--manifest")
         .arg("fixtures/manifest.json")
         .arg("--operator-seed")
         .arg("fixtures/seed.hex")
-        .arg("--dangerous-skip-interactive")
         .arg("--skip-post")
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("\"signature\""))
+        .stdout(predicate::str::contains("MANIFEST APPROVAL").not());
 }
 
 #[test]
@@ -84,7 +86,6 @@ fn manifest_and_deploy_id_are_mutually_exclusive() {
         .arg("fixtures/manifest.json")
         .arg("--deploy-id")
         .arg("some-deploy-id")
-        .arg("--dangerous-skip-interactive")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -96,13 +97,13 @@ fn manifest_and_deploy_id_are_mutually_exclusive() {
 #[test]
 fn approve_requires_manifest_id_or_skip_post() {
     cargo_bin_cmd!("tvc")
+        .arg("--no-input")
         .arg("deploy")
         .arg("approve")
         .arg("--manifest")
         .arg("fixtures/manifest.json")
         .arg("--operator-seed")
         .arg("fixtures/seed.hex")
-        .arg("--dangerous-skip-interactive")
         .assert()
         .failure()
         .stderr(predicate::str::contains(

--- a/tvc/tests/global_flags.rs
+++ b/tvc/tests/global_flags.rs
@@ -17,7 +17,6 @@ fn no_input_flag_recognized() {
         .arg("deploy")
         .arg("approve")
         .arg("--dry-run")
-        .arg("--dangerous-skip-interactive")
         .assert()
         .failure()
         .stderr(predicate::str::contains("manifest source is required"));


### PR DESCRIPTION
## Summary

Depends on #112.

- Removes `--dangerous-skip-interactive` flag from deploy approve
- Uses the global `--no-input` flag (from #112) to skip interactive manifest approval prompts
- Breaking change: scripts using `--dangerous-skip-interactive` must switch to `--no-input`

## Test plan

- [ ] `cargo test --test deploy_approve` (6 tests: non-interactive skip, interactive prompts, reject, error cases)
- [ ] `cargo test --test global_flags` (2 tests: flag recognition)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual: `tvc --no-input deploy approve --manifest <path> --skip-post` skips prompts and outputs JSON