### PR TITLE
fix: relax exact tokio version pin to semver-compatible range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ mime = { version = "0.3.17", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2"] }
 
 # Async runtime
-tokio = { version = "=1.47.1", default-features = false }
+tokio = { version = "1.47", default-features = false }
 
 # Protocol buffers
 prost = { version = "0.12", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ mime = { version = "0.3.17", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2"] }
 
 # Async runtime
-tokio = { version = "1.47", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
 
 # Protocol buffers
 prost = { version = "0.12", default-features = false, features = ["std"] }


### PR DESCRIPTION
## Summary

- Change `tokio = "=1.47.1"` to `tokio = "1.47"` in workspace `Cargo.toml`
- Fixes #122 — the exact pin prevents downstream crates from resolving tokio when any other dependency needs a different 1.x patch version

## Context

Library crates published to crates.io should use semver-compatible ranges (`"1.47"` = `^1.47` = `>=1.47.0, <2.0.0`) rather than exact pins (`"=1.47.1"`). The exact pin makes the crate unusable alongside any dependency that requires a different tokio 1.x version — for example, applications using Solana SDK or alloy which pull in newer tokio patches.

Reference: https://users.rust-lang.org/t/impact-of-pinning-dependencies/17634