### PR TITLE
chore: add tvc to release-plz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "tvc"
-version = "0.1.0-alpha.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains tooling to interact with the Turnkey API using Rust, an
 | `turnkey_client` | Rust client to interact with the Turnkey API | [![Latest](https://img.shields.io/crates/v/turnkey_client.svg)](https://crates.io/crates/turnkey_client) | [![docs.rs](https://img.shields.io/docsrs/turnkey_client)](https://docs.rs/turnkey_client) | [CHANGELOG](./client/CHANGELOG.md) | [`client`](./client/) |
 | `turnkey_enclave_encrypt` | Utilities to decrypt and encrypt data from and to Turnkey secure enclaves | [![Latest](https://img.shields.io/crates/v/turnkey_enclave_encrypt.svg)](https://crates.io/crates/turnkey_enclave_encrypt) | [![docs.rs](https://img.shields.io/docsrs/turnkey_enclave_encrypt)](https://docs.rs/turnkey_enclave_encrypt) | [CHANGELOG](./enclave_encrypt/CHANGELOG.md) | [`enclave_encrypt`](./enclave_encrypt/) |
 | `turnkey_proofs` | Utilities to verify Turnkey secure enclave proofs | [![Latest](https://img.shields.io/crates/v/turnkey_proofs.svg)](https://crates.io/crates/turnkey_proofs) | [![docs.rs](https://img.shields.io/docsrs/turnkey_proofs)](https://docs.rs/turnkey_proofs) | [CHANGELOG](./proofs/CHANGELOG.md) | [`proofs`](./proofs/) |
+| `tvc` | CLI for Turnkey Verifiable Cloud | [![Latest](https://img.shields.io/crates/v/tvc.svg)](https://crates.io/crates/tvc) | [![docs.rs](https://img.shields.io/docsrs/tvc)](https://docs.rs/tvc) | [CHANGELOG](./tvc/CHANGELOG.md) | [`tvc`](./tvc/) |
 
 
 ## Examples

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -36,5 +36,5 @@ version_group = "rust-sdk"
 
 [[package]]
 name = "tvc"
-publish = false
-release = false
+changelog_update = true
+version_group = "rust-sdk"

--- a/tvc/CHANGELOG.md
+++ b/tvc/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.1.0-alpha.1] - 2026-04-03
+## 0.6.2 - 2026-04-09
+
+### Other
+
+- Added `tvc` to `rust-sdk` release version group
+
+## 0.1.0-alpha.1 - 2026-04-03
 
 ### Added
 

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tvc"
-version = "0.1.0-alpha.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
-description = "Experimental CLI for Turnkey Verifiable Cloud"
+description = "CLI for Turnkey Verifiable Cloud"
 repository = "https://github.com/tkhq/rust-sdk"
 homepage = "https://turnkey.com"
 readme = "README.md"

--- a/tvc/README.md
+++ b/tvc/README.md
@@ -1,6 +1,6 @@
 # `tvc`
 
-Experimental CLI for [Turnkey Verifiable Cloud](https://turnkey.com) - see [this guide](https://docs.turnkey.com/getting-started/verifiable-cloud-quickstart) for example usage.
+CLI for [Turnkey Verifiable Cloud](https://turnkey.com) - see [this guide](https://docs.turnkey.com/getting-started/verifiable-cloud-quickstart) for example usage.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds tvc to the release-plz workflow. Note: it also adds tvc to the rust-sdk version_group, so we will be going from `0.1.0-alpha.1` to `0.6.2` in the next release.