### PR TITLE
chore(tvc): allow non-default app shareSets

### DIFF
--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -1,7 +1,7 @@
 //! App create command - creates an app from a config file.
 
 use crate::client::build_client;
-use crate::config::app::AppConfig;
+use crate::config::app::{AppConfig, OperatorSetParams};
 use crate::config::turnkey;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
@@ -31,22 +31,9 @@ pub async fn run(args: Args) -> Result<()> {
         )
     })?;
 
-    // Validate config
-    if app_config.has_placeholders() {
-        anyhow::bail!(
-            "Config file contains placeholder values (<FILL_IN_...>). \
-             Please edit {} and fill in all required values.",
-            args.config_file.display()
-        );
-    }
-
-    // Validate operator set config
-    if app_config.manifest_set_id.is_some() && app_config.manifest_set_params.is_some() {
-        anyhow::bail!("Cannot specify both manifestSetId and manifestSetParams");
-    }
-    if app_config.manifest_set_id.is_none() && app_config.manifest_set_params.is_none() {
-        anyhow::bail!("Must specify either manifestSetId or manifestSetParams");
-    }
+    app_config
+        .validate()
+        .with_context(|| format!("invalid config file: {}", args.config_file.display()))?;
 
     println!("Creating app '{}'...", app_config.name);
 
@@ -54,44 +41,7 @@ pub async fn run(args: Args) -> Result<()> {
     let auth = build_client().await?;
 
     // Convert config to API intent
-    let intent = CreateTvcAppIntent {
-        name: app_config.name.clone(),
-        quorum_public_key: app_config.quorum_public_key.clone(),
-        manifest_set_id: app_config.manifest_set_id.clone(),
-        manifest_set_params: app_config.manifest_set_params.as_ref().map(|p| {
-            TvcOperatorSetParams {
-                name: p.name.clone(),
-                threshold: p.threshold,
-                new_operators: p
-                    .new_operators
-                    .iter()
-                    .map(|o| TvcOperatorParams {
-                        name: o.name.clone(),
-                        public_key: o.public_key.clone(),
-                    })
-                    .collect(),
-                existing_operator_ids: p.existing_operator_ids.clone(),
-            }
-        }),
-        share_set_id: None,
-        share_set_params: {
-            let p = AppConfig::share_set_params();
-            Some(TvcOperatorSetParams {
-                name: p.name,
-                threshold: p.threshold,
-                new_operators: p
-                    .new_operators
-                    .into_iter()
-                    .map(|o| TvcOperatorParams {
-                        name: o.name,
-                        public_key: o.public_key,
-                    })
-                    .collect(),
-                existing_operator_ids: p.existing_operator_ids,
-            })
-        },
-        enable_egress: app_config.external_connectivity,
-    };
+    let intent = build_create_tvc_app_intent(&app_config);
 
     // Get timestamp
     let timestamp_ms = SystemTime::now()
@@ -131,4 +81,110 @@ pub async fn run(args: Args) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
+    let share_set_params = app_config.effective_share_set_params();
+
+    CreateTvcAppIntent {
+        name: app_config.name.clone(),
+        quorum_public_key: app_config.quorum_public_key.clone(),
+        manifest_set_id: app_config.manifest_set_id.clone(),
+        manifest_set_params: app_config
+            .manifest_set_params
+            .as_ref()
+            .map(to_tvc_operator_set_params),
+        share_set_id: app_config.share_set_id.clone(),
+        share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
+        enable_egress: app_config.external_connectivity,
+    }
+}
+
+fn to_tvc_operator_set_params(params: &OperatorSetParams) -> TvcOperatorSetParams {
+    TvcOperatorSetParams {
+        name: params.name.clone(),
+        threshold: params.threshold,
+        new_operators: params
+            .new_operators
+            .iter()
+            .map(|o| TvcOperatorParams {
+                name: o.name.clone(),
+                public_key: o.public_key.clone(),
+            })
+            .collect(),
+        existing_operator_ids: params.existing_operator_ids.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::app::{OperatorParams, KNOWN_QUORUM_KEY};
+
+    fn valid_config() -> AppConfig {
+        AppConfig {
+            name: "test-app".to_string(),
+            quorum_public_key: KNOWN_QUORUM_KEY.to_string(),
+            external_connectivity: Some(false),
+            manifest_set_id: None,
+            manifest_set_params: Some(OperatorSetParams {
+                name: "manifest-set".to_string(),
+                threshold: 1,
+                new_operators: vec![OperatorParams {
+                    name: "manifest-operator".to_string(),
+                    public_key: "manifest-public-key".to_string(),
+                }],
+                existing_operator_ids: vec![],
+            }),
+            share_set_id: None,
+            share_set_params: None,
+        }
+    }
+
+    #[test]
+    fn build_intent_uses_default_share_set_params_when_omitted() {
+        let intent = build_create_tvc_app_intent(&valid_config());
+        let share_set_params = intent.share_set_params.unwrap();
+
+        assert_eq!(share_set_params.name, "dev-known-share-set");
+        assert_eq!(share_set_params.threshold, 2);
+        assert_eq!(share_set_params.new_operators.len(), 2);
+        assert!(share_set_params.existing_operator_ids.is_empty());
+    }
+
+    #[test]
+    fn build_intent_uses_custom_share_set_params_when_configured() {
+        let mut config = valid_config();
+        config.share_set_params = Some(OperatorSetParams {
+            name: "custom-share-set".to_string(),
+            threshold: 2,
+            new_operators: vec![OperatorParams {
+                name: "share-operator".to_string(),
+                public_key: "share-public-key".to_string(),
+            }],
+            existing_operator_ids: vec!["existing-operator-id".to_string()],
+        });
+
+        let intent = build_create_tvc_app_intent(&config);
+        let share_set_params = intent.share_set_params.unwrap();
+
+        assert_eq!(share_set_params.name, "custom-share-set");
+        assert_eq!(share_set_params.threshold, 2);
+        assert_eq!(share_set_params.new_operators[0].name, "share-operator");
+        assert_eq!(
+            share_set_params.existing_operator_ids,
+            vec!["existing-operator-id".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_intent_uses_share_set_id_when_configured() {
+        let mut config = valid_config();
+        config.share_set_id = Some("share-set-id".to_string());
+
+        let intent = build_create_tvc_app_intent(&config);
+
+        assert_eq!(intent.share_set_id.as_deref(), Some("share-set-id"));
+        assert!(intent.share_set_params.is_none());
+    }
 }

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -11,7 +11,13 @@ use std::path::PathBuf;
 #[command(about, long_about = None)]
 pub struct Args {
     /// Output file path.
-    #[arg(short, long, value_name = "PATH", default_value = "app.json", env = "TVC_APP_CONFIG_OUT")]
+    #[arg(
+        short,
+        long,
+        value_name = "PATH",
+        default_value = "app.json",
+        env = "TVC_APP_CONFIG_OUT"
+    )]
     pub output: PathBuf,
 }
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -1,6 +1,5 @@
 //! Approve deploy command - cryptographically approve a QOS manifest.
 
-use crate::config::app::KNOWN_SHARE_SET_KEYS;
 use crate::config::turnkey::Config;
 use crate::operator_key::load_operator_pair;
 use crate::util::{read_file_to_string, write_file};
@@ -308,37 +307,14 @@ fn review_manifest_set(set: &ManifestSet) -> anyhow::Result<()> {
 }
 
 fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
-    // Verify the share set matches the known keys (no interactive prompt)
-    let expected_keys: std::collections::HashSet<Vec<u8>> = KNOWN_SHARE_SET_KEYS
-        .iter()
-        .map(|(_, key)| hex::decode(key).expect("known key should be valid hex"))
-        .collect();
-
-    let actual_keys: std::collections::HashSet<Vec<u8>> =
-        set.members.iter().map(|m| m.pub_key.clone()).collect();
-
-    if expected_keys != actual_keys {
-        bail!(
-            "Share set public keys do not match known keys.\n\
-             Expected keys defined in KNOWN_SHARE_SET_KEYS (config/app.rs).\n\
-             Found: {:?}",
-            set.members
-                .iter()
-                .map(|m| hex::encode(&m.pub_key))
-                .collect::<Vec<_>>()
-        );
-    }
-
-    if set.threshold != 2 {
-        bail!("Share set threshold must be 2, found: {}", set.threshold);
-    }
-
     println!("SHARE SET");
     println!("─────────────────────────────────────");
-    println!("  ✓ Keys and threshold match dev known share set operators");
+    println!("  Threshold: {} of {}", set.threshold, set.members.len());
+    println!("  Members:");
+    print_quorum_members(&set.members);
     println!();
 
-    Ok(())
+    confirm("Approve share set?")
 }
 
 async fn read_manifest_from_path(path: &Path) -> anyhow::Result<Manifest> {
@@ -374,7 +350,6 @@ async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(Manifest
         .manifest
         .ok_or_else(|| anyhow!("manifest not found in deployment"))?;
 
-    // Deserialize manifest from bytes
     let manifest: Manifest = serde_json::from_slice(&tvc_manifest.manifest)
         .context("failed to parse manifest from deployment")?;
 

--- a/tvc/src/commands/keys/generate_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_quorum_key.rs
@@ -63,8 +63,12 @@ pub async fn run(args: Args) -> Result<()> {
 
     let metadata_json =
         serde_json::to_vec_pretty(&metadata).context("failed to serialize quorum key metadata")?;
-    fs::write(&args.quorum_key_metadata_out, &metadata_json)
-        .with_context(|| format!("failed to write file: {}", args.quorum_key_metadata_out.display()))?;
+    fs::write(&args.quorum_key_metadata_out, &metadata_json).with_context(|| {
+        format!(
+            "failed to write file: {}",
+            args.quorum_key_metadata_out.display()
+        )
+    })?;
 
     println!(
         "Quorum key metadata written to: {}",

--- a/tvc/src/commands/keys/init_quorum_key.rs
+++ b/tvc/src/commands/keys/init_quorum_key.rs
@@ -11,7 +11,13 @@ use std::path::PathBuf;
 #[command(about, long_about = None)]
 pub struct Args {
     /// Output file path.
-    #[arg(short, long, value_name = "PATH", default_value = "quorum_key.json", env = "TVC_QUORUM_KEY_CONFIG_OUT")]
+    #[arg(
+        short,
+        long,
+        value_name = "PATH",
+        default_value = "quorum_key.json",
+        env = "TVC_QUORUM_KEY_CONFIG_OUT"
+    )]
     pub output: PathBuf,
 }
 
@@ -40,7 +46,10 @@ pub async fn run(args: Args) -> Result<()> {
     println!("  threshold : >= 2 and <= shares");
     println!();
     println!("Edit the file to fill in your values, then run:");
-    println!("  tvc keys generate-quorum-key --config-file {}", args.output.display());
+    println!(
+        "  tvc keys generate-quorum-key --config-file {}",
+        args.output.display()
+    );
 
     Ok(())
 }

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
+
 /// App configuration loaded from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,6 +16,10 @@ pub struct AppConfig {
     pub manifest_set_id: Option<String>,
     #[serde(default)]
     pub manifest_set_params: Option<OperatorSetParams>,
+    #[serde(default)]
+    pub share_set_id: Option<String>,
+    #[serde(default)]
+    pub share_set_params: Option<OperatorSetParams>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,6 +69,8 @@ impl AppConfig {
                 }],
                 existing_operator_ids: vec![],
             }),
+            share_set_id: None,
+            share_set_params: None,
         }
     }
 
@@ -91,5 +99,126 @@ impl AppConfig {
                         .iter()
                         .any(|o| o.public_key.starts_with("<FILL_IN"))
             })
+            || self.share_set_params.as_ref().is_some_and(|p| {
+                p.name.starts_with("<FILL_IN")
+                    || p.new_operators
+                        .iter()
+                        .any(|o| o.public_key.starts_with("<FILL_IN"))
+            })
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.has_placeholders() {
+            anyhow::bail!("config contains placeholder values (<FILL_IN_...)");
+        }
+
+        if self.manifest_set_id.is_some() && self.manifest_set_params.is_some() {
+            anyhow::bail!("Cannot specify both manifestSetId and manifestSetParams");
+        }
+        if self.manifest_set_id.is_none() && self.manifest_set_params.is_none() {
+            anyhow::bail!("Must specify either manifestSetId or manifestSetParams");
+        }
+        if self.share_set_id.is_some() && self.share_set_params.is_some() {
+            anyhow::bail!("Cannot specify both shareSetId and shareSetParams");
+        }
+        // It is fine if both share set id and params are none since we support a default dev share set
+
+        if let Some(params) = &self.share_set_params {
+            if params.threshold < MIN_SHARE_SET_THRESHOLD {
+                anyhow::bail!(
+                    "shareSetParams.threshold must be >= {MIN_SHARE_SET_THRESHOLD}, got {}",
+                    params.threshold
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn effective_share_set_params(&self) -> Option<OperatorSetParams> {
+        if self.share_set_id.is_some() {
+            None
+        } else {
+            Some(
+                self.share_set_params
+                    .clone()
+                    .unwrap_or_else(Self::share_set_params),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn valid_config_json() -> serde_json::Value {
+        json!({
+            "name": "test-app",
+            "quorumPublicKey": KNOWN_QUORUM_KEY,
+            "manifestSetParams": {
+                "name": "manifest-set",
+                "threshold": 1,
+                "newOperators": [{
+                    "name": "operator-1",
+                    "publicKey": "operator-public-key"
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn validate_accepts_omitted_share_set_params() {
+        let config: AppConfig = serde_json::from_value(valid_config_json()).unwrap();
+
+        config.validate().unwrap();
+        assert_eq!(config.effective_share_set_params().unwrap().threshold, 2);
+    }
+
+    #[test]
+    fn validate_accepts_share_set_id() {
+        let mut json = valid_config_json();
+        json["shareSetId"] = json!("share-set-id");
+        let config: AppConfig = serde_json::from_value(json).unwrap();
+
+        config.validate().unwrap();
+        assert_eq!(config.share_set_id.as_deref(), Some("share-set-id"));
+        assert!(config.effective_share_set_params().is_none());
+    }
+
+    #[test]
+    fn validate_rejects_share_set_id_and_params() {
+        let mut json = valid_config_json();
+        json["shareSetId"] = json!("share-set-id");
+        json["shareSetParams"] = json!({
+            "name": "custom-share-set",
+            "threshold": 2,
+            "newOperators": []
+        });
+        let config: AppConfig = serde_json::from_value(json).unwrap();
+
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot specify both shareSetId and shareSetParams"));
+    }
+
+    #[test]
+    fn validate_rejects_low_share_set_threshold() {
+        let mut json = valid_config_json();
+        json["shareSetParams"] = json!({
+            "name": "custom-share-set",
+            "threshold": 1,
+            "newOperators": []
+        });
+        let config: AppConfig = serde_json::from_value(json).unwrap();
+
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("shareSetParams.threshold must be"));
     }
 }


### PR DESCRIPTION
This change enables users to specify a new shareSet when creating an app (instead of always defaulting to the known shares). It also allows custom specified share-sets to be approved (instead of gating on only known shares). When a share set isn't specified, the cli still defaults to known shares. 

The second commit includes the straggler files from running `make fmt`.