### PR TITLE
feat(tvc): add re-encrypt-share command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3956,6 +3956,7 @@ dependencies = [
  "turnkey_api_key_stamper",
  "turnkey_client",
  "turnkey_enclave_encrypt",
+ "zeroize",
 ]
 
 [[package]]

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -29,6 +29,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -33,6 +33,7 @@ impl Cli {
                 AppCommands::Create(args) => commands::app::create::run(args).await,
                 AppCommands::Init(args) => commands::app::init::run(args).await,
             },
+            Commands::ReEncryptShare(args) => commands::re_encrypt_share::run(args).await,
             Commands::Login(args) => commands::login::run(args).await,
         }
     }
@@ -52,6 +53,8 @@ enum Commands {
         #[command(subcommand)]
         command: AppCommands,
     },
+    /// Re-encrypt a share for enclave provisioning.
+    ReEncryptShare(commands::re_encrypt_share::Args),
 }
 
 #[derive(Debug, Subcommand)]

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -1,8 +1,8 @@
 //! Approve deploy command - cryptographically approve a QOS manifest.
 
 use crate::config::app::KNOWN_SHARE_SET_KEYS;
-use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::pair::LocalPair;
+use crate::config::turnkey::Config;
+use crate::operator_key::load_operator_pair;
 use crate::util::{read_file_to_string, write_file};
 use anyhow::{anyhow, bail, Context};
 use clap::{ArgGroup, Args as ClapArgs};
@@ -95,28 +95,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Get operator key - from --operator-seed or from logged-in config
-    let pair: Box<dyn crate::pair::Pair> = match &args.operator_seed {
-        Some(path) => Box::new(LocalPair::from_master_seed(path).await?),
-        None => {
-            // Default to operator key from logged-in org config
-            let tvc_config = Config::load().await?;
-            let (alias, org_config) = tvc_config.active_org_config().ok_or_else(|| {
-                anyhow!("No active organization. Run `tvc login` first or provide --operator-seed.")
-            })?;
-
-            let operator_key = StoredQosOperatorKey::load(org_config)
-                .await?
-                .ok_or_else(|| {
-                    anyhow!(
-                        "No operator key found for org '{alias}'. \
-                     Run `tvc login` first or provide --operator-seed."
-                    )
-                })?;
-
-            Box::new(LocalPair::from_hex_seed(&operator_key.private_key)?)
-        }
-    };
+    let pair: Box<dyn crate::pair::Pair> =
+        Box::new(load_operator_pair(args.operator_seed.as_deref()).await?);
 
     let approval = generate_approval(pair, &manifest).await?;
     let json = serde_json::to_string_pretty(&approval)?;

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -1,14 +1,13 @@
 //! Deploy provisioning-details command.
 
+use crate::provisioning::{
+    extract_ephemeral_public_key_bytes, verify_provisioning_details, ProvisionBundle,
+};
 use crate::util::write_file;
-use anyhow::{anyhow, bail, Context};
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use anyhow::{bail, Context};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, ManifestEnvelope};
-use qos_core::protocol::QosHash;
 use qos_nsm::types::NsmDigest;
-use qos_p256::P256Public;
-use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{
@@ -30,15 +29,6 @@ pub struct Args {
     /// Write provisioning details to a local json bundle usable during re-encryption.
     #[arg(long, value_name = "PATH")]
     pub provision_bundle_out: Option<PathBuf>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct ProvisionBundle {
-    attestation_document_cose_sign1_base64: String,
-    manifest_envelope: ManifestEnvelope,
-    fetched_at_unix_ms: u64,
-    deployment_id: String,
-    ephemeral_public_key_hex: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,7 +98,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     )?;
 
     if let Some(path) = args.provision_bundle_out.as_ref() {
-        let bundle = build_provision_bundle(
+        let bundle = ProvisionBundle::new(
             args.deploy_id.clone(),
             &attestation_document,
             manifest_envelope.clone(),
@@ -129,57 +119,11 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_provision_bundle(
-    deployment_id: String,
-    attestation_document: &[u8],
-    manifest_envelope: ManifestEnvelope,
-    fetched_at_unix_ms: u64,
-    ephemeral_public_key: &[u8],
-) -> ProvisionBundle {
-    ProvisionBundle {
-        attestation_document_cose_sign1_base64: BASE64_STANDARD.encode(attestation_document),
-        manifest_envelope,
-        fetched_at_unix_ms,
-        deployment_id,
-        ephemeral_public_key_hex: hex::encode(ephemeral_public_key),
-    }
-}
-
 async fn write_provision_bundle(path: &Path, bundle: &ProvisionBundle) -> anyhow::Result<()> {
     let contents =
         serde_json::to_vec_pretty(bundle).context("failed to serialize provision bundle")?;
     write_file(path, &contents).await?;
     println!("Provision bundle written to: {}", path.display());
-    Ok(())
-}
-
-fn verify_provisioning_details(
-    cose_sign1_der: &[u8],
-    manifest_envelope: &ManifestEnvelope,
-    validation_time_override: Option<u64>,
-) -> anyhow::Result<()> {
-    manifest_envelope
-        .check_approvals()
-        .context("failed to verify manifest approvals")?;
-
-    let attestation_doc = qos_nsm::nitro::attestation_doc_from_der(
-        cose_sign1_der,
-        &qos_nsm::nitro::cert_from_pem(qos_nsm::nitro::AWS_ROOT_CERT_PEM)
-            .context("failed to parse AWS Nitro root certificate")?,
-        validation_time_secs(validation_time_override)?,
-    )
-    .context("failed to parse and verify attestation document")?;
-
-    qos_nsm::nitro::verify_attestation_doc_against_user_input(
-        &attestation_doc,
-        &manifest_envelope.manifest.qos_hash(),
-        &manifest_envelope.manifest.enclave.pcr0,
-        &manifest_envelope.manifest.enclave.pcr1,
-        &manifest_envelope.manifest.enclave.pcr2,
-        &manifest_envelope.manifest.enclave.pcr3,
-    )
-    .context("attestation document did not match manifest expectations")?;
-
     Ok(())
 }
 
@@ -197,7 +141,7 @@ fn build_summary_with_optional_verify(
         .context("failed to parse attestation document")?;
 
     Ok(AttestationSummary {
-        ephemeral_key: extract_ephemeral_key(
+        ephemeral_key: extract_ephemeral_public_key_bytes(
             attestation_doc
                 .public_key
                 .as_ref()
@@ -232,25 +176,6 @@ fn approval_summaries(approvals: &[Approval]) -> Vec<ApprovalSummary> {
             public_key: approval.member.pub_key.clone(),
         })
         .collect()
-}
-
-fn validation_time_secs(validation_time_override: Option<u64>) -> anyhow::Result<u64> {
-    match validation_time_override {
-        Some(time) => Ok(time),
-        None => Ok(SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .context("system time before unix epoch")?
-            .as_secs()),
-    }
-}
-
-fn extract_ephemeral_key(public_key: Option<&[u8]>) -> anyhow::Result<Vec<u8>> {
-    let public_key =
-        public_key.ok_or_else(|| anyhow!("attestation document missing ephemeral public key"))?;
-
-    P256Public::from_bytes(public_key)
-        .map(|ephemeral_key| ephemeral_key.to_bytes())
-        .map_err(|err| anyhow!("invalid ephemeral public key: {err:?}"))
 }
 
 fn print_summary(deploy_id: &str, verification_status: &str, summary: &AttestationSummary) {
@@ -308,11 +233,10 @@ fn print_approval_summary_entries(approvals: &[ApprovalSummary]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_provision_bundle, extract_ephemeral_key, verify_provisioning_details};
+    use super::build_summary_with_optional_verify;
     use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
     use qos_core::protocol::services::boot::ManifestEnvelope;
     use serde::Deserialize;
-    use serde_json::json;
 
     #[derive(Debug, Deserialize)]
     struct ValidProvisioningDetailsFixture {
@@ -328,116 +252,34 @@ mod tests {
         .unwrap()
     }
 
-    fn sample_manifest_envelope() -> ManifestEnvelope {
-        serde_json::from_value(json!({
-            "manifest": {
-                "namespace": {
-                    "name": "test-namespace",
-                    "nonce": 7,
-                    "quorumKey": "0102"
-                },
-                "pivot": {
-                    "hash": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "restart": "Never",
-                    "bridgeConfig": [],
-                    "debugMode": false,
-                    "args": ["--serve"]
-                },
-                "manifestSet": {
-                    "threshold": 1,
-                    "members": [{
-                        "alias": "member-1",
-                        "pubKey": "aabbcc"
-                    }]
-                },
-                "shareSet": {
-                    "threshold": 0,
-                    "members": []
-                },
-                "enclave": {
-                    "pcr0": "00",
-                    "pcr1": "11",
-                    "pcr2": "22",
-                    "pcr3": "33",
-                    "awsRootCertificate": "44",
-                    "qosCommit": "test-commit"
-                },
-                "patchSet": {
-                    "threshold": 0,
-                    "members": []
-                }
-            },
-            "manifestSetApprovals": [{
-                "signature": "beef",
-                "member": {
-                    "alias": "member-1",
-                    "pubKey": "aabbcc"
-                }
-            }],
-            "shareSetApprovals": []
-        }))
-        .unwrap()
-    }
-
     #[test]
-    fn extract_ephemeral_key_requires_key() {
-        let err = extract_ephemeral_key(None).unwrap_err();
-
-        assert!(err
-            .to_string()
-            .contains("attestation document missing ephemeral public key"));
-    }
-
-    #[test]
-    fn extract_ephemeral_key_rejects_malformed_key() {
-        let err = extract_ephemeral_key(Some(&[1, 2, 3])).unwrap_err();
-
-        assert!(err.to_string().contains("invalid ephemeral public key"));
-    }
-
-    #[test]
-    fn provision_bundle_serializes_expected_fields() {
-        let manifest_envelope = sample_manifest_envelope();
-        let bundle = build_provision_bundle(
-            "deploy-123".to_string(),
-            &[1, 2, 3, 4],
-            manifest_envelope.clone(),
-            1_712_345_678_901,
-            &[0x04, 0xab, 0xcd],
-        );
-
-        let value = serde_json::to_value(&bundle).unwrap();
-
-        assert_eq!(
-            value["attestation_document_cose_sign1_base64"],
-            json!(BASE64_STANDARD.encode([1, 2, 3, 4])),
-        );
-        assert_eq!(value["fetched_at_unix_ms"], json!(1_712_345_678_901_u64));
-        assert_eq!(value["deployment_id"], json!("deploy-123"));
-        assert_eq!(value["ephemeral_public_key_hex"], json!("04abcd"));
-        assert_eq!(
-            value["manifest_envelope"],
-            serde_json::to_value(&manifest_envelope).unwrap()
-        );
-    }
-
-    #[test]
-    fn verify_provisioning_details_accepts_real_fixture() {
+    fn build_summary_accepts_real_fixture() {
         let fixture = valid_provisioning_details_fixture();
         let attestation_document = BASE64_STANDARD
             .decode(&fixture.attestation_document_cose_sign1_base64)
             .unwrap();
 
-        verify_provisioning_details(
+        let summary = build_summary_with_optional_verify(
             &attestation_document,
             &fixture.manifest_envelope,
+            false,
             Some(fixture.validation_time_secs),
         )
         .unwrap();
+
+        assert!(!summary.ephemeral_key.is_empty());
+        assert_eq!(
+            summary.manifest_set_threshold,
+            fixture.manifest_envelope.manifest.manifest_set.threshold
+        );
+        assert_eq!(
+            summary.manifest_set_approvals.len(),
+            fixture.manifest_envelope.manifest_set_approvals.len()
+        );
     }
 
     #[test]
-    fn verify_provisioning_details_rejects_real_fixture_with_missing_manifest_approval() {
+    fn build_summary_rejects_real_fixture_with_missing_manifest_approval() {
         let fixture = valid_provisioning_details_fixture();
         let attestation_document = BASE64_STANDARD
             .decode(&fixture.attestation_document_cose_sign1_base64)
@@ -445,9 +287,10 @@ mod tests {
         let mut manifest_envelope = fixture.manifest_envelope;
         manifest_envelope.manifest_set_approvals.clear();
 
-        assert!(verify_provisioning_details(
+        assert!(build_summary_with_optional_verify(
             &attestation_document,
             &manifest_envelope,
+            false,
             Some(fixture.validation_time_secs),
         )
         .is_err());

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod app;
 pub mod app_status;
 pub mod deploy;
 pub mod login;
+pub mod re_encrypt_share;

--- a/tvc/src/commands/re_encrypt_share.rs
+++ b/tvc/src/commands/re_encrypt_share.rs
@@ -1,0 +1,329 @@
+//! Re-encrypt share command.
+
+use crate::operator_key::load_operator_pair;
+use crate::pair::Pair;
+use crate::provisioning::ProvisionBundle;
+use crate::util::write_file;
+use anyhow::{anyhow, Context};
+use clap::Args as ClapArgs;
+use qos_core::protocol::services::boot::{Approval, ManifestEnvelope, QuorumMember};
+use qos_core::protocol::QosHash;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
+
+/// Re-encrypt a share with an ephemeral key.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Path to the share file to re-encrypt.
+    /// Assumed to be encrypted by the operator key.
+    #[arg(long, env = "SHARE_PATH")]
+    pub share_path: PathBuf,
+
+    /// Provision bundle from a deployment.
+    /// This should match the output format of `tvc deploy provisioning-details`.
+    #[arg(long, env = "PROVISION_BUNDLE")]
+    pub provision_bundle: PathBuf,
+
+    /// Path to the file containing the master seed for the operator key.
+    /// If not provided, uses the operator key from the logged-in org config.
+    #[arg(
+        long,
+        help_heading = "Operator encryption key",
+        value_name = "OPERATOR_PATH"
+    )]
+    pub operator_seed: Option<PathBuf>,
+
+    /// Never use for sensitive applications! Skip attestation and manifest approval verification.
+    #[arg(long)]
+    pub dangerous_skip_verification: bool,
+
+    /// Output path for the re-encrypted share.
+    #[arg(long, env = "OUTPUT_PATH")]
+    pub re_encrypted_out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ReEncryptedShareOutput {
+    re_encrypted_share: String,
+    share_approval: Approval,
+}
+
+/// Run the re-encrypt-share command.
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    if args.dangerous_skip_verification {
+        eprintln!(
+            "WARNING: Skipping verification! This is dangerous and should not be used for sensitive applications."
+        );
+    }
+
+    let provision_bundle = read_provision_bundle(&args.provision_bundle).await?;
+    let encrypted_share = tokio::fs::read(&args.share_path)
+        .await
+        .with_context(|| format!("failed to read share file: {}", args.share_path.display()))?;
+    let operator_pair = load_operator_pair(args.operator_seed.as_deref()).await?;
+
+    let output = build_re_encrypted_share_output(
+        &encrypted_share,
+        &provision_bundle,
+        &operator_pair,
+        args.dangerous_skip_verification,
+    )
+    .await?;
+
+    write_output(args.re_encrypted_out.as_deref(), &output).await
+}
+
+async fn read_provision_bundle(path: &Path) -> anyhow::Result<ProvisionBundle> {
+    let contents = tokio::fs::read(path)
+        .await
+        .with_context(|| format!("failed to read provision bundle: {}", path.display()))?;
+    serde_json::from_slice(&contents)
+        .with_context(|| format!("failed to parse provision bundle: {}", path.display()))
+}
+
+async fn build_re_encrypted_share_output(
+    encrypted_share: &[u8],
+    provision_bundle: &ProvisionBundle,
+    operator_pair: &dyn Pair,
+    dangerous_skip_verification: bool,
+) -> anyhow::Result<ReEncryptedShareOutput> {
+    let ephemeral_public_key =
+        provision_bundle.ephemeral_public_key(dangerous_skip_verification)?;
+    let member = find_share_set_member(
+        provision_bundle.manifest_envelope(),
+        &operator_pair.public_key(),
+    )?;
+
+    let re_encrypted_share = {
+        let plaintext_share = Zeroizing::new(
+            operator_pair
+                .decrypt(encrypted_share.to_vec())
+                .await
+                .context("failed to decrypt share with operator key")?,
+        );
+
+        ephemeral_public_key
+            .encrypt(plaintext_share.as_slice())
+            .map_err(|err| anyhow!("failed to encrypt share to ephemeral key: {err:?}"))?
+    };
+
+    let signature = operator_pair
+        .sign(
+            provision_bundle
+                .manifest_envelope()
+                .manifest
+                .qos_hash()
+                .to_vec(),
+        )
+        .await
+        .context("failed to sign share approval with operator key")?;
+    let share_approval = Approval { signature, member };
+
+    Ok(ReEncryptedShareOutput {
+        re_encrypted_share: hex::encode(re_encrypted_share),
+        share_approval,
+    })
+}
+
+fn find_share_set_member(
+    manifest_envelope: &ManifestEnvelope,
+    operator_public_key: &[u8],
+) -> anyhow::Result<QuorumMember> {
+    manifest_envelope
+        .manifest
+        .share_set
+        .members
+        .iter()
+        .find(|member| member.pub_key == operator_public_key)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!(
+                "operator ({}) not part of share set",
+                hex::encode(operator_public_key)
+            )
+        })
+}
+
+async fn write_output(path: Option<&Path>, output: &ReEncryptedShareOutput) -> anyhow::Result<()> {
+    let contents =
+        serde_json::to_string_pretty(output).context("failed to serialize re-encrypted share")?;
+
+    if let Some(path) = path {
+        write_file(path, &contents).await?;
+        eprintln!("Re-encrypted share written to: {}", path.display());
+    } else {
+        println!("{contents}");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_re_encrypted_share_output, find_share_set_member, ReEncryptedShareOutput};
+    use crate::pair::LocalPair;
+    use crate::provisioning::ProvisionBundle;
+    use qos_core::protocol::services::boot::{
+        Approval, Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig, PatchSet,
+        PivotConfig, QuorumMember, RestartPolicy, ShareSet,
+    };
+    use qos_core::protocol::QosHash;
+    use qos_p256::{P256Pair, P256Public};
+    use serde_json::json;
+
+    fn sample_manifest_envelope(share_set_members: Vec<QuorumMember>) -> ManifestEnvelope {
+        ManifestEnvelope {
+            manifest: Manifest {
+                namespace: Namespace {
+                    name: "test-namespace".to_string(),
+                    nonce: 7,
+                    quorum_key: P256Pair::generate().unwrap().public_key().to_bytes(),
+                },
+                pivot: PivotConfig {
+                    hash: [0; 32],
+                    restart: RestartPolicy::Never,
+                    bridge_config: vec![],
+                    debug_mode: false,
+                    args: vec![],
+                },
+                manifest_set: ManifestSet {
+                    threshold: 0,
+                    members: vec![],
+                },
+                share_set: ShareSet {
+                    threshold: share_set_members.len() as u32,
+                    members: share_set_members,
+                },
+                enclave: NitroConfig {
+                    pcr0: vec![0; 48],
+                    pcr1: vec![1; 48],
+                    pcr2: vec![2; 48],
+                    pcr3: vec![3; 48],
+                    aws_root_certificate: vec![],
+                    qos_commit: "test-commit".to_string(),
+                },
+                patch_set: PatchSet {
+                    threshold: 0,
+                    members: vec![],
+                },
+            },
+            manifest_set_approvals: vec![],
+            share_set_approvals: vec![],
+        }
+    }
+
+    fn bundle_with_ephemeral_key(
+        ephemeral_key: &P256Public,
+        share_set_members: Vec<QuorumMember>,
+    ) -> ProvisionBundle {
+        ProvisionBundle::new(
+            "deploy-123".to_string(),
+            b"not parsed when verification is skipped",
+            sample_manifest_envelope(share_set_members),
+            1_712_345_678_901,
+            &ephemeral_key.to_bytes(),
+        )
+    }
+
+    fn local_pair_from_pair(pair: &P256Pair) -> LocalPair {
+        let seed_hex = String::from_utf8(pair.to_master_seed_hex()).unwrap();
+        LocalPair::from_hex_seed(&seed_hex).unwrap()
+    }
+
+    #[test]
+    fn output_serializes_expected_json_shape_with_hex() {
+        let output = ReEncryptedShareOutput {
+            re_encrypted_share: "010203".to_string(),
+            share_approval: Approval {
+                signature: vec![0xde, 0xad, 0xbe, 0xef],
+                member: QuorumMember {
+                    alias: "operator-1".to_string(),
+                    pub_key: vec![0xaa, 0xbb, 0xcc],
+                },
+            },
+        };
+
+        let value = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "re_encrypted_share": "010203",
+                "share_approval": {
+                    "signature": "deadbeef",
+                    "member": {
+                        "alias": "operator-1",
+                        "pubKey": "aabbcc",
+                    },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn finds_operator_share_set_member_by_public_key() {
+        let operator_pair = P256Pair::generate().unwrap();
+        let member = QuorumMember {
+            alias: "operator-1".to_string(),
+            pub_key: operator_pair.public_key().to_bytes(),
+        };
+        let manifest_envelope = sample_manifest_envelope(vec![member.clone()]);
+
+        let found =
+            find_share_set_member(&manifest_envelope, &operator_pair.public_key().to_bytes())
+                .unwrap();
+
+        assert_eq!(found, member);
+    }
+
+    #[test]
+    fn rejects_operator_missing_from_share_set() {
+        let operator_pair = P256Pair::generate().unwrap();
+        let other_pair = P256Pair::generate().unwrap();
+        let manifest_envelope = sample_manifest_envelope(vec![QuorumMember {
+            alias: "operator-1".to_string(),
+            pub_key: other_pair.public_key().to_bytes(),
+        }]);
+
+        assert!(
+            find_share_set_member(&manifest_envelope, &operator_pair.public_key().to_bytes())
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn re_encrypt_round_trip_and_generates_verifiable_approval() {
+        let operator_pair = P256Pair::generate().unwrap();
+        let operator_member = QuorumMember {
+            alias: "operator-1".to_string(),
+            pub_key: operator_pair.public_key().to_bytes(),
+        };
+        let operator_local_pair = local_pair_from_pair(&operator_pair);
+        let ephemeral_pair = P256Pair::generate().unwrap();
+        let bundle =
+            bundle_with_ephemeral_key(&ephemeral_pair.public_key(), vec![operator_member.clone()]);
+        let plaintext_share = b"arbitrary test share bytes";
+        let encrypted_share = operator_pair.public_key().encrypt(plaintext_share).unwrap();
+
+        let output =
+            build_re_encrypted_share_output(&encrypted_share, &bundle, &operator_local_pair, true)
+                .await
+                .unwrap();
+
+        let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
+        let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
+        assert_eq!(decrypted_share, plaintext_share);
+        assert_eq!(output.share_approval.member, operator_member);
+
+        let approval_public_key =
+            P256Public::from_bytes(&output.share_approval.member.pub_key).unwrap();
+        approval_public_key
+            .verify(
+                &bundle.manifest_envelope().manifest.qos_hash(),
+                &output.share_approval.signature,
+            )
+            .unwrap();
+    }
+}

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -3,6 +3,8 @@ pub mod cli;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub(crate) mod operator_key;
 pub mod pair;
+pub(crate) mod provisioning;
 pub mod pull_secret;
 pub mod util;

--- a/tvc/src/operator_key.rs
+++ b/tvc/src/operator_key.rs
@@ -1,0 +1,31 @@
+//! Resolve an operator's QOS key pair from CLI args or the active org config.
+
+use crate::config::turnkey::{Config, StoredQosOperatorKey};
+use crate::pair::LocalPair;
+use anyhow::anyhow;
+use std::path::Path;
+
+/// Load the operator's QOS key pair, preferring an explicit seed file path
+/// and falling back to the operator key stored under the active org config.
+pub async fn load_operator_pair(operator_seed: Option<&Path>) -> anyhow::Result<LocalPair> {
+    match operator_seed {
+        Some(path) => LocalPair::from_master_seed(path).await,
+        None => {
+            let tvc_config = Config::load().await?;
+            let (alias, org_config) = tvc_config.active_org_config().ok_or_else(|| {
+                anyhow!("No active organization. Run `tvc login` first or provide --operator-seed.")
+            })?;
+
+            let operator_key = StoredQosOperatorKey::load(org_config)
+                .await?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "No operator key found for org '{alias}'. \
+                         Run `tvc login` first or provide --operator-seed."
+                    )
+                })?;
+
+            LocalPair::from_hex_seed(&operator_key.private_key)
+        }
+    }
+}

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -14,6 +14,12 @@ pub trait Pair: Send + Sync {
         message: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<u8>>> + Send + '_>>;
 
+    /// Decrypt the given ciphertext.
+    fn decrypt(
+        &self,
+        ciphertext: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<u8>>> + Send + '_>>;
+
     /// The public key for this pair.
     fn public_key(&self) -> Vec<u8>;
 }
@@ -65,5 +71,21 @@ impl Pair for LocalPair {
 
     fn public_key(&self) -> Vec<u8> {
         self.pair.public_key().to_bytes()
+    }
+
+    fn decrypt(
+        &self,
+        ciphertext: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<u8>>> + Send + '_>> {
+        let pair2 = Arc::clone(&self.pair);
+
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                pair2
+                    .decrypt(&ciphertext)
+                    .map_err(|_| anyhow!("failed to decrypt with local signer"))
+            })
+            .await?
+        })
     }
 }

--- a/tvc/src/provisioning.rs
+++ b/tvc/src/provisioning.rs
@@ -1,0 +1,343 @@
+//! Shared provisioning bundle and attestation verification helpers.
+
+use anyhow::{anyhow, bail, Context};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use qos_core::protocol::services::boot::ManifestEnvelope;
+use qos_core::protocol::QosHash;
+use qos_p256::P256Public;
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ProvisionBundle {
+    attestation_document_cose_sign1_base64: String,
+    manifest_envelope: ManifestEnvelope,
+    fetched_at_unix_ms: u64,
+    deployment_id: String,
+    ephemeral_public_key_hex: String,
+}
+
+impl ProvisionBundle {
+    pub(crate) fn new(
+        deployment_id: String,
+        attestation_document: &[u8],
+        manifest_envelope: ManifestEnvelope,
+        fetched_at_unix_ms: u64,
+        ephemeral_public_key: &[u8],
+    ) -> Self {
+        Self {
+            attestation_document_cose_sign1_base64: BASE64_STANDARD.encode(attestation_document),
+            manifest_envelope,
+            fetched_at_unix_ms,
+            deployment_id,
+            ephemeral_public_key_hex: hex::encode(ephemeral_public_key),
+        }
+    }
+
+    pub(crate) fn manifest_envelope(&self) -> &ManifestEnvelope {
+        &self.manifest_envelope
+    }
+
+    pub(crate) fn ephemeral_public_key(
+        &self,
+        dangerous_skip_verification: bool,
+    ) -> anyhow::Result<P256Public> {
+        self.ephemeral_public_key_with_validation_time(dangerous_skip_verification, None)
+    }
+
+    fn ephemeral_public_key_with_validation_time(
+        &self,
+        dangerous_skip_verification: bool,
+        validation_time_override: Option<u64>,
+    ) -> anyhow::Result<P256Public> {
+        let bundled_public_key = decode_ephemeral_public_key_hex(&self.ephemeral_public_key_hex)?;
+
+        if dangerous_skip_verification {
+            return Ok(bundled_public_key);
+        }
+
+        let attestation_document = BASE64_STANDARD
+            .decode(&self.attestation_document_cose_sign1_base64)
+            .context("failed to decode attestation document in provision bundle")?;
+
+        verify_provisioning_details(
+            &attestation_document,
+            &self.manifest_envelope,
+            validation_time_override,
+        )?;
+
+        let attestation_doc =
+            qos_nsm::nitro::unsafe_attestation_doc_from_der(&attestation_document)
+                .context("failed to parse attestation document")?;
+        let attested_public_key = extract_ephemeral_public_key_bytes(
+            attestation_doc
+                .public_key
+                .as_ref()
+                .map(|public_key| public_key.as_ref()),
+        )?;
+
+        if attested_public_key != bundled_public_key.to_bytes() {
+            bail!("provision bundle ephemeral public key does not match attestation document");
+        }
+
+        Ok(bundled_public_key)
+    }
+}
+
+pub(crate) fn verify_provisioning_details(
+    cose_sign1_der: &[u8],
+    manifest_envelope: &ManifestEnvelope,
+    validation_time_override: Option<u64>,
+) -> anyhow::Result<()> {
+    manifest_envelope
+        .check_approvals()
+        .context("failed to verify manifest approvals")?;
+
+    let attestation_doc = qos_nsm::nitro::attestation_doc_from_der(
+        cose_sign1_der,
+        &qos_nsm::nitro::cert_from_pem(qos_nsm::nitro::AWS_ROOT_CERT_PEM)
+            .context("failed to parse AWS Nitro root certificate")?,
+        validation_time_secs(validation_time_override)?,
+    )
+    .context("failed to parse and verify attestation document")?;
+
+    qos_nsm::nitro::verify_attestation_doc_against_user_input(
+        &attestation_doc,
+        &manifest_envelope.manifest.qos_hash(),
+        &manifest_envelope.manifest.enclave.pcr0,
+        &manifest_envelope.manifest.enclave.pcr1,
+        &manifest_envelope.manifest.enclave.pcr2,
+        &manifest_envelope.manifest.enclave.pcr3,
+    )
+    .context("attestation document did not match manifest expectations")?;
+
+    Ok(())
+}
+
+pub(crate) fn extract_ephemeral_public_key_bytes(
+    public_key: Option<&[u8]>,
+) -> anyhow::Result<Vec<u8>> {
+    let public_key =
+        public_key.ok_or_else(|| anyhow!("attestation document missing ephemeral public key"))?;
+
+    P256Public::from_bytes(public_key)
+        .map(|ephemeral_key| ephemeral_key.to_bytes())
+        .map_err(|err| anyhow!("invalid ephemeral public key: {err:?}"))
+}
+
+fn decode_ephemeral_public_key_hex(ephemeral_public_key_hex: &str) -> anyhow::Result<P256Public> {
+    let public_key_bytes = hex::decode(ephemeral_public_key_hex.trim())
+        .context("failed to decode ephemeral public key from provision bundle")?;
+
+    P256Public::from_bytes(&public_key_bytes)
+        .map_err(|err| anyhow!("invalid ephemeral public key in provision bundle: {err:?}"))
+}
+
+fn validation_time_secs(validation_time_override: Option<u64>) -> anyhow::Result<u64> {
+    match validation_time_override {
+        Some(time) => Ok(time),
+        None => Ok(SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system time before unix epoch")?
+            .as_secs()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_ephemeral_public_key_bytes, verify_provisioning_details, ProvisionBundle};
+    use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+    use qos_core::protocol::services::boot::ManifestEnvelope;
+    use qos_p256::P256Pair;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    struct ValidProvisioningDetailsFixture {
+        validation_time_secs: u64,
+        attestation_document_cose_sign1_base64: String,
+        manifest_envelope: ManifestEnvelope,
+    }
+
+    fn valid_provisioning_details_fixture() -> ValidProvisioningDetailsFixture {
+        serde_json::from_str(include_str!("../fixtures/valid_provisioning_details.json")).unwrap()
+    }
+
+    fn sample_manifest_envelope() -> ManifestEnvelope {
+        serde_json::from_value(json!({
+            "manifest": {
+                "namespace": {
+                    "name": "test-namespace",
+                    "nonce": 7,
+                    "quorumKey": "0102"
+                },
+                "pivot": {
+                    "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "restart": "Never",
+                    "bridgeConfig": [],
+                    "debugMode": false,
+                    "args": ["--serve"]
+                },
+                "manifestSet": {
+                    "threshold": 1,
+                    "members": [{
+                        "alias": "member-1",
+                        "pubKey": "aabbcc"
+                    }]
+                },
+                "shareSet": {
+                    "threshold": 0,
+                    "members": []
+                },
+                "enclave": {
+                    "pcr0": "00",
+                    "pcr1": "11",
+                    "pcr2": "22",
+                    "pcr3": "33",
+                    "awsRootCertificate": "44",
+                    "qosCommit": "test-commit"
+                },
+                "patchSet": {
+                    "threshold": 0,
+                    "members": []
+                }
+            },
+            "manifestSetApprovals": [{
+                "signature": "beef",
+                "member": {
+                    "alias": "member-1",
+                    "pubKey": "aabbcc"
+                }
+            }],
+            "shareSetApprovals": []
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn extract_ephemeral_public_key_bytes_requires_key() {
+        let err = extract_ephemeral_public_key_bytes(None).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("attestation document missing ephemeral public key"));
+    }
+
+    #[test]
+    fn extract_ephemeral_public_key_bytes_rejects_malformed_key() {
+        let err = extract_ephemeral_public_key_bytes(Some(&[1, 2, 3])).unwrap_err();
+
+        assert!(err.to_string().contains("invalid ephemeral public key"));
+    }
+
+    #[test]
+    fn provision_bundle_serializes_expected_fields() {
+        let manifest_envelope = sample_manifest_envelope();
+        let bundle = ProvisionBundle::new(
+            "deploy-123".to_string(),
+            &[1, 2, 3, 4],
+            manifest_envelope.clone(),
+            1_712_345_678_901,
+            &[0x04, 0xab, 0xcd],
+        );
+
+        let value = serde_json::to_value(&bundle).unwrap();
+
+        assert_eq!(
+            value["attestation_document_cose_sign1_base64"],
+            json!(BASE64_STANDARD.encode([1, 2, 3, 4])),
+        );
+        assert_eq!(value["fetched_at_unix_ms"], json!(1_712_345_678_901_u64));
+        assert_eq!(value["deployment_id"], json!("deploy-123"));
+        assert_eq!(value["ephemeral_public_key_hex"], json!("04abcd"));
+        assert_eq!(
+            value["manifest_envelope"],
+            serde_json::to_value(&manifest_envelope).unwrap()
+        );
+    }
+
+    #[test]
+    fn verify_provisioning_details_accepts_real_fixture() {
+        let fixture = valid_provisioning_details_fixture();
+        let attestation_document = BASE64_STANDARD
+            .decode(&fixture.attestation_document_cose_sign1_base64)
+            .unwrap();
+
+        verify_provisioning_details(
+            &attestation_document,
+            &fixture.manifest_envelope,
+            Some(fixture.validation_time_secs),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn verify_provisioning_details_rejects_real_fixture_with_missing_manifest_approval() {
+        let fixture = valid_provisioning_details_fixture();
+        let attestation_document = BASE64_STANDARD
+            .decode(&fixture.attestation_document_cose_sign1_base64)
+            .unwrap();
+        let mut manifest_envelope = fixture.manifest_envelope;
+        manifest_envelope.manifest_set_approvals.clear();
+
+        assert!(verify_provisioning_details(
+            &attestation_document,
+            &manifest_envelope,
+            Some(fixture.validation_time_secs),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn safe_bundle_ephemeral_key_extraction_rejects_mismatched_bundle_key() {
+        let fixture = valid_provisioning_details_fixture();
+        let attestation_document = BASE64_STANDARD
+            .decode(&fixture.attestation_document_cose_sign1_base64)
+            .unwrap();
+        let attestation_doc =
+            qos_nsm::nitro::unsafe_attestation_doc_from_der(&attestation_document).unwrap();
+        let valid_ephemeral_key = extract_ephemeral_public_key_bytes(
+            attestation_doc
+                .public_key
+                .as_ref()
+                .map(|public_key| public_key.as_ref()),
+        )
+        .unwrap();
+        let mut bundle = ProvisionBundle::new(
+            "deploy-123".to_string(),
+            &attestation_document,
+            fixture.manifest_envelope,
+            1_712_345_678_901,
+            &valid_ephemeral_key,
+        );
+        bundle.ephemeral_public_key_hex =
+            hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+
+        let err = match bundle
+            .ephemeral_public_key_with_validation_time(false, Some(fixture.validation_time_secs))
+        {
+            Ok(_) => panic!("mismatched bundle key should be rejected"),
+            Err(err) => err,
+        };
+
+        assert!(err
+            .to_string()
+            .contains("does not match attestation document"));
+    }
+
+    #[test]
+    fn skip_bundle_ephemeral_key_extraction_accepts_valid_bundle_key_without_attestation() {
+        let expected_public_key = P256Pair::generate().unwrap().public_key();
+        let bundle = ProvisionBundle {
+            attestation_document_cose_sign1_base64: "not base64".to_string(),
+            manifest_envelope: sample_manifest_envelope(),
+            fetched_at_unix_ms: 1_712_345_678_901,
+            deployment_id: "deploy-123".to_string(),
+            ephemeral_public_key_hex: hex::encode(expected_public_key.to_bytes()),
+        };
+
+        let public_key = bundle.ephemeral_public_key(true).unwrap();
+
+        assert_eq!(public_key.to_bytes(), expected_public_key.to_bytes());
+    }
+}

--- a/tvc/tests/re_encrypt_share.rs
+++ b/tvc/tests/re_encrypt_share.rs
@@ -1,0 +1,45 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn root_help_lists_re_encrypt_share_command() {
+    cargo_bin_cmd!("tvc")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("re-encrypt-share"))
+        .stdout(predicate::str::contains(
+            "Re-encrypt a share for enclave provisioning",
+        ));
+}
+
+#[test]
+fn re_encrypt_share_help_lists_expected_flags() {
+    cargo_bin_cmd!("tvc")
+        .arg("re-encrypt-share")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--share-path <SHARE_PATH>"))
+        .stdout(predicate::str::contains(
+            "--provision-bundle <PROVISION_BUNDLE>",
+        ))
+        .stdout(predicate::str::contains("--operator-seed <OPERATOR_PATH>"))
+        .stdout(predicate::str::contains("--dangerous-skip-verification"))
+        .stdout(predicate::str::contains(
+            "--re-encrypted-out <RE_ENCRYPTED_OUT>",
+        ));
+}
+
+#[test]
+fn re_encrypt_share_requires_share_and_provision_bundle() {
+    cargo_bin_cmd!("tvc")
+        .arg("re-encrypt-share")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the following required arguments were not provided",
+        ))
+        .stderr(predicate::str::contains("--share-path"))
+        .stderr(predicate::str::contains("--provision-bundle"));
+}


### PR DESCRIPTION
This PR adds `tvc re-encrypt-share`, which takes a share encrypted to the operator public key and re-encrypts it to a recently fetched attestation doc's ephemeral key. It is designed to work with the output of `tvc deploy provisioning-details`, and can be used on an offline and airgapped machine. 