### PR TITLE
chore: sync protos v2026.4.9

### DIFF
--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -3715,6 +3715,19 @@ impl<S: Stamp> TurnkeyClient<S> {
         self.process_request(&request, "/public/v1/query/get_tvc_deployment".to_string())
             .await
     }
+    /// Get TVC Deployment's Provisioning Details
+    ///
+    /// Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment
+    pub async fn get_tvc_deployment_provisioning_details(
+        &self,
+        request: coordinator::GetTvcDeploymentProvisioningDetailsRequest,
+    ) -> Result<coordinator::GetTvcDeploymentProvisioningDetailsResponse, TurnkeyClientError> {
+        self.process_request(
+            &request,
+            "/public/v1/query/get_tvc_deployment_provisioning_details".to_string(),
+        )
+        .await
+    }
     /// Create TVC Manifest Approvals
     ///
     /// Post one or more manifest approvals for a TVC Manifest
@@ -3794,5 +3807,97 @@ impl<S: Stamp> TurnkeyClient<S> {
             "/public/v1/query/list_supported_assets".to_string(),
         )
         .await
+    }
+    /// Set IP Allowlist
+    ///
+    /// Create or update IP allowlist and rules for organization or API key. The IP allowlist restricts API access to specific CIDR blocks. Organization-level allowlists apply to all API keys unless overridden by a key-specific allowlist.
+    pub async fn set_ip_allowlist(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::SetIpAllowlistIntent,
+    ) -> Result<ActivityResult<immutable_activity::SetIpAllowlistResult>, TurnkeyClientError> {
+        let request = external_activity::SetIpAllowlistRequest {
+            r#type: "ACTIVITY_TYPE_SET_IP_ALLOWLIST".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+            generate_app_proofs: self.generate_app_proofs(),
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/set_ip_allowlist".to_string())
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::SetIpAllowlistResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// Remove IP Allowlist
+    ///
+    /// Delete IP allowlist and all associated rules for organization or API key. After removal, access will be determined by organization-level allowlist (for API keys) or allowed from all IPs (for organizations).
+    pub async fn remove_ip_allowlist(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::RemoveIpAllowlistIntent,
+    ) -> Result<ActivityResult<immutable_activity::RemoveIpAllowlistResult>, TurnkeyClientError>
+    {
+        let request = external_activity::RemoveIpAllowlistRequest {
+            r#type: "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+            generate_app_proofs: self.generate_app_proofs(),
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/remove_ip_allowlist".to_string(),
+            )
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::RemoveIpAllowlistResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// Get IP Allowlist
+    ///
+    /// Get IP allowlist and rules for an organization.
+    pub async fn get_ip_allowlist(
+        &self,
+        request: coordinator::GetIpAllowlistRequest,
+    ) -> Result<coordinator::GetIpAllowlistResponse, TurnkeyClientError> {
+        self.process_request(&request, "/public/v1/query/get_ip_allowlist".to_string())
+            .await
     }
 }

--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -3822,7 +3822,6 @@ impl<S: Stamp> TurnkeyClient<S> {
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
-            generate_app_proofs: self.generate_app_proofs(),
         };
         let activity: external_activity::Activity = self
             .process_activity(&request, "/public/v1/submit/set_ip_allowlist".to_string())
@@ -3862,7 +3861,6 @@ impl<S: Stamp> TurnkeyClient<S> {
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
-            generate_app_proofs: self.generate_app_proofs(),
         };
         let activity: external_activity::Activity = self
             .process_activity(

--- a/client/src/generated/external.activity.v1.rs
+++ b/client/src/generated/external.activity.v1.rs
@@ -1473,3 +1473,29 @@ pub struct DeleteWebhookEndpointRequest {
     #[serde(default)]
     pub generate_app_proofs: ::core::option::Option<bool>,
 }
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SetIpAllowlistRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::SetIpAllowlistIntent,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct RemoveIpAllowlistRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::RemoveIpAllowlistIntent,
+    >,
+}

--- a/client/src/generated/external.data.v1.rs
+++ b/client/src/generated/external.data.v1.rs
@@ -530,6 +530,7 @@ pub struct TvcApp {
     pub updated_at: ::core::option::Option<Timestamp>,
     #[serde(default)]
     pub live_deployment_id: ::core::option::Option<::prost::alloc::string::String>,
+    pub public_domain: ::prost::alloc::string::String,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -142,6 +142,8 @@ pub mod intent {
         CreateWebhookEndpointIntent(super::CreateWebhookEndpointIntent),
         UpdateWebhookEndpointIntent(super::UpdateWebhookEndpointIntent),
         DeleteWebhookEndpointIntent(super::DeleteWebhookEndpointIntent),
+        SetIpAllowlistIntent(super::SetIpAllowlistIntent),
+        RemoveIpAllowlistIntent(super::RemoveIpAllowlistIntent),
     }
 }
 #[derive(Debug)]
@@ -2395,6 +2397,8 @@ pub mod result {
         CreateWebhookEndpointResult(super::CreateWebhookEndpointResult),
         UpdateWebhookEndpointResult(super::UpdateWebhookEndpointResult),
         DeleteWebhookEndpointResult(super::DeleteWebhookEndpointResult),
+        SetIpAllowlistResult(super::SetIpAllowlistResult),
+        RemoveIpAllowlistResult(super::RemoveIpAllowlistResult),
     }
 }
 #[derive(Debug)]
@@ -3583,6 +3587,53 @@ pub struct DeletePoliciesParams {
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
+pub struct IpAllowlistIntentRule {
+    /// @inject_tag: validate:"required,tk_cidr"
+    pub cidr: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub label: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SetIpAllowlistIntent {
+    /// NULL = org-level, non-NULL = API key level
+    #[serde(default)]
+    pub public_key: ::core::option::Option<::prost::alloc::string::String>,
+    /// Only meaningful for org-level allowlist; omit for API key-level allowlist.
+    #[serde(default)]
+    pub enabled: ::core::option::Option<bool>,
+    /// @inject_tag: validate:"dive,required"
+    #[serde(default)]
+    pub rules: ::prost::alloc::vec::Vec<IpAllowlistIntentRule>,
+    /// Behavior when an error occurs during IP allowlist evaluation. Valid values: "ALLOW", "DENY". Defaults to "DENY".
+    #[serde(default)]
+    pub on_evaluation_error: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct RemoveIpAllowlistIntent {
+    /// NULL = org-level, non-NULL = API key level
+    #[serde(default)]
+    pub public_key: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq)]
+pub struct SetIpAllowlistResult {}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq)]
+pub struct RemoveIpAllowlistResult {}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
 pub struct ClientSignature {
     pub public_key: ::prost::alloc::string::String,
     pub scheme: super::super::common::v1::ClientSignatureScheme,
@@ -3849,6 +3900,10 @@ pub enum ActivityType {
     UpdateWebhookEndpoint = 126,
     #[serde(rename = "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT")]
     DeleteWebhookEndpoint = 127,
+    #[serde(rename = "ACTIVITY_TYPE_SET_IP_ALLOWLIST")]
+    SetIpAllowlist = 128,
+    #[serde(rename = "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST")]
+    RemoveIpAllowlist = 129,
 }
 impl ActivityType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4001,6 +4056,8 @@ impl ActivityType {
             Self::CreateWebhookEndpoint => "ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT",
             Self::UpdateWebhookEndpoint => "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
             Self::DeleteWebhookEndpoint => "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT",
+            Self::SetIpAllowlist => "ACTIVITY_TYPE_SET_IP_ALLOWLIST",
+            Self::RemoveIpAllowlist => "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -4182,6 +4239,8 @@ impl ActivityType {
             "ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT" => Some(Self::CreateWebhookEndpoint),
             "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT" => Some(Self::UpdateWebhookEndpoint),
             "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT" => Some(Self::DeleteWebhookEndpoint),
+            "ACTIVITY_TYPE_SET_IP_ALLOWLIST" => Some(Self::SetIpAllowlist),
+            "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST" => Some(Self::RemoveIpAllowlist),
             _ => None,
         }
     }

--- a/client/src/generated/immutable.common.v1.rs
+++ b/client/src/generated/immutable.common.v1.rs
@@ -224,6 +224,11 @@ pub enum AddressFormat {
     TonV5r1 = 36,
     #[serde(rename = "ADDRESS_FORMAT_XRP")]
     Xrp = 35,
+    /// Spark (Bitcoin L2) address types
+    #[serde(rename = "ADDRESS_FORMAT_SPARK_MAINNET")]
+    SparkMainnet = 37,
+    #[serde(rename = "ADDRESS_FORMAT_SPARK_REGTEST")]
+    SparkRegtest = 38,
 }
 impl AddressFormat {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -269,6 +274,8 @@ impl AddressFormat {
             Self::TonV4r2 => "ADDRESS_FORMAT_TON_V4R2",
             Self::TonV5r1 => "ADDRESS_FORMAT_TON_V5R1",
             Self::Xrp => "ADDRESS_FORMAT_XRP",
+            Self::SparkMainnet => "ADDRESS_FORMAT_SPARK_MAINNET",
+            Self::SparkRegtest => "ADDRESS_FORMAT_SPARK_REGTEST",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -311,6 +318,8 @@ impl AddressFormat {
             "ADDRESS_FORMAT_TON_V4R2" => Some(Self::TonV4r2),
             "ADDRESS_FORMAT_TON_V5R1" => Some(Self::TonV5r1),
             "ADDRESS_FORMAT_XRP" => Some(Self::Xrp),
+            "ADDRESS_FORMAT_SPARK_MAINNET" => Some(Self::SparkMainnet),
+            "ADDRESS_FORMAT_SPARK_REGTEST" => Some(Self::SparkRegtest),
             _ => None,
         }
     }

--- a/client/src/generated/services.coordinator.public.v1.rs
+++ b/client/src/generated/services.coordinator.public.v1.rs
@@ -958,6 +958,24 @@ pub struct ValidateTvcImageResponse {
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
+pub struct GetTvcDeploymentProvisioningDetailsRequest {
+    pub organization_id: ::prost::alloc::string::String,
+    pub deployment_id: ::prost::alloc::string::String,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct GetTvcDeploymentProvisioningDetailsResponse {
+    #[serde(default)]
+    pub attestation_document: ::prost::alloc::vec::Vec<u8>,
+    #[serde(default)]
+    pub manifest_envelope: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
 pub struct GetAppStatusRequest {
     pub organization_id: ::prost::alloc::string::String,
     pub app_id: ::prost::alloc::string::String,
@@ -1048,4 +1066,47 @@ pub struct AssetMetadata {
     pub decimals: i32,
     pub logo_url: ::prost::alloc::string::String,
     pub name: ::prost::alloc::string::String,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct GetIpAllowlistRequest {
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub public_key: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct IpAllowlistRule {
+    pub cidr: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub label: ::core::option::Option<::prost::alloc::string::String>,
+    pub created_at: ::prost::alloc::string::String,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct IpAllowlist {
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub rules: ::prost::alloc::vec::Vec<IpAllowlistRule>,
+    #[serde(default)]
+    pub public_key: ::core::option::Option<::prost::alloc::string::String>,
+    #[serde(default)]
+    pub enabled: ::core::option::Option<bool>,
+    /// @inject_tag: validate:"omitempty,oneof=ALLOW DENY"
+    #[serde(default)]
+    pub on_evaluation_error: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct GetIpAllowlistResponse {
+    #[serde(default)]
+    pub allowlist: ::core::option::Option<IpAllowlist>,
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -51,7 +51,6 @@ fn main() {
         .unwrap();
 
     let proto = fs::read_to_string(PUBLIC_API_PROTO_PATH).expect("Failed to read proto file");
-
     // Capture the start of "service... {" until a single "}" is encountered on its own line without indentation.
     // That's just a simple alternative to writing a nesting-aware parser...
     // We're trying to match on blocks like this one:
@@ -338,7 +337,11 @@ fn to_snake_case(name: &str) -> String {
     result
 }
 fn build_generate_app_proofs_field(req_type: &str, is_tvc: bool) -> String {
-    if is_tvc || req_type == "UpdateOrganizationNameRequest" {
+    if is_tvc
+        || req_type == "UpdateOrganizationNameRequest"
+        || req_type == "SetIpAllowlistRequest"
+        || req_type == "RemoveIpAllowlistRequest"
+    {
         String::new()
     } else {
         "generate_app_proofs: self.generate_app_proofs(),".to_string()
@@ -355,6 +358,14 @@ mod tests {
             .contains("generate_app_proofs"));
         assert_eq!(
             build_generate_app_proofs_field("UpdateOrganizationNameRequest", false),
+            ""
+        );
+        assert_eq!(
+            build_generate_app_proofs_field("SetIpAllowlistRequest", false),
+            ""
+        );
+        assert_eq!(
+            build_generate_app_proofs_field("RemoveIpAllowlistRequest", false),
             ""
         );
         assert_eq!(

--- a/proto/activities.json
+++ b/proto/activities.json
@@ -414,6 +414,16 @@
       "type": "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT",
       "intentType": "DeleteWebhookEndpointIntent",
       "resultType": "DeleteWebhookEndpointResult"
+    },
+    "/public/v1/submit/set_ip_allowlist": {
+      "type": "ACTIVITY_TYPE_SET_IP_ALLOWLIST",
+      "intentType": "SetIpAllowlistIntent",
+      "resultType": "SetIpAllowlistResult"
+    },
+    "/public/v1/submit/remove_ip_allowlist": {
+      "type": "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST",
+      "intentType": "RemoveIpAllowlistIntent",
+      "resultType": "RemoveIpAllowlistResult"
     }
   }
 }

--- a/proto/external/activity/v1/activity.proto
+++ b/proto/external/activity/v1/activity.proto
@@ -1919,3 +1919,39 @@ message DeleteWebhookEndpointRequest {
   immutable.activity.v1.DeleteWebhookEndpointIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
   optional bool generate_app_proofs = 5 [(google.api.field_behavior) = OPTIONAL];
 }
+
+message SetIpAllowlistRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_SET_IP_ALLOWLIST"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.SetIpAllowlistIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message RemoveIpAllowlistRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.RemoveIpAllowlistIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}

--- a/proto/external/data/v1/tvc.proto
+++ b/proto/external/data/v1/tvc.proto
@@ -41,6 +41,10 @@ message TvcApp {
   Timestamp created_at = 8 [(google.api.field_behavior) = REQUIRED];
   Timestamp updated_at = 9 [(google.api.field_behavior) = REQUIRED];
   optional string live_deployment_id = 10 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The deployment currently designated to receive traffic. Null if no deployment for this app is deployed."}];
+  string public_domain = 11 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The public domain for ingress to this TVC App (in the format \"app-<ID>.turnkey.cloud\")."}
+  ];
 }
 
 message TvcDeployment {

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -152,6 +152,8 @@ enum ActivityType {
   ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT = 125;
   ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT = 126;
   ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT = 127;
+  ACTIVITY_TYPE_SET_IP_ALLOWLIST = 128;
+  ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST = 129;
 }
 
 // The current processing status of an Activity.
@@ -309,6 +311,8 @@ message Intent {
     CreateWebhookEndpointIntent create_webhook_endpoint_intent = 126;
     UpdateWebhookEndpointIntent update_webhook_endpoint_intent = 127;
     DeleteWebhookEndpointIntent delete_webhook_endpoint_intent = 128;
+    SetIpAllowlistIntent set_ip_allowlist_intent = 129;
+    RemoveIpAllowlistIntent remove_ip_allowlist_intent = 130;
   }
 }
 
@@ -4394,6 +4398,8 @@ message Result {
     CreateWebhookEndpointResult create_webhook_endpoint_result = 105;
     UpdateWebhookEndpointResult update_webhook_endpoint_result = 106;
     DeleteWebhookEndpointResult delete_webhook_endpoint_result = 107;
+    SetIpAllowlistResult set_ip_allowlist_result = 108;
+    RemoveIpAllowlistResult remove_ip_allowlist_result = 109;
   }
 }
 
@@ -5338,7 +5344,7 @@ message WebhookSubscriptionParams {
   // @inject_tag: validate:"required"
   string event_type = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The event type to subscribe to (for example, ACTIVITY_UPDATES or BALANCE_UPDATES)."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The event type to subscribe to (for example, ACTIVITY_UPDATES or BALANCE_CONFIRMED_UPDATES)."}
   ];
   // @inject_tag: validate:"omitempty"
   optional string filters_json = 2 [
@@ -5931,6 +5937,74 @@ message DeletePoliciesParams {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "List of unique identifiers for policies within an organization"}
   ];
 }
+
+message IpAllowlistIntentRule {
+  // @inject_tag: validate:"required,tk_cidr"
+  string cidr = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "CIDR block (e.g., '192.168.1.0/24', '2001:db8::/32')."
+      title: ""
+    }
+  ];
+  optional string label = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Optional human-readable label for this rule (e.g., 'Office VPN')."
+      title: ""
+    }
+  ];
+}
+
+message SetIpAllowlistIntent {
+  // NULL = org-level, non-NULL = API key level
+  optional string public_key = 1 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "The public component of an API key. If null, the IP allowlist applies at the organization level. If set, it applies only to this specific API key."
+      title: ""
+    }
+  ];
+  // Only meaningful for org-level allowlist; omit for API key-level allowlist.
+  optional bool enabled = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Whether the IP allowlist is enabled. Only meaningful for organization-level allowlists. Omit for API key-level allowlists."
+      title: ""
+    }
+  ];
+  // @inject_tag: validate:"dive,required"
+  repeated IpAllowlistIntentRule rules = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "List of IP allowlist rules with CIDR blocks and optional labels."
+      title: ""
+    }
+  ];
+  // Behavior when an error occurs during IP allowlist evaluation. Valid values: "ALLOW", "DENY". Defaults to "DENY".
+  optional string on_evaluation_error = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Behavior when an error occurs during IP allowlist evaluation. Valid values: ALLOW, DENY. Defaults to DENY."
+      title: ""
+    }
+  ];
+}
+
+message RemoveIpAllowlistIntent {
+  // NULL = org-level, non-NULL = API key level
+  optional string public_key = 1 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "The public component of an API key. If null, removes the organization-level IP allowlist. If set, removes the IP allowlist for this specific API key."
+      title: ""
+    }
+  ];
+}
+
+message SetIpAllowlistResult {}
+
+message RemoveIpAllowlistResult {}
 
 message ClientSignature {
   string public_key = 1 [

--- a/proto/immutable/common/v1/common.proto
+++ b/proto/immutable/common/v1/common.proto
@@ -97,6 +97,10 @@ enum AddressFormat {
   ADDRESS_FORMAT_TON_V5R1 = 36;
 
   ADDRESS_FORMAT_XRP = 35;
+
+  // Spark (Bitcoin L2) address types
+  ADDRESS_FORMAT_SPARK_MAINNET = 37;
+  ADDRESS_FORMAT_SPARK_REGTEST = 38;
 }
 
 enum HashFunction {

--- a/proto/services/coordinator/public/v1/public_api.proto
+++ b/proto/services/coordinator/public/v1/public_api.proto
@@ -145,6 +145,13 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
         "Policies can enforce consensus requirements for Activities. For example, adding a new user requires two admins to approve the request."
         "\n\n"
         "Activities that have been proposed, but don't yet meet the Consensus requirements will have the status: `REQUIRES_CONSENSUS`. Activities in this state can be approved or rejected using the unique fingerprint generated when an Activity is created."
+    },
+    {
+      name: "IP Allowlist"
+      description:
+        "IP Allowlists restrict API access to specific CIDR blocks. They can be configured at the organization level (applying to all API keys) or at the individual API key level (overriding organization-level allowlists)."
+        "\n\n"
+        "When no IP allowlist is configured, all IP addresses are allowed. Organization-level allowlists can be enabled or disabled, while API key-level allowlists are always enforced when present."
     }
   ]
 
@@ -167,7 +174,8 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
                       {string_value: "Organizations"},
                       {string_value: "Invitations"},
                       {string_value: "Policies"},
-                      {string_value: "Features"}]
+                      {string_value: "Features"},
+                      {string_value: "IP Allowlist"}]
                   }
                 }
               }
@@ -1700,8 +1708,6 @@ service PublicApiService {
   }
 
   rpc CreateTvcApp(external.activity.v1.CreateTvcAppRequest) returns (ActivityResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/submit/create_tvc_app"
       body: "*"
@@ -1714,8 +1720,6 @@ service PublicApiService {
   }
 
   rpc GetTvcApps(GetTvcAppsRequest) returns (GetTvcAppsResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/query/list_tvc_apps"
       body: "*"
@@ -1728,8 +1732,6 @@ service PublicApiService {
   }
 
   rpc GetTvcApp(GetTvcAppRequest) returns (GetTvcAppResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/query/get_tvc_app"
       body: "*"
@@ -1742,8 +1744,6 @@ service PublicApiService {
   }
 
   rpc CreateTvcDeployment(external.activity.v1.CreateTvcDeploymentRequest) returns (ActivityResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/submit/create_tvc_deployment"
       body: "*"
@@ -1756,8 +1756,6 @@ service PublicApiService {
   }
 
   rpc ValidateTvcImage(ValidateTvcImageRequest) returns (ValidateTvcImageResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/query/validate_tvc_image"
       body: "*"
@@ -1770,8 +1768,6 @@ service PublicApiService {
   }
 
   rpc GetTvcAppDeployments(GetTvcAppDeploymentsRequest) returns (GetTvcAppDeploymentsResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/query/list_tvc_app_deployments"
       body: "*"
@@ -1784,8 +1780,6 @@ service PublicApiService {
   }
 
   rpc GetTvcDeployment(GetTvcDeploymentRequest) returns (GetTvcDeploymentResponse) {
-    // TODO: remove me when it's time to unleash TVC
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/query/get_tvc_deployment"
       body: "*"
@@ -1797,9 +1791,21 @@ service PublicApiService {
     };
   }
 
-  rpc CreateTvcManifestApprovals(external.activity.v1.CreateTvcManifestApprovalsRequest) returns (ActivityResponse) {
-    // TODO: remove me when it's time to unleash TVC
+  rpc GetTvcDeploymentProvisioningDetails(GetTvcDeploymentProvisioningDetailsRequest) returns (GetTvcDeploymentProvisioningDetailsResponse) {
+    // TODO(tvc): remove when provisioning flow is fully usable
     option (google.api.method_visibility).restriction = "INTERNAL";
+    option (google.api.http) = {
+      post: "/public/v1/query/get_tvc_deployment_provisioning_details"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Get the attestation document and manifest envelope of the provisioning enclave for a TVC deployment"
+      summary: "Get TVC Deployment's Provisioning Details"
+      tags: "TVC"
+    };
+  }
+
+  rpc CreateTvcManifestApprovals(external.activity.v1.CreateTvcManifestApprovalsRequest) returns (ActivityResponse) {
     option (google.api.http) = {
       post: "/public/v1/submit/create_tvc_manifest_approvals"
       body: "*"
@@ -1844,6 +1850,42 @@ service PublicApiService {
       description: "List supported assets for the specified network. This feature is in beta - please contact support for access."
       summary: "List supported assets"
       tags: "Wallets"
+    };
+  }
+
+  rpc SetIpAllowlist(external.activity.v1.SetIpAllowlistRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/set_ip_allowlist"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Create or update IP allowlist and rules for organization or API key. The IP allowlist restricts API access to specific CIDR blocks. Organization-level allowlists apply to all API keys unless overridden by a key-specific allowlist."
+      summary: "Set IP Allowlist"
+      tags: "IP Allowlist"
+    };
+  }
+
+  rpc RemoveIpAllowlist(external.activity.v1.RemoveIpAllowlistRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/remove_ip_allowlist"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Delete IP allowlist and all associated rules for organization or API key. After removal, access will be determined by organization-level allowlist (for API keys) or allowed from all IPs (for organizations)."
+      summary: "Remove IP Allowlist"
+      tags: "IP Allowlist"
+    };
+  }
+
+  rpc GetIpAllowlist(GetIpAllowlistRequest) returns (GetIpAllowlistResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/query/get_ip_allowlist"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Get IP allowlist and rules for an organization."
+      summary: "Get IP Allowlist"
+      tags: "IP Allowlist"
     };
   }
 
@@ -2716,6 +2758,28 @@ message ValidateTvcImageResponse {
   string resolved_image_digest = 1 [(google.api.field_behavior) = OPTIONAL];
 }
 
+message GetTvcDeploymentProvisioningDetailsRequest {
+  string organization_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  string deployment_id = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given TVC Deployment."}
+  ];
+}
+
+message GetTvcDeploymentProvisioningDetailsResponse {
+  bytes attestation_document = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The attestation document of the provisioning enclave in a TVC deployment."}
+  ];
+  bytes manifest_envelope = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The manifest envelope containing the TVC deployment's manifest and signatures."}
+  ];
+}
+
 message GetAppStatusRequest {
   string organization_id = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -2816,4 +2880,43 @@ message AssetMetadata {
   int32 decimals = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The number of decimals this asset uses"}];
   string logo_url = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The url of the asset logo"}];
   string name = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The asset name"}];
+}
+
+message GetIpAllowlistRequest {
+  string organization_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given organization."}
+  ];
+  optional string public_key = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "If provided, return only the allowlist for this specific API key."}
+  ];
+}
+
+message IpAllowlistRule {
+  string cidr = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "CIDR block (e.g., '192.168.1.0/24')."}
+  ];
+  optional string label = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional human-readable label for this rule."}];
+  string created_at = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Creation timestamp as millisecond epoch string."}];
+}
+
+message IpAllowlist {
+  string organization_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for the organization this allowlist belongs to."}
+  ];
+  repeated IpAllowlistRule rules = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "List of IP allowlist rules with their metadata."}
+  ];
+  optional string public_key = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Public key of the API key this allowlist applies to. Null means the allowlist applies to the entire organization."}];
+  optional bool enabled = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Whether the IP allowlist is enabled. Only present for organization-level allowlists. Null for API key-level allowlists (presence of the allowlist implies enablement)."}];
+  // @inject_tag: validate:"omitempty,oneof=ALLOW DENY"
+  optional string on_evaluation_error = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Behavior when an error occurs during IP allowlist evaluation. Valid values: ALLOW, DENY. Defaults to DENY."}];
+}
+
+message GetIpAllowlistResponse {
+  IpAllowlist allowlist = 1 [(google.api.field_behavior) = REQUIRED];
 }


### PR DESCRIPTION
This sync adds the new endpoints to
- get tvc provisioning details
- set ip allowlist

And makes tvc endpoints public