### PR TITLE
feat(tvc): programmatic `tvc deploy create`

### DIFF
--- a/tvc/README.md
+++ b/tvc/README.md
@@ -23,6 +23,38 @@ Special rules:
 
 `tvc deploy create` accepts `--config-file` *or* the equivalent flags (`--app-id`, `--qos-version`, `--pivot-image-url`, `--pivot-path`, `--expected-pivot-digest`, plus optional fields). `tvc app create` and `tvc keys generate-quorum-key` require `--config-file` because their configs include nested arrays.
 
+## Authentication
+
+For **local use**, run `tvc login` once and the CLI will read `~/.config/turnkey/` thereafter.
+
+For **programmatic use** (GitHub Actions, etc.), set these four env vars to authenticate directly without touching disk:
+
+| Env | Source |
+|---|---|
+| `TVC_ORG_ID` | your Turnkey organization UUID |
+| `TVC_API_BASE_URL` | e.g. `https://api.turnkey.com` |
+| `TVC_API_KEY_PUBLIC` | hex-encoded compressed P256 public key |
+| `TVC_API_KEY_PRIVATE` | hex-encoded P256 private key |
+
+When all four are present, every command authenticates directly from env. Setting some but not all is rejected.
+
+The typical flow: run `tvc login` once locally to generate an API key, register the public key in the Turnkey dashboard, then store the values in your CI's secret store (e.g. `TVC_API_KEY_PRIVATE` as a GitHub Secret, the rest as GitHub Variables).
+
+### Example: CI deploy with no config file
+
+```bash
+TVC_ORG_ID=...                      \
+TVC_API_BASE_URL=...                \
+TVC_API_KEY_PUBLIC=...              \
+TVC_API_KEY_PRIVATE=...             \
+TVC_APP_ID=...                      \
+TVC_QOS_VERSION=...                 \
+TVC_PIVOT_PATH=...                  \
+TVC_PIVOT_IMAGE_URL=...             \
+TVC_EXPECTED_PIVOT_DIGEST=...       \
+  tvc deploy create
+```
+
 ## Usage
 
 ### Create an App

--- a/tvc/README.md
+++ b/tvc/README.md
@@ -27,16 +27,17 @@ Special rules:
 
 For **local use**, run `tvc login` once and the CLI will read `~/.config/turnkey/` thereafter.
 
-For **programmatic use** (GitHub Actions, etc.), set these four env vars to authenticate directly without touching disk:
+For **programmatic use** (GitHub Actions, etc.), set these three env vars to authenticate directly without touching disk:
 
 | Env | Source |
 |---|---|
 | `TVC_ORG_ID` | your Turnkey organization UUID |
-| `TVC_API_BASE_URL` | e.g. `https://api.turnkey.com` |
 | `TVC_API_KEY_PUBLIC` | hex-encoded compressed P256 public key |
 | `TVC_API_KEY_PRIVATE` | hex-encoded P256 private key |
 
-When all four are present, every command authenticates directly from env. Setting some but not all is rejected.
+`TVC_API_BASE_URL` is optional and defaults to `https://api.turnkey.com`.
+
+When all three required vars are present, every command authenticates directly from env. Setting some but not all is rejected.
 
 The typical flow: run `tvc login` once locally to generate an API key, register the public key in the Turnkey dashboard, then store the values in your CI's secret store (e.g. `TVC_API_KEY_PRIVATE` as a GitHub Secret, the rest as GitHub Variables).
 
@@ -44,7 +45,6 @@ The typical flow: run `tvc login` once locally to generate an API key, register 
 
 ```bash
 TVC_ORG_ID=...                      \
-TVC_API_BASE_URL=...                \
 TVC_API_KEY_PUBLIC=...              \
 TVC_API_KEY_PRIVATE=...             \
 TVC_APP_ID=...                      \

--- a/tvc/README.md
+++ b/tvc/README.md
@@ -8,21 +8,6 @@ CLI for [Turnkey Verifiable Cloud](https://turnkey.com) - see [this guide](https
 cargo install tvc
 ```
 
-## Configuration precedence
-
-Configuration values are resolved in this order, highest priority first:
-
-1. Command-line flag (e.g. `--app-id`)
-2. Environment variable (e.g. `TVC_APP_ID`)
-3. Config file value (`--config-file`)
-4. Built-in default
-
-Special rules:
-
-- `--pivot-args` replaces the config file's list entirely (does not append).
-
-`tvc deploy create` accepts `--config-file` *or* the equivalent flags (`--app-id`, `--qos-version`, `--pivot-image-url`, `--pivot-path`, `--expected-pivot-digest`, plus optional fields). `tvc app create` and `tvc keys generate-quorum-key` require `--config-file` because their configs include nested arrays.
-
 ## Authentication
 
 For **local use**, run `tvc login` once and the CLI will read `~/.config/turnkey/` thereafter.
@@ -35,25 +20,13 @@ For **programmatic use** (GitHub Actions, etc.), set these three env vars to aut
 | `TVC_API_KEY_PUBLIC` | hex-encoded compressed P256 public key |
 | `TVC_API_KEY_PRIVATE` | hex-encoded P256 private key |
 
-`TVC_API_BASE_URL` is optional and defaults to `https://api.turnkey.com`.
-
-When all three required vars are present, every command authenticates directly from env. Setting some but not all is rejected.
+When all three required vars are present, every command authenticates directly from env. Env vars take precedence over local config files. Setting some but not all is rejected.
 
 The typical flow: run `tvc login` once locally to generate an API key, register the public key in the Turnkey dashboard, then store the values in your CI's secret store (e.g. `TVC_API_KEY_PRIVATE` as a GitHub Secret, the rest as GitHub Variables).
 
-### Example: CI deploy with no config file
-
-```bash
-TVC_ORG_ID=...                      \
-TVC_API_KEY_PUBLIC=...              \
-TVC_API_KEY_PRIVATE=...             \
-TVC_APP_ID=...                      \
-TVC_QOS_VERSION=...                 \
-TVC_PIVOT_PATH=...                  \
-TVC_PIVOT_IMAGE_URL=...             \
-TVC_EXPECTED_PIVOT_DIGEST=...       \
-  tvc deploy create
-```
+Some commands support environment variables and command-line flags for
+programmatic use. Run command help, such as `tvc deploy create --help`, to see
+the supported inputs and precedence for that command.
 
 ## Usage
 
@@ -82,6 +55,9 @@ tvc deploy init --output my-deploy.json
 
 # Create the deployment
 tvc deploy create --config-file my-deploy.json
+
+# To create a deployment without a config file, see:
+tvc deploy create --help
 
 # Recommended: uses GetTvcDeployment to fetch manifest and manifest_id automatically
 tvc deploy approve \

--- a/tvc/README.md
+++ b/tvc/README.md
@@ -8,6 +8,21 @@ CLI for [Turnkey Verifiable Cloud](https://turnkey.com) - see [this guide](https
 cargo install tvc
 ```
 
+## Configuration precedence
+
+Configuration values are resolved in this order, highest priority first:
+
+1. Command-line flag (e.g. `--app-id`)
+2. Environment variable (e.g. `TVC_APP_ID`)
+3. Config file value (`--config-file`)
+4. Built-in default
+
+Special rules:
+
+- `--pivot-args` replaces the config file's list entirely (does not append).
+
+`tvc deploy create` accepts `--config-file` *or* the equivalent flags (`--app-id`, `--qos-version`, `--pivot-image-url`, `--pivot-path`, `--expected-pivot-digest`, plus optional fields). `tvc app create` and `tvc keys generate-quorum-key` require `--config-file` because their configs include nested arrays.
+
 ## Usage
 
 ### Create an App

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -19,9 +19,8 @@ Special rules:
 Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.
   CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
-         env vars to authenticate without files. TVC_API_BASE_URL is
-         optional (defaults to https://api.turnkey.com). Setting some
-         but not all three required vars will error.";
+         env vars to authenticate without files. Setting some but not all
+         three required vars will error.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -18,9 +18,10 @@ Special rules:
 
 Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.
-  CI:    set TVC_ORG_ID, TVC_API_BASE_URL, TVC_API_KEY_PUBLIC, and
-         TVC_API_KEY_PRIVATE env vars to authenticate without files.
-         Setting some but not all four will error.";
+  CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
+         env vars to authenticate without files. TVC_API_BASE_URL is
+         optional (defaults to https://api.turnkey.com). Setting some
+         but not all three required vars will error.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
 const LONG_ABOUT: &str = "\
 CLI for building with Turnkey Verifiable Cloud.
 
+Some commands accept multiple configuration input types.
 Configuration values are resolved in this order, highest priority first:
   1. Command-line flag (e.g. --app-id)
   2. Environment variable (e.g. TVC_APP_ID)
@@ -19,7 +20,7 @@ Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.
   CI:    set TVC_ORG_ID, TVC_API_BASE_URL, TVC_API_KEY_PUBLIC, and
          TVC_API_KEY_PRIVATE env vars to authenticate without files.
-         Setting some but not all four will fail to avoid unexpected operations";
+         Setting some but not all four will error.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -3,9 +3,21 @@
 use crate::commands;
 use clap::{Parser, Subcommand};
 
+const LONG_ABOUT: &str = "\
+CLI for building with Turnkey Verifiable Cloud.
+
+Configuration values are resolved in this order, highest priority first:
+  1. Command-line flag (e.g. --app-id)
+  2. Environment variable (e.g. TVC_APP_ID)
+  3. Config file value (--config-file)
+  4. Built-in default
+
+Special rules:
+  --pivot-args replaces the config file's list entirely (does not append)";
+
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]
-#[command(about = "CLI for building with Turnkey Verifiable Cloud", long_about = None)]
+#[command(about = "CLI for building with Turnkey Verifiable Cloud", long_about = LONG_ABOUT)]
 pub struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -19,8 +19,8 @@ Special rules:
 Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.
   CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
-         env vars to authenticate without files. Setting some but not all
-         three required vars will error.";
+         to authenticate without files. Env vars take precedence over local
+         config files. Setting some but not all three required vars will error.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]
@@ -100,6 +100,7 @@ enum DeployCommands {
     /// Get the status of a deployment.
     Status(commands::deploy::status::Args),
     /// Create a new deployment from a config file.
+    #[command(long_about = commands::deploy::create::LONG_ABOUT)]
     Create(commands::deploy::create::Args),
     /// Generate a template deployment configuration file.
     Init(commands::deploy::init::Args),

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -13,7 +13,13 @@ Configuration values are resolved in this order, highest priority first:
   4. Built-in default
 
 Special rules:
-  --pivot-args replaces the config file's list entirely (does not append)";
+  --pivot-args replaces the config file's list entirely (does not append)
+
+Authentication:
+  Local: run `tvc login` once; commands then read ~/.config/turnkey/.
+  CI:    set TVC_ORG_ID, TVC_API_BASE_URL, TVC_API_KEY_PUBLIC, and
+         TVC_API_KEY_PRIVATE env vars to authenticate without files.
+         Setting some but not all four will fail to avoid unexpected operations";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -1,9 +1,15 @@
 //! Client utilities for authenticated API calls.
 
 use crate::config::turnkey::{Config, StoredApiKey};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::TurnkeyClient;
+
+const NUM_AUTH_ENV_VARS: usize = 4;
+const ENV_ORG_ID: &str = "TVC_ORG_ID";
+const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
+const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
+const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
 
 /// An authenticated Turnkey client with organization context.
 pub struct AuthenticatedClient {
@@ -15,33 +21,117 @@ pub struct AuthenticatedClient {
     pub api_base_url: String,
 }
 
-/// Build an authenticated Turnkey client from the local config.
+/// Build an authenticated Turnkey client.
 ///
-/// Loads the active organization and API key from `~/.config/turnkey/`.
-/// Returns an error if not logged in.
+/// Prefers direct env auth (CI use case): if all required env vars are set, builds the
+/// client from env
+///
+/// Otherwise falls back to loading from `~/.config/turnkey/` (after `tvc login`).
+///
+/// If only some of the four env vars are set, errors with the list of missing
+/// names — no silent fallback to disk.
 pub async fn build_client() -> Result<AuthenticatedClient> {
+    // Try env first; fall back to disk config.
+    let (org_id, api_base_url, api_key_public, api_key_private) = match load_credentials_from_env_vars()? {
+        Some(creds) => creds,
+        None => load_credentials_from_config().await?,
+    };
+    build_authed_client(&org_id, &api_base_url, &api_key_public, &api_key_private)
+}
+
+async fn load_credentials_from_config() -> Result<(String, String, String, String)> {
     let config = Config::load().await?;
 
     let (alias, org_config) = config
         .active_org_config()
-        .ok_or_else(|| anyhow::anyhow!("No active organization. Run `tvc login` first."))?;
+        .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?;
 
-    let api_key = StoredApiKey::load(org_config).await?.ok_or_else(|| {
-        anyhow::anyhow!("No API key found for org '{alias}'. Run `tvc login` first.")
-    })?;
+    let api_key = StoredApiKey::load(org_config)
+        .await?
+        .ok_or_else(|| anyhow!("No API key found for org '{alias}'. Run `tvc login` first."))?;
 
-    let stamper = TurnkeyP256ApiKey::from_strings(&api_key.private_key, Some(&api_key.public_key))
+    Ok((
+        org_config.id.clone(),
+        org_config.api_base_url.clone(),
+        api_key.public_key.clone(),
+        api_key.private_key.clone(),
+    ))
+}
+
+fn build_authed_client(
+    org_id: &str,
+    api_base_url: &str,
+    api_key_public: &str,
+    api_key_private: &str,
+) -> Result<AuthenticatedClient> {
+    let stamper = TurnkeyP256ApiKey::from_strings(api_key_private, Some(api_key_public))
         .context("failed to load API key")?;
 
     let client = TurnkeyClient::builder()
         .api_key(stamper)
-        .base_url(&org_config.api_base_url)
+        .base_url(api_base_url)
         .build()
         .context("failed to build Turnkey client")?;
 
     Ok(AuthenticatedClient {
         client,
-        org_id: org_config.id.clone(),
-        api_base_url: org_config.api_base_url.clone(),
+        org_id: org_id.to_string(),
+        api_base_url: api_base_url.to_string(),
     })
+}
+
+/// Read an env var, treating empty strings as unset. CI tools may default missing
+/// secrets/vars to `""` which could cause downstream errors.
+fn read_env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+/// Parse auth env vars for building client.
+///
+/// - `Ok(None)`: none set; caller should fall back to disk.
+/// - `Ok(Some((org_id, api_base_url, api_key_public, api_key_private)))`: all four set.
+/// - `Err`: only some are set; the error names which.
+fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, String)>> {
+    let org_id = read_env_var(ENV_ORG_ID);
+    let api_base_url = read_env_var(ENV_API_BASE_URL);
+    let api_key_public = read_env_var(ENV_API_KEY_PUBLIC);
+    let api_key_private = read_env_var(ENV_API_KEY_PRIVATE);
+
+    let mut missing: Vec<&str> = Vec::new();
+    if org_id.is_none() {
+        missing.push(ENV_ORG_ID);
+    }
+    if api_base_url.is_none() {
+        missing.push(ENV_API_BASE_URL);
+    }
+    if api_key_public.is_none() {
+        missing.push(ENV_API_KEY_PUBLIC);
+    }
+    if api_key_private.is_none() {
+        missing.push(ENV_API_KEY_PRIVATE);
+    }
+
+    // Acceptable to have none set: fall back to disk.
+    if missing.len() == NUM_AUTH_ENV_VARS {
+        return Ok(None);
+    }
+
+    // Partial: bail with the list of missing names.
+    if !missing.is_empty() {
+        bail!(
+            "partial env var auth: missing {}. Set all four ({}, {}, {}, {}) env vars or none.",
+            missing.join(", "),
+            ENV_ORG_ID,
+            ENV_API_BASE_URL,
+            ENV_API_KEY_PUBLIC,
+            ENV_API_KEY_PRIVATE,
+        );
+    }
+
+    Ok(Some((
+        org_id.unwrap(),
+        api_base_url.unwrap(),
+        api_key_public.unwrap(),
+        api_key_private.unwrap(),
+    )))
 }

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -23,15 +23,14 @@ pub struct AuthenticatedClient {
 
 /// Build an authenticated Turnkey client.
 ///
-/// Prefers direct env auth (CI use case): if all required env vars are set, builds the
-/// client from env
+/// Prefers env auth (CI use case): if all required env vars are set, builds the
+/// client from env vars
 ///
-/// Otherwise falls back to loading from `~/.config/turnkey/` (after `tvc login`).
+/// Otherwise, falls back to loading from `~/.config/turnkey/` (after `tvc login`).
 ///
 /// If only some of the four env vars are set, errors with the list of missing
-/// names — no silent fallback to disk.
+/// names — no merged resolve between env and disk vars
 pub async fn build_client() -> Result<AuthenticatedClient> {
-    // Try env first; fall back to disk config.
     let (org_id, api_base_url, api_key_public, api_key_private) = match load_credentials_from_env_vars()? {
         Some(creds) => creds,
         None => load_credentials_from_config().await?,

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -5,11 +5,14 @@ use anyhow::{anyhow, bail, Context, Result};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::TurnkeyClient;
 
-const NUM_AUTH_ENV_VARS: usize = 4;
+/// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
+/// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.
+const NUM_AUTH_ENV_VARS: usize = 3;
 const ENV_ORG_ID: &str = "TVC_ORG_ID";
 const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
 const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
 const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const DEFAULT_API_BASE_URL: &str = "https://api.turnkey.com";
 
 /// An authenticated Turnkey client with organization context.
 pub struct AuthenticatedClient {
@@ -23,13 +26,14 @@ pub struct AuthenticatedClient {
 
 /// Build an authenticated Turnkey client.
 ///
-/// Prefers env auth (CI use case): if all required env vars are set, builds the
-/// client from env vars
+/// Prefers env auth (CI use case): if `TVC_ORG_ID`, `TVC_API_KEY_PUBLIC`, and
+/// `TVC_API_KEY_PRIVATE` are all set, builds the client from env vars.
+/// `TVC_API_BASE_URL` is optional and defaults to `https://api.turnkey.com`.
 ///
 /// Otherwise, falls back to loading from `~/.config/turnkey/` (after `tvc login`).
 ///
-/// If only some of the four env vars are set, errors with the list of missing
-/// names — no merged resolve between env and disk vars
+/// If only some of the three required env vars are set, errors with the list of
+/// missing names — no merged resolve between env and disk vars.
 pub async fn build_client() -> Result<AuthenticatedClient> {
     let (org_id, api_base_url, api_key_public, api_key_private) = match load_credentials_from_env_vars()? {
         Some(creds) => creds,
@@ -87,21 +91,21 @@ fn read_env_var(name: &str) -> Option<String> {
 
 /// Parse auth env vars for building client.
 ///
-/// - `Ok(None)`: none set; caller should fall back to disk.
-/// - `Ok(Some((org_id, api_base_url, api_key_public, api_key_private)))`: all four set.
-/// - `Err`: only some are set; the error names which.
+/// - `Ok(None)`: none of the required env vars set; caller should fall back to disk.
+/// - `Ok(Some((org_id, api_base_url, api_key_public, api_key_private)))`: all three
+///   required vars set; `api_base_url` falls back to the default if unset.
+/// - `Err`: only some of the required vars are set; the error names which.
 fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, String)>> {
     let org_id = read_env_var(ENV_ORG_ID);
-    let api_base_url = read_env_var(ENV_API_BASE_URL);
     let api_key_public = read_env_var(ENV_API_KEY_PUBLIC);
     let api_key_private = read_env_var(ENV_API_KEY_PRIVATE);
+    // Optional; defaults to prod if unset.
+    let api_base_url =
+        read_env_var(ENV_API_BASE_URL).unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string());
 
     let mut missing: Vec<&str> = Vec::new();
     if org_id.is_none() {
         missing.push(ENV_ORG_ID);
-    }
-    if api_base_url.is_none() {
-        missing.push(ENV_API_BASE_URL);
     }
     if api_key_public.is_none() {
         missing.push(ENV_API_KEY_PUBLIC);
@@ -118,10 +122,9 @@ fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, St
     // Partial: bail with the list of missing names.
     if !missing.is_empty() {
         bail!(
-            "partial env var auth: missing {}. Set all four ({}, {}, {}, {}) env vars or none.",
+            "partial env var auth: missing {}. Set all three ({}, {}, {}) env vars or none.",
             missing.join(", "),
             ENV_ORG_ID,
-            ENV_API_BASE_URL,
             ENV_API_KEY_PUBLIC,
             ENV_API_KEY_PRIVATE,
         );
@@ -129,7 +132,7 @@ fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, St
 
     Ok(Some((
         org_id.unwrap(),
-        api_base_url.unwrap(),
+        api_base_url,
         api_key_public.unwrap(),
         api_key_private.unwrap(),
     )))

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -1,21 +1,58 @@
-//! Deploy create command - creates a deployment from a config file.
+//! Deploy create command - creates a deployment from a config file or CLI flags.
 
 use crate::client::build_client;
 use crate::config::deploy::DeployConfig;
 use crate::pull_secret::encrypt_pivot_pull_secret;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
 
-/// Create a new TVC deployment from a config file.
+/// Create a new TVC deployment from a config file or CLI flags.
 #[derive(Debug, ClapArgs)]
 #[command(about, long_about = None)]
 pub struct Args {
     /// Path to the deployment configuration file (JSON).
+    /// Optional when all required fields are provided via flags or env.
     #[arg(short = 'c', long, value_name = "PATH", env = "TVC_DEPLOY_CONFIG")]
-    pub config_file: PathBuf,
+    pub config_file: Option<PathBuf>,
+
+    /// Override the appId field.
+    #[arg(long, env = "TVC_APP_ID")]
+    pub app_id: Option<String>,
+
+    /// Override the qosVersion field.
+    #[arg(long, env = "TVC_QOS_VERSION")]
+    pub qos_version: Option<String>,
+
+    /// Override the pivotContainerImageUrl field.
+    #[arg(long, env = "TVC_PIVOT_IMAGE_URL")]
+    pub pivot_image_url: Option<String>,
+
+    /// Override the expectedPivotDigest field.
+    #[arg(long, env = "TVC_EXPECTED_PIVOT_DIGEST")]
+    pub expected_pivot_digest: Option<String>,
+
+    /// Override the pivotPath field.
+    #[arg(long, env = "TVC_PIVOT_PATH")]
+    pub pivot_path: Option<String>,
+
+    /// Override pivotArgs (replaces the file's list entirely; not appended).
+    #[arg(long, value_name = "ARG", value_delimiter = ',', env = "TVC_PIVOT_ARGS")]
+    pub pivot_args: Vec<String>,
+
+    /// Enable debug mode. One-way: cannot disable a `true` set earlier via the file.
+    #[arg(long, env = "TVC_DEBUG_MODE")]
+    pub debug_mode: bool,
+
+    /// Override the healthCheckPort field.
+    #[arg(long, env = "TVC_HEALTH_CHECK_PORT")]
+    pub health_check_port: Option<u16>,
+
+    /// Override the publicIngressPort field.
+    #[arg(long, env = "TVC_PUBLIC_INGRESS_PORT")]
+    pub public_ingress_port: Option<u16>,
 
     /// Path to an unencrypted pivot container pull secret file.
     ///
@@ -66,27 +103,75 @@ fn pin_image_url(image_url: &str, resolved_digest: &str) -> String {
     }
 }
 
-/// Run the deploy create command.
-pub async fn run(args: Args) -> Result<()> {
-    // Read and parse config file
-    let config_content = std::fs::read_to_string(&args.config_file)
-        .with_context(|| format!("failed to read config file: {}", args.config_file.display()))?;
+fn apply_overrides(config: &mut DeployConfig, args: &Args) {
+    if let Some(v) = &args.app_id {
+        config.app_id = v.clone();
+    }
+    if let Some(v) = &args.qos_version {
+        config.qos_version = v.clone();
+    }
+    if let Some(v) = &args.pivot_image_url {
+        config.pivot_container_image_url = v.clone();
+    }
+    if let Some(v) = &args.expected_pivot_digest {
+        config.expected_pivot_digest = v.clone();
+    }
+    if let Some(v) = &args.pivot_path {
+        config.pivot_path = v.clone();
+    }
+    if !args.pivot_args.is_empty() {
+        config.pivot_args = args.pivot_args.clone();
+    }
+    // One-way: only ever flips false -> true.
+    if args.debug_mode {
+        config.debug_mode = Some(true);
+    }
+    if let Some(v) = args.health_check_port {
+        config.health_check_port = v;
+    }
+    if let Some(v) = args.public_ingress_port {
+        config.public_ingress_port = v;
+    }
+}
 
-    let deploy_config: DeployConfig = serde_json::from_str(&config_content).with_context(|| {
-        format!(
-            "failed to parse config file: {}",
-            args.config_file.display()
-        )
-    })?;
+fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
+    let mut config = match &args.config_file {
+        Some(path) => {
+            let content = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read config file: {}", path.display()))?;
+            serde_json::from_str(&content)
+                .with_context(|| format!("failed to parse config file: {}", path.display()))?
+        }
+        None => {
+            let mut t = DeployConfig::template(None);
+            // Strip the template's "<REMOVE_ME...>" hint so flag-only mode
+            // doesn't ship it to the API for public images.
+            t.pivot_container_encrypted_pull_secret = None;
+            t
+        }
+    };
 
-    // Validate config
-    if deploy_config.has_placeholders() {
-        anyhow::bail!(
-            "Config file contains placeholder values (<FILL_IN_...>). \
-             Please edit {} and fill in all required values.",
-            args.config_file.display()
+    apply_overrides(&mut config, args);
+
+    let missing = config.missing_required_fields();
+    if !missing.is_empty() {
+        let suggestion = if args.config_file.is_some() {
+            "Edit the config file or override via flag/TVC_* env."
+        } else {
+            "Provide via flag, TVC_* env, or --config-file."
+        };
+        bail!(
+            "missing required values: {}. {suggestion}",
+            missing.join(", ")
         );
     }
+
+    Ok(config)
+}
+
+/// Run the deploy create command.
+pub async fn run(args: Args) -> Result<()> {
+    let deploy_config = resolve_deploy_config(&args)?;
 
     println!("Creating deployment for app '{}'...", deploy_config.app_id);
 
@@ -100,7 +185,7 @@ pub async fn run(args: Args) -> Result<()> {
             })?;
 
             if pull_secret.trim().is_empty() {
-                anyhow::bail!(
+                bail!(
                     "pivot pull secret file is empty after trimming whitespace: {}",
                     path.display()
                 );
@@ -156,7 +241,9 @@ pub async fn run(args: Args) -> Result<()> {
     println!();
     println!("Deployment ID: {}", result.result.deployment_id);
     println!("App ID: {}", deploy_config.app_id);
-    println!("Config: {}", args.config_file.display());
+    if let Some(path) = &args.config_file {
+        println!("Config: {}", path.display());
+    }
     println!();
     println!("Next steps:");
     println!(

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -260,21 +260,137 @@ pub async fn run(args: Args) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::pin_image_url;
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn pin_image_url_appends_digest_to_tagged_reference() {
-        let image_url = "ghcr.io/team/app:latest";
-        let pinned = pin_image_url(image_url, "sha256:abc123");
-
+        let pinned = pin_image_url("ghcr.io/team/app:latest", "sha256:abc123");
         assert_eq!(pinned, "ghcr.io/team/app:latest@sha256:abc123");
     }
 
     #[test]
     fn pin_image_url_appends_digest_to_untagged_reference() {
-        let image_url = "ghcr.io/team/app";
-        let pinned = pin_image_url(image_url, "sha256:abc123");
-
+        let pinned = pin_image_url("ghcr.io/team/app", "sha256:abc123");
         assert_eq!(pinned, "ghcr.io/team/app@sha256:abc123");
+    }
+
+    fn empty_args() -> Args {
+        Args {
+            config_file: None,
+            app_id: None,
+            qos_version: None,
+            pivot_image_url: None,
+            expected_pivot_digest: None,
+            pivot_path: None,
+            pivot_args: vec![],
+            debug_mode: false,
+            health_check_port: None,
+            public_ingress_port: None,
+            pivot_pull_secret: None,
+        }
+    }
+
+    fn all_required_flags() -> Args {
+        Args {
+            app_id: Some("flag-app-id".into()),
+            qos_version: Some("flag-qos".into()),
+            pivot_image_url: Some("flag-image".into()),
+            expected_pivot_digest: Some("flag-digest".into()),
+            pivot_path: Some("flag-path".into()),
+            ..empty_args()
+        }
+    }
+
+    fn file_config() -> DeployConfig {
+        let mut c = DeployConfig::template(None);
+        c.app_id = "file-app-id".into();
+        c.qos_version = "file-qos".into();
+        c.pivot_container_image_url = "file-image".into();
+        c.pivot_path = "file-path".into();
+        c.pivot_args = vec!["a".into(), "b".into()];
+        c.expected_pivot_digest = "file-digest".into();
+        c.debug_mode = Some(false);
+        c.pivot_container_encrypted_pull_secret = None;
+        c.health_check_port = 4000;
+        c.public_ingress_port = 5000;
+        c
+    }
+
+    fn write_config(config: &DeployConfig) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(serde_json::to_string(config).unwrap().as_bytes())
+            .unwrap();
+        f
+    }
+
+    #[test]
+    fn flag_overrides_file_value() {
+        let file = write_config(&file_config());
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            app_id: Some("flag-app-id".into()),
+            ..empty_args()
+        };
+        let resolved = resolve_deploy_config(&args).unwrap();
+        assert_eq!(resolved.app_id, "flag-app-id");
+        // Untouched fields keep their file values.
+        assert_eq!(resolved.qos_version, "file-qos");
+        assert_eq!(resolved.health_check_port, 4000);
+    }
+
+    #[test]
+    fn file_value_used_when_flag_absent() {
+        let file = write_config(&file_config());
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            ..empty_args()
+        };
+        let resolved = resolve_deploy_config(&args).unwrap();
+        assert_eq!(resolved.app_id, "file-app-id");
+        assert_eq!(resolved.qos_version, "file-qos");
+        assert_eq!(resolved.health_check_port, 4000);
+    }
+
+    #[test]
+    fn no_file_uses_flag_only_with_template_defaults() {
+        let resolved = resolve_deploy_config(&all_required_flags()).unwrap();
+        // Required fields come from flags.
+        assert_eq!(resolved.app_id, "flag-app-id");
+        assert_eq!(resolved.qos_version, "flag-qos");
+        assert_eq!(resolved.pivot_container_image_url, "flag-image");
+        assert_eq!(resolved.pivot_path, "flag-path");
+        assert_eq!(resolved.expected_pivot_digest, "flag-digest");
+        // Optional fields fall back to template defaults.
+        assert_eq!(resolved.health_check_port, 3000);
+        assert_eq!(resolved.public_ingress_port, 3000);
+        assert_eq!(resolved.debug_mode, Some(false));
+        assert!(resolved.pivot_args.is_empty());
+        // Pull-secret placeholder cleared in flag-only mode.
+        assert_eq!(resolved.pivot_container_encrypted_pull_secret, None);
+    }
+
+    #[test]
+    fn no_file_no_required_flags_bails_naming_each_flag() {
+        let err = resolve_deploy_config(&empty_args()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--app-id"), "{msg}");
+        assert!(msg.contains("--qos-version"), "{msg}");
+        assert!(msg.contains("--pivot-image-url"), "{msg}");
+        assert!(msg.contains("--pivot-path"), "{msg}");
+        assert!(msg.contains("--expected-pivot-digest"), "{msg}");
+    }
+
+    #[test]
+    fn pivot_args_flag_replaces_file_list() {
+        let file = write_config(&file_config()); // file has ["a", "b"]
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            pivot_args: vec!["c".into()],
+            ..empty_args()
+        };
+        let resolved = resolve_deploy_config(&args).unwrap();
+        assert_eq!(resolved.pivot_args, vec!["c"]);
     }
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -9,6 +9,41 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
 
+pub(crate) const LONG_ABOUT: &str = "\
+Create a new TVC deployment.
+
+Use --config-file, flags, env vars, or a mix of them. Command-line flags
+override env vars; env vars override config file values. If --config-file is
+omitted, all required deployment fields must be provided by flags or env vars.
+
+Required deployment fields:
+  --app-id / TVC_APP_ID
+  --qos-version / TVC_QOS_VERSION
+  --pivot-image-url / TVC_PIVOT_IMAGE_URL
+  --pivot-path / TVC_PIVOT_PATH
+  --expected-pivot-digest / TVC_EXPECTED_PIVOT_DIGEST
+
+Special rules:
+  --pivot-args replaces the config file's list entirely (does not append).
+  --debug-mode can enable debug mode but cannot disable a true config value.
+  --pivot-pull-secret reads an unencrypted pull secret file, encrypts it for the
+  active org's API environment, and overrides the encrypted secret in the config.
+
+Examples:
+  tvc deploy create --config-file deploy.json
+
+  # OR
+
+  TVC_ORG_ID=... \\
+  TVC_API_KEY_PUBLIC=... \\
+  TVC_API_KEY_PRIVATE=... \\
+  TVC_APP_ID=... \\
+  TVC_QOS_VERSION=... \\
+  TVC_PIVOT_PATH=... \\
+  TVC_PIVOT_IMAGE_URL=... \\
+  TVC_EXPECTED_PIVOT_DIGEST=... \\
+    tvc deploy create";
+
 /// Create a new TVC deployment from a config file or CLI flags.
 #[derive(Debug, ClapArgs)]
 #[command(about, long_about = None)]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -44,12 +44,25 @@ impl DeployConfig {
         }
     }
 
-    /// Check if config contains placeholder values.
-    pub fn has_placeholders(&self) -> bool {
-        self.app_id.starts_with("<FILL_IN")
-            || self.qos_version.starts_with("<FILL_IN")
-            || self.pivot_container_image_url.starts_with("<FILL_IN")
-            || self.pivot_path.starts_with("<FILL_IN")
-            || self.expected_pivot_digest.starts_with("<FILL_IN")
+    /// Return the user-facing flag names of fields still containing
+    /// `<FILL_IN...>` placeholders, in struct order. Empty if complete.
+    pub fn missing_required_fields(&self) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        if self.app_id.starts_with("<FILL_IN") {
+            missing.push("--app-id");
+        }
+        if self.qos_version.starts_with("<FILL_IN") {
+            missing.push("--qos-version");
+        }
+        if self.pivot_container_image_url.starts_with("<FILL_IN") {
+            missing.push("--pivot-image-url");
+        }
+        if self.pivot_path.starts_with("<FILL_IN") {
+            missing.push("--pivot-path");
+        }
+        if self.expected_pivot_digest.starts_with("<FILL_IN") {
+            missing.push("--expected-pivot-digest");
+        }
+        missing
     }
 }

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -1,0 +1,118 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use tvc::config::turnkey::{Config, KeyCurve, OrgConfig, StoredApiKey};
+
+const ENV_ORG_ID: &str = "TVC_ORG_ID";
+const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
+const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const LOCAL_API_BASE_URL: &str = "http://127.0.0.1:1";
+
+fn app_status_cmd() -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .arg("app")
+        .arg("status")
+        .arg("--app-id")
+        .arg("app_test");
+    cmd
+}
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+#[test]
+fn env_auth_accepts_all_three_required_vars() {
+    let (public_key, private_key) = generated_api_key();
+
+    app_status_cmd()
+        .env(ENV_ORG_ID, "org-env")
+        .env(ENV_API_KEY_PUBLIC, public_key)
+        .env(ENV_API_KEY_PRIVATE, private_key)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to fetch app status"))
+        .stderr(predicate::str::contains("partial env var auth").not())
+        .stderr(predicate::str::contains("failed to load API key").not());
+}
+
+#[test]
+fn env_auth_rejects_two_required_vars() {
+    let (public_key, _) = generated_api_key();
+
+    app_status_cmd()
+        .env(ENV_ORG_ID, "org-env")
+        .env(ENV_API_KEY_PUBLIC, public_key)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("partial env var auth"))
+        .stderr(predicate::str::contains(ENV_API_KEY_PRIVATE));
+}
+
+#[test]
+fn env_auth_rejects_one_required_var() {
+    app_status_cmd()
+        .env(ENV_ORG_ID, "org-env")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("partial env var auth"))
+        .stderr(predicate::str::contains(ENV_API_KEY_PUBLIC))
+        .stderr(predicate::str::contains(ENV_API_KEY_PRIVATE));
+}
+
+#[test]
+fn auth_falls_back_to_disk_config_when_required_env_vars_are_unset() {
+    let temp = TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config").join("turnkey");
+    let org_dir = turnkey_dir.join("orgs").join("test");
+    let api_key_path = org_dir.join("api_key.json");
+    let operator_key_path = org_dir.join("operator.json");
+    fs::create_dir_all(&org_dir).unwrap();
+
+    let (public_key, private_key) = generated_api_key();
+    fs::write(
+        &api_key_path,
+        serde_json::to_string_pretty(&StoredApiKey {
+            public_key,
+            private_key,
+            curve: KeyCurve::P256,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-from-disk".to_string(),
+                api_key_path,
+                operator_key_path,
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+    };
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        toml::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+
+    app_status_cmd()
+        .env("HOME", temp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to fetch app status"))
+        .stderr(predicate::str::contains("No active organization").not());
+}

--- a/tvc/tests/deploy_create_help.rs
+++ b/tvc/tests/deploy_create_help.rs
@@ -1,0 +1,61 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn deploy_create_help_documents_config_and_override_precedence() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Use --config-file, flags, env vars, or a mix of them.",
+        ))
+        .stdout(predicate::str::contains(
+            "override env vars; env vars override config file values.",
+        ))
+        .stdout(predicate::str::contains(
+            "--pivot-args replaces the config file's list entirely",
+        ));
+}
+
+#[test]
+fn deploy_create_help_documents_env_only_usage() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("TVC_ORG_ID=..."))
+        .stdout(predicate::str::contains("TVC_API_KEY_PUBLIC=..."))
+        .stdout(predicate::str::contains("TVC_API_KEY_PRIVATE=..."))
+        .stdout(predicate::str::contains("TVC_EXPECTED_PIVOT_DIGEST=..."))
+        .stdout(predicate::str::contains("# OR"))
+        .stdout(predicate::str::contains("tvc deploy create"));
+}
+
+#[test]
+fn deploy_create_help_leaves_auth_details_to_global_docs() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authentication:").not());
+}
+
+#[test]
+fn top_level_help_documents_auth_precedence() {
+    cargo_bin_cmd!("tvc")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authentication:"))
+        .stdout(predicate::str::contains("Env vars take precedence over"))
+        .stdout(predicate::str::contains("TVC_ORG_ID"))
+        .stdout(predicate::str::contains("TVC_API_KEY_PUBLIC"))
+        .stdout(predicate::str::contains("TVC_API_KEY_PRIVATE"));
+}


### PR DESCRIPTION
Adding ENV+flag overrides for `tvc deploy create` command and ENV var overrides for authenticating. 

Allows you to run `tvc deploy create` from Github CI. You first need to run `tvc login` and save the values into Github settings as secrets or variables. Sensitive values like the private key should be Github Secrets. More [info](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow)

Sample command
```bash
TVC_ORG_ID=...                      \
TVC_API_KEY_PUBLIC=...              \
TVC_API_KEY_PRIVATE=...             \
TVC_APP_ID=...                      \
TVC_QOS_VERSION=...                 \
TVC_PIVOT_PATH=...                  \
TVC_PIVOT_IMAGE_URL=...             \
TVC_EXPECTED_PIVOT_DIGEST=...       \
  tvc deploy create
```

