### PR TITLE
feat(tvc): debug mode in app and deployment intents

### DIFF
--- a/tvc/CHANGELOG.md
+++ b/tvc/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `tvc deploy create --dangerous-deploy-insecure` flag to enable debug
+  mode on a TVC deployment. Overrides the `debugMode` field from the JSON
+  config when set; cannot downgrade an explicit `debugMode: true` in the
+  config to false. A deployment created with debug mode is permanently
+  considered insecure (enclave logs forwarded to the host and attestation
+  PCRs zeroed).
+
 ## 0.6.2 - 2026-04-09
 
 ### Other

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -14,8 +14,13 @@ Configuration values are resolved in this order, highest priority first:
   3. Config file value (--config-file)
   4. Built-in default
 
-Special rules:
+Special rules (exceptions to the order above):
   --pivot-args replaces the config file's list entirely (does not append)
+  Debug-mode flags (--dangerous-deploy-debug-mode and
+    --dangerous-enable-debug-mode-deployments) are opt-in only: the flag
+    or its env var can turn debug mode ON, but its absence never turns OFF
+    a config file that enables it. To disable debug mode, set it false in
+    the config file (or omit it) and do not pass the flag.
 
 Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -147,13 +147,13 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
         share_set_id: app_config.share_set_id.clone(),
         share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
         enable_egress: app_config.external_connectivity,
-        enable_debug_mode_deployments: app_config.enable_debug_mode_deployments.into(),
+        enable_debug_mode_deployments: app_config.dangerous_enable_debug_mode_deployments.into(),
     }
 }
 
 fn apply_overrides(mut config: AppConfig, args: &Args) -> AppConfig {
     if args.dangerous_enable_debug_mode_deployments {
-        config.enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
+        config.dangerous_enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
     }
     config
 }
@@ -196,7 +196,7 @@ mod tests {
             }),
             share_set_id: None,
             share_set_params: None,
-            enable_debug_mode_deployments: false,
+            dangerous_enable_debug_mode_deployments: false,
         }
     }
 
@@ -244,12 +244,12 @@ mod tests {
         assert_eq!(intent.enable_debug_mode_deployments, Some(false));
     }
 
-    /// An explicit `enableDebugModeDeployments: true` in the config flows into
+    /// An explicit `dangerousEnableDebugModeDeployments: true` in the config flows into
     /// the intent so the server records the app's debug-mode capability.
     #[test]
     fn build_intent_forwards_debug_mode_from_config() {
         let mut config = valid_config();
-        config.enable_debug_mode_deployments = true;
+        config.dangerous_enable_debug_mode_deployments = true;
 
         let intent = build_create_tvc_app_intent(&config);
         assert_eq!(intent.enable_debug_mode_deployments, Some(true));
@@ -266,7 +266,7 @@ mod tests {
         };
 
         let config = apply_overrides(config, &args);
-        assert!(config.enable_debug_mode_deployments);
+        assert!(config.dangerous_enable_debug_mode_deployments);
     }
 
     /// Omitting the CLI flag must NOT override a config that enables debug-mode
@@ -275,14 +275,14 @@ mod tests {
     #[test]
     fn absent_dangerous_flag_preserves_config_debug_mode() {
         let mut config = valid_config();
-        config.enable_debug_mode_deployments = true;
+        config.dangerous_enable_debug_mode_deployments = true;
         let args = Args {
             config_file: PathBuf::new(),
             dangerous_enable_debug_mode_deployments: false,
         };
 
         let config = apply_overrides(config, &args);
-        assert!(config.enable_debug_mode_deployments);
+        assert!(config.dangerous_enable_debug_mode_deployments);
     }
 
     #[test]

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -148,7 +148,7 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
         share_set_id: app_config.share_set_id.clone(),
         share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
         enable_egress: app_config.external_connectivity,
-        enable_debug_mode_deployments: Some(app_config.enable_debug_mode_deployments),
+        enable_debug_mode_deployments: app_config.enable_debug_mode_deployments.into(),
     }
 }
 

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -22,6 +22,10 @@ pub struct Args {
     /// secure-enclave logs and emit zero'd attestation PCRs, so remote
     /// attestation cannot succeed. Cannot be changed after app creation; setting
     /// this true means the app's quorum key is considered permanently insecure.
+    ///
+    /// Opt-in only: passing this flag (or setting the env var) permits debug-mode
+    /// deployments even if the config file leaves it off, but omitting it does NOT
+    /// override a config file that enables it.
     #[arg(long, env = "TVC_DANGEROUS_ENABLE_DEBUG_MODE_DEPLOYMENTS")]
     pub dangerous_enable_debug_mode_deployments: bool,
 }
@@ -152,7 +156,9 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
 }
 
 fn apply_overrides(mut config: AppConfig, args: &Args) -> AppConfig {
-    config.enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
+    if args.dangerous_enable_debug_mode_deployments {
+        config.enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
+    }
     config
 }
 
@@ -261,6 +267,22 @@ mod tests {
         let args = Args {
             config_file: PathBuf::new(),
             dangerous_enable_debug_mode_deployments: true,
+        };
+
+        let config = apply_overrides(config, &args);
+        assert!(config.enable_debug_mode_deployments);
+    }
+
+    /// Omitting the CLI flag must NOT override a config that enables debug-mode
+    /// deployments: the flag is opt-in only and can never turn it off, so a
+    /// `true` config survives an absent flag.
+    #[test]
+    fn absent_dangerous_flag_preserves_config_debug_mode() {
+        let mut config = valid_config();
+        config.enable_debug_mode_deployments = true;
+        let args = Args {
+            config_file: PathBuf::new(),
+            dangerous_enable_debug_mode_deployments: false,
         };
 
         let config = apply_overrides(config, &args);

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -22,10 +22,6 @@ pub struct Args {
     /// secure-enclave logs and emit zero'd attestation PCRs, so remote
     /// attestation cannot succeed. Cannot be changed after app creation; setting
     /// this true means the app's quorum key is considered permanently insecure.
-    ///
-    /// Opt-in only: passing this flag (or setting the env var) permits debug-mode
-    /// deployments even if the config file leaves it off, but omitting it does NOT
-    /// override a config file that enables it.
     #[arg(long, env = "TVC_DANGEROUS_ENABLE_DEBUG_MODE_DEPLOYMENTS")]
     pub dangerous_enable_debug_mode_deployments: bool,
 }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -28,8 +28,7 @@ pub struct Args {
 
 /// Run the app create command.
 pub async fn run(args: Args) -> Result<()> {
-    let mut app_config = load_or_fill_app_config(&args.config_file).await?;
-    apply_overrides(&mut app_config, &args);
+    let app_config = apply_overrides(load_or_fill_app_config(&args.config_file).await?, &args);
 
     app_config
         .validate()
@@ -152,8 +151,9 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
     }
 }
 
-fn apply_overrides(config: &mut AppConfig, args: &Args) {
+fn apply_overrides(mut config: AppConfig, args: &Args) -> AppConfig {
     config.enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
+    config
 }
 
 fn to_tvc_operator_set_params(params: &OperatorSetParams) -> TvcOperatorSetParams {
@@ -257,13 +257,13 @@ mod tests {
     /// via the command line rather than the config file.
     #[test]
     fn dangerous_flag_enables_debug_mode_when_config_unset() {
-        let mut config = valid_config();
+        let config = valid_config();
         let args = Args {
             config_file: PathBuf::new(),
             dangerous_enable_debug_mode_deployments: true,
         };
 
-        apply_overrides(&mut config, &args);
+        let config = apply_overrides(config, &args);
         assert!(config.enable_debug_mode_deployments);
     }
 

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -17,11 +17,19 @@ pub struct Args {
     /// Path to the app configuration file (JSON).
     #[arg(short = 'c', long, value_name = "PATH", env = "TVC_APP_CONFIG")]
     pub config_file: PathBuf,
+
+    /// Permit debug-mode deployments for this app. Debug-mode deployments expose
+    /// secure-enclave logs and emit zero'd attestation PCRs, so remote
+    /// attestation cannot succeed. Cannot be changed after app creation; setting
+    /// this true means the app's quorum key is considered permanently insecure.
+    #[arg(long, env = "TVC_DANGEROUS_ENABLE_DEBUG_MODE_DEPLOYMENTS")]
+    pub dangerous_enable_debug_mode_deployments: bool,
 }
 
 /// Run the app create command.
 pub async fn run(args: Args) -> Result<()> {
-    let app_config = load_or_fill_app_config(&args.config_file).await?;
+    let mut app_config = load_or_fill_app_config(&args.config_file).await?;
+    apply_overrides(&mut app_config, &args);
 
     app_config
         .validate()
@@ -140,8 +148,12 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
         share_set_id: app_config.share_set_id.clone(),
         share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
         enable_egress: app_config.external_connectivity,
-        enable_debug_mode_deployments: None,
+        enable_debug_mode_deployments: Some(app_config.enable_debug_mode_deployments),
     }
+}
+
+fn apply_overrides(config: &mut AppConfig, args: &Args) {
+    config.enable_debug_mode_deployments = args.dangerous_enable_debug_mode_deployments;
 }
 
 fn to_tvc_operator_set_params(params: &OperatorSetParams) -> TvcOperatorSetParams {
@@ -182,6 +194,7 @@ mod tests {
             }),
             share_set_id: None,
             share_set_params: None,
+            enable_debug_mode_deployments: false,
         }
     }
 
@@ -219,6 +232,39 @@ mod tests {
             share_set_params.existing_operator_ids,
             vec!["existing-operator-id".to_string()]
         );
+    }
+
+    /// Default config has debug-mode disabled, and the intent reports `false`
+    /// — explicit so the server doesn't have to fall back to a proto default.
+    #[test]
+    fn build_intent_sends_false_debug_mode_by_default() {
+        let intent = build_create_tvc_app_intent(&valid_config());
+        assert_eq!(intent.enable_debug_mode_deployments, Some(false));
+    }
+
+    /// An explicit `enableDebugModeDeployments: true` in the config flows into
+    /// the intent so the server records the app's debug-mode capability.
+    #[test]
+    fn build_intent_forwards_debug_mode_from_config() {
+        let mut config = valid_config();
+        config.enable_debug_mode_deployments = true;
+
+        let intent = build_create_tvc_app_intent(&config);
+        assert_eq!(intent.enable_debug_mode_deployments, Some(true));
+    }
+
+    /// CLI flag flips a default `false` config to `true` — the user opted in
+    /// via the command line rather than the config file.
+    #[test]
+    fn dangerous_flag_enables_debug_mode_when_config_unset() {
+        let mut config = valid_config();
+        let args = Args {
+            config_file: PathBuf::new(),
+            dangerous_enable_debug_mode_deployments: true,
+        };
+
+        apply_overrides(&mut config, &args);
+        assert!(config.enable_debug_mode_deployments);
     }
 
     #[test]

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -22,6 +22,18 @@ pub struct Args {
     /// override `pivotContainerEncryptedPullSecret` from the config file.
     #[arg(long, alias = "pull-secret", value_name = "PATH")]
     pub pivot_pull_secret: Option<PathBuf>,
+
+    /// Deploy insecurely in debug mode, which forwards secure enclave logs to the host and zeroes
+    /// attestation PCRs. This defeats the purpose of a secure enclave, so it should only
+    /// be used to debug non-prod applications.
+    ///
+    /// **WARNING**: This compromises the quorum key for the app, so a single insecure deployment
+    /// will permanently mark the app and all subsequent deployments as insecure and cannot be
+    /// undone. You will need to create a new secure app deployment.
+    ///
+    /// Overrides `debugMode` in the config file when set.
+    #[arg(long)]
+    pub dangerous_deploy_insecure: bool,
 }
 
 fn build_validate_image_request(
@@ -71,12 +83,18 @@ pub async fn run(args: Args) -> Result<()> {
     let config_content = std::fs::read_to_string(&args.config_file)
         .with_context(|| format!("failed to read config file: {}", args.config_file.display()))?;
 
-    let deploy_config: DeployConfig = serde_json::from_str(&config_content).with_context(|| {
+    let mut deploy_config: DeployConfig = serde_json::from_str(&config_content).with_context(|| {
         format!(
             "failed to parse config file: {}",
             args.config_file.display()
         )
     })?;
+
+    // CLI flag is an asymmetric override: it can only upgrade the config to
+    // debug=true, never downgrade.
+    if args.dangerous_deploy_insecure {
+        deploy_config.debug_mode = Some(true);
+    }
 
     // Validate config
     if deploy_config.has_placeholders() {
@@ -172,7 +190,8 @@ pub async fn run(args: Args) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::pin_image_url;
+    use super::{build_create_intent, pin_image_url};
+    use crate::config::deploy::DeployConfig;
 
     #[test]
     fn pin_image_url_appends_digest_to_tagged_reference() {
@@ -188,5 +207,54 @@ mod tests {
         let pinned = pin_image_url(image_url, "sha256:abc123");
 
         assert_eq!(pinned, "ghcr.io/team/app@sha256:abc123");
+    }
+
+    #[test]
+    fn debug_mode_flag_upgrades_config_when_false() {
+        let mut cfg = DeployConfig::template(None);
+        cfg.debug_mode = Some(false);
+
+        let cli_flag = true;
+        if cli_flag {
+            cfg.debug_mode = Some(true);
+        }
+
+        assert_eq!(cfg.debug_mode, Some(true));
+    }
+
+    #[test]
+    fn debug_mode_flag_absent_preserves_config_true() {
+        let mut cfg = DeployConfig::template(None);
+        cfg.debug_mode = Some(true);
+
+        let cli_flag = false;
+        if cli_flag {
+            cfg.debug_mode = Some(true);
+        }
+
+        assert_eq!(cfg.debug_mode, Some(true));
+    }
+
+    #[test]
+    fn build_create_intent_propagates_debug_mode() {
+        let mut cfg = DeployConfig::template(None);
+        cfg.debug_mode = Some(true);
+
+        let intent = build_create_intent(&cfg, "img@sha256:abc".to_string(), None);
+
+        assert_eq!(intent.debug_mode, Some(true));
+    }
+
+    #[test]
+    fn debug_mode_serializes_camel_case() {
+        let mut cfg = DeployConfig::template(None);
+        cfg.debug_mode = Some(true);
+
+        let json = serde_json::to_string(&cfg).unwrap();
+
+        assert!(
+            json.contains("\"debugMode\":true"),
+            "expected camelCase debugMode in {json}"
+        );
     }
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -119,11 +119,6 @@ pub struct Args {
     /// Only valid for apps created with `--dangerous-enable-debug-mode-deployments`.
     /// Debug-mode deployments permanently mark the app's quorum key as insecure;
     /// to return to a secure posture, create a new app with a fresh quorum key.
-    ///
-    /// Opt-in only: passing this flag (or setting the env var) enables debug
-    /// mode even if the config file leaves it off, but omitting it does NOT
-    /// disable debug mode that the config file turns on. To deploy without
-    /// debug mode, set `debugMode: false` in the config and omit this flag.
     #[arg(long, env = "TVC_DANGEROUS_DEPLOY_DEBUG_MODE")]
     pub dangerous_deploy_debug_mode: bool,
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -28,7 +28,9 @@ Required deployment fields:
 
 Special rules:
   --pivot-args replaces the config file's list entirely (does not append).
-  --dangerous-deploy-debug-mode requires an app created with
+  --dangerous-deploy-debug-mode is opt-in only: the flag (or its env var) can
+  turn debug mode ON, but omitting it does not turn OFF debug mode enabled in
+  the config file. It also requires an app created with
   `--dangerous-enable-debug-mode-deployments`; the server rejects debug-mode
   deployments for apps without it.
   --pivot-pull-secret reads an unencrypted pull secret file, encrypts it for the
@@ -118,7 +120,10 @@ pub struct Args {
     /// Debug-mode deployments permanently mark the app's quorum key as insecure;
     /// to return to a secure posture, create a new app with a fresh quorum key.
     ///
-    /// Overrides `debugMode` in the config file when set.
+    /// Opt-in only: passing this flag (or setting the env var) enables debug
+    /// mode even if the config file leaves it off, but omitting it does NOT
+    /// disable debug mode that the config file turns on. To deploy without
+    /// debug mode, set `debugMode: false` in the config and omit this flag.
     #[arg(long, env = "TVC_DANGEROUS_DEPLOY_DEBUG_MODE")]
     pub dangerous_deploy_debug_mode: bool,
 }
@@ -183,7 +188,9 @@ fn apply_overrides(config: &mut DeployConfig, args: &Args) {
     if !args.pivot_args.is_empty() {
         config.pivot_args = args.pivot_args.clone();
     }
-    config.debug_mode = args.dangerous_deploy_debug_mode;
+    if args.dangerous_deploy_debug_mode {
+        config.debug_mode = args.dangerous_deploy_debug_mode;
+    }
     if let Some(v) = args.health_check_port {
         config.health_check_port = v;
     }
@@ -561,6 +568,23 @@ mod tests {
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
             dangerous_deploy_debug_mode: true,
+            ..empty_args()
+        };
+        let resolved = run_resolve(&args).unwrap();
+        assert!(resolved.debug_mode);
+    }
+
+    /// Omitting `--dangerous-deploy-debug-mode` must NOT override a config file
+    /// that enables debug mode: the flag is opt-in only and can never turn it
+    /// off, so a `debug_mode = true` config survives an absent flag.
+    #[test]
+    fn absent_debug_mode_flag_preserves_config_debug_mode() {
+        let mut cfg = file_config();
+        cfg.debug_mode = true;
+        let file = write_config(&cfg);
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            dangerous_deploy_debug_mode: false,
             ..empty_args()
         };
         let resolved = run_resolve(&args).unwrap();

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -148,7 +148,7 @@ fn build_create_intent(
         pivot_args: deploy_config.pivot_args.clone(),
         expected_pivot_digest: deploy_config.expected_pivot_digest.clone(),
         pivot_container_encrypted_pull_secret,
-        debug_mode: deploy_config.debug_mode.into(),
+        debug_mode: deploy_config.dangerous_deploy_debug_mode.into(),
         nonce: None,
         health_check_type: deploy_config.health_check_type,
         health_check_port: deploy_config.health_check_port as u32,
@@ -184,7 +184,7 @@ fn apply_overrides(config: &mut DeployConfig, args: &Args) {
         config.pivot_args = args.pivot_args.clone();
     }
     if args.dangerous_deploy_debug_mode {
-        config.debug_mode = args.dangerous_deploy_debug_mode;
+        config.dangerous_deploy_debug_mode = args.dangerous_deploy_debug_mode;
     }
     if let Some(v) = args.health_check_port {
         config.health_check_port = v;
@@ -431,7 +431,7 @@ mod tests {
         c.pivot_path = "file-path".into();
         c.pivot_args = vec!["a".into(), "b".into()];
         c.expected_pivot_digest = "file-digest".into();
-        c.debug_mode = false;
+        c.dangerous_deploy_debug_mode = false;
         c.pivot_container_encrypted_pull_secret = None;
         c.health_check_port = 4000;
         c.public_ingress_port = 5000;
@@ -496,7 +496,7 @@ mod tests {
         // Optional fields fall back to template defaults.
         assert_eq!(resolved.health_check_port, 3000);
         assert_eq!(resolved.public_ingress_port, 3000);
-        assert!(!resolved.debug_mode);
+        assert!(!resolved.dangerous_deploy_debug_mode);
         assert!(resolved.pivot_args.is_empty());
         // Pull-secret placeholder cleared in flag-only mode.
         assert_eq!(resolved.pivot_container_encrypted_pull_secret, None);
@@ -555,27 +555,27 @@ mod tests {
         );
     }
 
-    /// `--dangerous-deploy-debug-mode` flips the resolved `debug_mode` from
-    /// the file's `false` to `true`.
+    /// `--dangerous-deploy-debug-mode` flips the resolved
+    /// `dangerous_deploy_debug_mode` from the file's `false` to `true`.
     #[test]
     fn dangerous_debug_mode_flag_enables_debug_mode() {
-        let file = write_config(&file_config()); // file has debug_mode = false
+        let file = write_config(&file_config()); // file has dangerous_deploy_debug_mode = false
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
             dangerous_deploy_debug_mode: true,
             ..empty_args()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert!(resolved.debug_mode);
+        assert!(resolved.dangerous_deploy_debug_mode);
     }
 
     /// Omitting `--dangerous-deploy-debug-mode` must NOT override a config file
     /// that enables debug mode: the flag is opt-in only and can never turn it
-    /// off, so a `debug_mode = true` config survives an absent flag.
+    /// off, so a `dangerous_deploy_debug_mode = true` config survives an absent flag.
     #[test]
     fn absent_debug_mode_flag_preserves_config_debug_mode() {
         let mut cfg = file_config();
-        cfg.debug_mode = true;
+        cfg.dangerous_deploy_debug_mode = true;
         let file = write_config(&cfg);
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
@@ -583,15 +583,15 @@ mod tests {
             ..empty_args()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert!(resolved.debug_mode);
+        assert!(resolved.dangerous_deploy_debug_mode);
     }
 
-    /// The intent builder wraps the resolved config's debug_mode in `Some(...)`
-    /// when constructing the outgoing `CreateTvcDeploymentIntent`.
+    /// The intent builder wraps the resolved config's dangerous_deploy_debug_mode
+    /// in `Some(...)` when constructing the outgoing `CreateTvcDeploymentIntent`.
     #[test]
     fn build_intent_forwards_debug_mode() {
         let mut cfg = file_config();
-        cfg.debug_mode = true;
+        cfg.dangerous_deploy_debug_mode = true;
         let intent = build_create_intent(&cfg, "image-url".to_string(), None);
         assert_eq!(intent.debug_mode, Some(true));
     }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -27,7 +27,7 @@ pub struct Args {
     /// attestation PCRs. This defeats the purpose of a secure enclave, so it should only
     /// be used to debug non-prod applications.
     ///
-    /// **WARNING**: This compromises the quorum key for the app, so a single insecure deployment
+    /// WARNING: This compromises the quorum key for the app, so a single insecure deployment
     /// will permanently mark the app and all subsequent deployments as insecure and cannot be
     /// undone. You will need to create a new secure app deployment.
     ///

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -28,7 +28,9 @@ Required deployment fields:
 
 Special rules:
   --pivot-args replaces the config file's list entirely (does not append).
-  --debug-mode can enable debug mode but cannot disable a true config value.
+  --dangerous-deploy-debug-mode requires an app created with
+  `--dangerous-enable-debug-mode-deployments`; the server rejects debug-mode
+  deployments for apps without it.
   --pivot-pull-secret reads an unencrypted pull secret file, encrypts it for the
   active org's API environment, and overrides the encrypted secret in the config.
 
@@ -90,10 +92,6 @@ pub struct Args {
     )]
     pub pivot_args: Vec<String>,
 
-    /// Enable debug mode. One-way: cannot disable a `true` set earlier via the file.
-    #[arg(long, env = "TVC_DEBUG_MODE")]
-    pub debug_mode: bool,
-
     /// Override the healthCheckPort field.
     #[arg(long, env = "TVC_HEALTH_CHECK_PORT")]
     pub health_check_port: Option<u16>,
@@ -108,6 +106,19 @@ pub struct Args {
     /// override `pivotContainerEncryptedPullSecret` from the config file.
     #[arg(long, value_name = "PATH", env = "TVC_PIVOT_PULL_SECRET")]
     pub pivot_pull_secret: Option<PathBuf>,
+
+    /// Deploy in debug mode, which forwards secure enclave logs to the host and
+    /// zeroes attestation PCRs. This defeats the purpose of a secure enclave,
+    /// so it should only be used to debug non-prod applications and view application
+    /// logs.
+    ///
+    /// Only valid for apps created with `--dangerous-enable-debug-mode-deployments`.
+    /// Debug-mode deployments permanently mark the app's quorum key as insecure;
+    /// to return to a secure posture, create a new app with a fresh quorum key.
+    ///
+    /// Overrides `debugMode` in the config file when set.
+    #[arg(long, env = "TVC_DANGEROUS_DEPLOY_DEBUG_MODE")]
+    pub dangerous_deploy_debug_mode: bool,
 }
 
 fn build_validate_image_request(
@@ -135,7 +146,7 @@ fn build_create_intent(
         pivot_args: deploy_config.pivot_args.clone(),
         expected_pivot_digest: deploy_config.expected_pivot_digest.clone(),
         pivot_container_encrypted_pull_secret,
-        debug_mode: deploy_config.debug_mode,
+        debug_mode: Some(deploy_config.debug_mode),
         nonce: None,
         health_check_type: deploy_config.health_check_type,
         health_check_port: deploy_config.health_check_port as u32,
@@ -170,10 +181,7 @@ fn apply_overrides(config: &mut DeployConfig, args: &Args) {
     if !args.pivot_args.is_empty() {
         config.pivot_args = args.pivot_args.clone();
     }
-    // One-way: only ever flips false -> true.
-    if args.debug_mode {
-        config.debug_mode = Some(true);
-    }
+    config.debug_mode = args.dangerous_deploy_debug_mode;
     if let Some(v) = args.health_check_port {
         config.health_check_port = v;
     }
@@ -393,10 +401,10 @@ mod tests {
             expected_pivot_digest: None,
             pivot_path: None,
             pivot_args: vec![],
-            debug_mode: false,
             health_check_port: None,
             public_ingress_port: None,
             pivot_pull_secret: None,
+            dangerous_deploy_debug_mode: false,
         }
     }
 
@@ -419,7 +427,7 @@ mod tests {
         c.pivot_path = "file-path".into();
         c.pivot_args = vec!["a".into(), "b".into()];
         c.expected_pivot_digest = "file-digest".into();
-        c.debug_mode = Some(false);
+        c.debug_mode = false;
         c.pivot_container_encrypted_pull_secret = None;
         c.health_check_port = 4000;
         c.public_ingress_port = 5000;
@@ -484,7 +492,7 @@ mod tests {
         // Optional fields fall back to template defaults.
         assert_eq!(resolved.health_check_port, 3000);
         assert_eq!(resolved.public_ingress_port, 3000);
-        assert_eq!(resolved.debug_mode, Some(false));
+        assert!(!resolved.debug_mode);
         assert!(resolved.pivot_args.is_empty());
         // Pull-secret placeholder cleared in flag-only mode.
         assert_eq!(resolved.pivot_container_encrypted_pull_secret, None);
@@ -541,6 +549,30 @@ mod tests {
             err.contains("--pivot-pull-secret"),
             "error should point the user at the resolution flag: {err}"
         );
+    }
+
+    /// `--dangerous-deploy-debug-mode` flips the resolved `debug_mode` from
+    /// the file's `false` to `true`.
+    #[test]
+    fn dangerous_debug_mode_flag_enables_debug_mode() {
+        let file = write_config(&file_config()); // file has debug_mode = false
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            dangerous_deploy_debug_mode: true,
+            ..empty_args()
+        };
+        let resolved = run_resolve(&args).unwrap();
+        assert!(resolved.debug_mode);
+    }
+
+    /// The intent builder wraps the resolved config's debug_mode in `Some(...)`
+    /// when constructing the outgoing `CreateTvcDeploymentIntent`.
+    #[test]
+    fn build_intent_forwards_debug_mode() {
+        let mut cfg = file_config();
+        cfg.debug_mode = true;
+        let intent = build_create_intent(&cfg, "image-url".to_string(), None);
+        assert_eq!(intent.debug_mode, Some(true));
     }
 
     /// Sets `TVC_NON_INTERACTIVE=1` for the lifetime of the value so a test

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -112,6 +112,8 @@ pub struct Args {
     /// so it should only be used to debug non-prod applications and view application
     /// logs.
     ///
+    /// # WARNING
+    ///
     /// Only valid for apps created with `--dangerous-enable-debug-mode-deployments`.
     /// Debug-mode deployments permanently mark the app's quorum key as insecure;
     /// to return to a secure posture, create a new app with a fresh quorum key.
@@ -146,7 +148,7 @@ fn build_create_intent(
         pivot_args: deploy_config.pivot_args.clone(),
         expected_pivot_digest: deploy_config.expected_pivot_digest.clone(),
         pivot_container_encrypted_pull_secret,
-        debug_mode: Some(deploy_config.debug_mode),
+        debug_mode: deploy_config.debug_mode.into(),
         nonce: None,
         health_check_type: deploy_config.health_check_type,
         health_check_port: deploy_config.health_check_port as u32,

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -26,7 +26,7 @@ pub struct AppConfig {
     /// creation and cannot be changed after. Setting this true means the app's
     /// quorum key is considered permanently insecure.
     #[serde(default)]
-    pub enable_debug_mode_deployments: bool,
+    pub dangerous_enable_debug_mode_deployments: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ impl AppConfig {
             }),
             share_set_id: None,
             share_set_params: None,
-            enable_debug_mode_deployments: false,
+            dangerous_enable_debug_mode_deployments: false,
         }
     }
 

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -22,6 +22,11 @@ pub struct AppConfig {
     pub share_set_id: Option<String>,
     #[serde(default)]
     pub share_set_params: Option<OperatorSetParams>,
+    /// Whether this app permits debug-mode deployments. Must be set at app
+    /// creation and cannot be changed after. Setting this true means the app's
+    /// quorum key is considered permanently insecure.
+    #[serde(default)]
+    pub enable_debug_mode_deployments: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,6 +78,7 @@ impl AppConfig {
             }),
             share_set_id: None,
             share_set_params: None,
+            enable_debug_mode_deployments: false,
         }
     }
 

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -21,8 +21,11 @@ pub struct DeployConfig {
     #[serde(default)]
     pub pivot_args: Vec<String>,
     pub expected_pivot_digest: String,
+    /// Deploy in debug mode. A deployment with debug enabled is permanently
+    /// marked insecure: enclave logs are forwarded to the host and attestation
+    /// PCRs are zeroed, so anything the enclave processed may have leaked.
     #[serde(default)]
-    pub debug_mode: Option<bool>,
+    pub debug_mode: bool,
     #[serde(default)]
     pub pivot_container_encrypted_pull_secret: Option<String>,
     pub health_check_type: TvcHealthCheckType,
@@ -41,7 +44,7 @@ impl DeployConfig {
             pivot_path: "<FILL_IN_PIVOT_PATH>".to_string(),
             pivot_args: vec![],
             expected_pivot_digest: "<FILL_IN_EXPECTED_PIVOT_DIGEST>".to_string(),
-            debug_mode: Some(false),
+            debug_mode: false,
             pivot_container_encrypted_pull_secret: Some(PULL_SECRET_PLACEHOLDER.to_string()),
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -14,6 +14,9 @@ pub struct DeployConfig {
     #[serde(default)]
     pub pivot_args: Vec<String>,
     pub expected_pivot_digest: String,
+    /// Deploy in debug mode. A deployment with debug enabled is permanently
+    /// marked insecure: enclave logs are forwarded to the host and attestation
+    /// PCRs are zeroed, so anything the enclave processed may have leaked.
     #[serde(default)]
     pub debug_mode: Option<bool>,
     #[serde(default)]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -25,7 +25,7 @@ pub struct DeployConfig {
     /// marked insecure: enclave logs are forwarded to the host and attestation
     /// PCRs are zeroed, so anything the enclave processed may have leaked.
     #[serde(default)]
-    pub debug_mode: bool,
+    pub dangerous_deploy_debug_mode: bool,
     #[serde(default)]
     pub pivot_container_encrypted_pull_secret: Option<String>,
     pub health_check_type: TvcHealthCheckType,
@@ -44,7 +44,7 @@ impl DeployConfig {
             pivot_path: "<FILL_IN_PIVOT_PATH>".to_string(),
             pivot_args: vec![],
             expected_pivot_digest: "<FILL_IN_EXPECTED_PIVOT_DIGEST>".to_string(),
-            debug_mode: false,
+            dangerous_deploy_debug_mode: false,
             pivot_container_encrypted_pull_secret: Some(PULL_SECRET_PLACEHOLDER.to_string()),
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,


### PR DESCRIPTION
## Summary

Debug-mode deployments expose enclave logs and zero out attestation PCRs, permanently marking an app's quorum key insecure. To make that risk explicit, debug-mode deployment requires a **two-step opt-in**: an app-level flag set at creation, plus a per-deployment flag that the server only accepts for capable apps. Attempting a debug-mode deployment on an app that isn't opted in will error from `mono`.

This is implemented in [mono PR 6314](https://github.com/tkhq/mono/pull/6314/).

This PR adds equivalent functionality to the Rust SDK with the updated protos/intents. The SDK config fields, env vars, and CLI args all use a unified `dangerous*` term to make the risk explicit; the proto intent fields (`enable_debug_mode_deployments`, `debug_mode`) keep their server-defined names.

### `tvc app create`

New flag:

| Flag | Env var | Default |
| --- | --- | --- |
| `--dangerous-enable-debug-mode-deployments` | `TVC_DANGEROUS_ENABLE_DEBUG_MODE_DEPLOYMENTS` | `false` |

New JSON config field:

```json
{
  "dangerousEnableDebugModeDeployments": false
}
```

> [!WARNING]
> Cannot be changed after the app is created. To move between debug-capable and non-debug, create a new app with a fresh quorum key.

---

### `tvc deploy create`

| Old | New |
| --- | --- |
| `--debug-mode` | `--dangerous-deploy-debug-mode` |
| `TVC_DEBUG_MODE` | `TVC_DANGEROUS_DEPLOY_DEBUG_MODE` |
| `debugMode` (config) | `dangerousDeployDebugMode` (config) |

`--debug-mode` was previously a no-op, so this breaking change is fine.

The server rejects debug-mode deployments for apps that weren't created with `--dangerous-enable-debug-mode-deployments`.

The JSON deploy config's `dangerousDeployDebugMode` field is a plain `bool` (defaults to `false` when omitted) rather than `bool | null`. Existing configs with `true`, `false`, or the field omitted keep working unchanged.

---

### Override order

Standard value flags follow the existing `clap` order:

```
CLI flag > env var > config file
```

**Exception — the debug flags are opt-in only.** As bare booleans, clap can't tell "flag absent" from "explicitly false", so they don't follow strict override order: passing the flag (or env var) turns debug mode **on**, but omitting it does **not** turn off debug mode enabled in the config. Debug mode is on if *either* source enables it; the flag can never disable it.

---

### Proto

Synced `proto/external/data/v1/tvc.proto` and `proto/immutable/activity/v1/activity.proto` from [mono PR #6314](https://github.com/tkhq/mono/pull/6314) to pick up the new `enable_debug_mode_deployments` field on `CreateTvcAppIntent` and `TvcApp`.
