### PR TITLE
workspace: relax tokio version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ mime = { version = "0.3.17", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2"] }
 
 # Async runtime
-tokio = { version = "=1.47.1", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
 
 # Protocol buffers
 prost = { version = "0.12", default-features = false, features = ["std"] }


### PR DESCRIPTION
Seeing a CI build issue in public contribution https://github.com/tkhq/rust-sdk/pull/123 - do to some CI constraints on public contributions, using this PR