### PR TITLE
codegen: emit Default + #[serde(default)] for proto enum scalars

### DIFF
--- a/client/src/generated/external.activity.v1.rs
+++ b/client/src/generated/external.activity.v1.rs
@@ -6,7 +6,9 @@
 pub struct Activity {
     pub id: ::prost::alloc::string::String,
     pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub status: super::super::super::immutable::activity::v1::ActivityStatus,
+    #[serde(default)]
     pub r#type: super::super::super::immutable::activity::v1::ActivityType,
     #[serde(default)]
     pub intent: ::core::option::Option<

--- a/client/src/generated/external.data.v1.rs
+++ b/client/src/generated/external.data.v1.rs
@@ -127,6 +127,7 @@ pub struct Authenticator {
 pub struct Credential {
     pub public_key: ::prost::alloc::string::String,
     /// To distinguish the credential type (webauthn, API key)
+    #[serde(default)]
     pub r#type: super::super::super::immutable::common::v1::CredentialType,
 }
 #[derive(Debug)]
@@ -136,6 +137,7 @@ pub struct Credential {
 pub struct Policy {
     pub policy_id: ::prost::alloc::string::String,
     pub policy_name: ::prost::alloc::string::String,
+    #[serde(default)]
     pub effect: super::super::super::immutable::common::v1::Effect,
     #[serde(default)]
     pub created_at: ::core::option::Option<Timestamp>,
@@ -155,6 +157,7 @@ pub struct PrivateKey {
     pub private_key_id: ::prost::alloc::string::String,
     pub public_key: ::prost::alloc::string::String,
     pub private_key_name: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve: super::super::super::immutable::common::v1::Curve,
     #[serde(default)]
     pub addresses: ::prost::alloc::vec::Vec<Address>,
@@ -174,6 +177,7 @@ pub struct PrivateKey {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct Address {
+    #[serde(default)]
     pub format: super::super::super::immutable::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
 }
@@ -187,7 +191,9 @@ pub struct Invitation {
     pub receiver_email: ::prost::alloc::string::String,
     #[serde(default)]
     pub receiver_user_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[serde(default)]
     pub access_type: super::super::super::immutable::common::v1::AccessType,
+    #[serde(default)]
     pub status: InvitationStatus,
     #[serde(default)]
     pub created_at: ::core::option::Option<Timestamp>,
@@ -202,6 +208,7 @@ pub struct Invitation {
 pub struct Tag {
     pub tag_id: ::prost::alloc::string::String,
     pub tag_name: ::prost::alloc::string::String,
+    #[serde(default)]
     pub tag_type: TagType,
     #[serde(default)]
     pub created_at: ::core::option::Option<Timestamp>,
@@ -253,6 +260,7 @@ pub struct Config {
 pub struct Oauth2Credential {
     pub oauth2_credential_id: ::prost::alloc::string::String,
     pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub provider: super::super::super::immutable::common::v1::Oauth2Provider,
     pub client_id: ::prost::alloc::string::String,
     pub encrypted_client_secret: ::prost::alloc::string::String,
@@ -268,6 +276,7 @@ pub struct Oauth2Credential {
 pub struct FiatOnRampCredential {
     pub fiat_onramp_credential_id: ::prost::alloc::string::String,
     pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub onramp_provider: super::super::super::immutable::common::v1::FiatOnRampProvider,
     /// @inject_tag: validate:"omitempty"
     #[serde(default)]
@@ -291,8 +300,10 @@ pub struct FiatOnRampCredential {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum InvitationStatus {
     #[serde(rename = "INVITATION_STATUS_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "INVITATION_STATUS_CREATED")]
     Created = 1,
@@ -327,8 +338,10 @@ impl InvitationStatus {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum TagType {
     #[serde(rename = "TAG_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "TAG_TYPE_USER")]
     User = 1,
@@ -377,6 +390,7 @@ pub struct BootProof {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct AppProof {
+    #[serde(default)]
     pub scheme: SignatureScheme,
     pub public_key: ::prost::alloc::string::String,
     pub proof_payload: ::prost::alloc::string::String,
@@ -387,6 +401,7 @@ pub struct AppProof {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct AppProofPayload {
+    #[serde(default)]
     pub r#type: AppProofType,
     pub timestamp_ms: ::prost::alloc::string::String,
     #[serde(default)]
@@ -422,6 +437,7 @@ pub struct AddressDerivationProofPayload {
 #[derive(Clone, PartialEq)]
 pub struct PolicyOutcomeProofPayload {
     pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub outcome: super::super::super::immutable::common::v1::Outcome,
     pub decision_context_digest: ::prost::alloc::string::String,
     pub organization_data_digest: ::prost::alloc::string::String,
@@ -433,8 +449,10 @@ pub struct PolicyOutcomeProofPayload {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum SignatureScheme {
     #[serde(rename = "SIGNATURE_SCHEME_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Scheme used by our enclave applications
     #[serde(rename = "SIGNATURE_SCHEME_EPHEMERAL_KEY_P256")]
@@ -462,8 +480,10 @@ impl SignatureScheme {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum AppProofType {
     #[serde(rename = "APP_PROOF_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "APP_PROOF_TYPE_ADDRESS_DERIVATION")]
     AddressDerivation = 1,
@@ -569,6 +589,7 @@ pub struct TvcContainerSpec {
     pub args: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[serde(default)]
     pub has_pull_secret: bool,
+    #[serde(default)]
     pub health_check_type: super::super::super::immutable::common::v1::TvcHealthCheckType,
     #[serde(default)]
     pub health_check_port: u32,
@@ -670,9 +691,12 @@ pub struct WalletAccount {
     pub wallet_account_id: ::prost::alloc::string::String,
     pub organization_id: ::prost::alloc::string::String,
     pub wallet_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve: super::super::super::immutable::common::v1::Curve,
+    #[serde(default)]
     pub path_format: super::super::super::immutable::common::v1::PathFormat,
     pub path: ::prost::alloc::string::String,
+    #[serde(default)]
     pub address_format: super::super::super::immutable::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
     #[serde(default)]

--- a/client/src/generated/external.webauthn.v1.rs
+++ b/client/src/generated/external.webauthn.v1.rs
@@ -12,9 +12,11 @@ pub struct WebAuthnStamp {
 /// buf:lint:ignore ENUM_VALUE_PREFIX
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum AuthenticatorType {
     /// buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX
     #[serde(rename = "AUTHENTICATOR_TYPE_UNKNOWN")]
+    #[default]
     Unknown = 0,
     #[serde(rename = "AUTHENTICATOR_TYPE_CROSS_PLATFORM")]
     CrossPlatform = 1,

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -511,7 +511,9 @@ pub struct SignRawPayloadIntent {
     /// @inject_tag: validate:"required"
     pub payload: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub encoding: super::super::common::v1::PayloadEncoding,
+    #[serde(default)]
     pub hash_function: super::super::common::v1::HashFunction,
 }
 #[derive(Debug)]
@@ -524,7 +526,9 @@ pub struct SignRawPayloadIntentV2 {
     /// @inject_tag: validate:"required"
     pub payload: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub encoding: super::super::common::v1::PayloadEncoding,
+    #[serde(default)]
     pub hash_function: super::super::common::v1::HashFunction,
 }
 #[derive(Debug)]
@@ -538,7 +542,9 @@ pub struct SignRawPayloadsIntent {
     #[serde(default)]
     pub payloads: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub encoding: super::super::common::v1::PayloadEncoding,
+    #[serde(default)]
     pub hash_function: super::super::common::v1::HashFunction,
 }
 #[derive(Debug)]
@@ -551,6 +557,7 @@ pub struct CreatePolicyIntent {
     /// @inject_tag: validate:"required,dive,required"
     #[serde(default)]
     pub selectors: ::prost::alloc::vec::Vec<Selector>,
+    #[serde(default)]
     pub effect: super::super::common::v1::Effect,
     pub notes: ::prost::alloc::string::String,
 }
@@ -564,6 +571,7 @@ pub struct CreatePolicyIntentV2 {
     /// @inject_tag: validate:"required,dive,required"
     #[serde(default)]
     pub selectors: ::prost::alloc::vec::Vec<SelectorV2>,
+    #[serde(default)]
     pub effect: super::super::common::v1::Effect,
     pub notes: ::prost::alloc::string::String,
 }
@@ -575,6 +583,7 @@ pub struct CreatePolicyIntentV3 {
     /// @inject_tag: validate:"required,tk_label,tk_label_length"
     pub policy_name: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub effect: super::super::common::v1::Effect,
     #[serde(default)]
     pub condition: ::core::option::Option<::prost::alloc::string::String>,
@@ -633,6 +642,7 @@ pub struct CreateReadWriteSessionIntentV2 {
 #[derive(Clone, PartialEq)]
 pub struct Selector {
     pub subject: ::prost::alloc::string::String,
+    #[serde(default)]
     pub operator: super::super::common::v1::Operator,
     pub target: ::prost::alloc::string::String,
 }
@@ -642,6 +652,7 @@ pub struct Selector {
 #[derive(Clone, PartialEq)]
 pub struct SelectorV2 {
     pub subject: ::prost::alloc::string::String,
+    #[serde(default)]
     pub operator: super::super::common::v1::Operator,
     #[serde(default)]
     pub targets: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
@@ -793,6 +804,7 @@ pub struct SignTransactionIntent {
     /// @inject_tag: validate:"required"
     pub unsigned_transaction: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub r#type: super::super::common::v1::TransactionType,
 }
 #[derive(Debug)]
@@ -805,6 +817,7 @@ pub struct SignTransactionIntentV2 {
     /// @inject_tag: validate:"required"
     pub unsigned_transaction: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub r#type: super::super::common::v1::TransactionType,
 }
 #[derive(Debug)]
@@ -902,6 +915,7 @@ pub struct CreateSmartContractInterfaceIntent {
     /// @inject_tag: validate:"required,tk_max_length=400000"
     pub smart_contract_interface: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub r#type: super::super::common::v1::SmartContractInterfaceType,
     /// @inject_tag: validate:"required,tk_label,tk_label_length"
     pub label: ::prost::alloc::string::String,
@@ -1144,6 +1158,7 @@ pub struct RecoverUserIntent {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct SetOrganizationFeatureIntent {
+    #[serde(default)]
     pub name: super::super::common::v1::FeatureName,
     #[serde(default)]
     pub value: ::core::option::Option<::prost::alloc::string::String>,
@@ -1153,6 +1168,7 @@ pub struct SetOrganizationFeatureIntent {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, Copy, PartialEq)]
 pub struct RemoveOrganizationFeatureIntent {
+    #[serde(default)]
     pub name: super::super::common::v1::FeatureName,
 }
 #[derive(Debug)]
@@ -1898,12 +1914,15 @@ pub struct EmailAuthIntentV3 {
 #[derive(Clone, PartialEq)]
 pub struct InitFiatOnRampIntent {
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub onramp_provider: super::super::common::v1::FiatOnRampProvider,
     /// @inject_tag: validate:"required"
     pub wallet_address: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub network: super::super::common::v1::FiatOnRampBlockchainNetwork,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub crypto_currency_code: super::super::common::v1::FiatOnRampCryptoCurrency,
     #[serde(default)]
     pub fiat_currency_code: Option<super::super::common::v1::FiatOnRampCurrency>,
@@ -1947,6 +1966,7 @@ pub struct ImportPrivateKeyIntent {
     /// @inject_tag: validate:"required"
     pub encrypted_bundle: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
     /// @inject_tag: validate:"dive"
     #[serde(default)]
@@ -2021,6 +2041,7 @@ pub struct DeleteSubOrganizationIntent {
 #[derive(Clone, PartialEq)]
 pub struct CreateOauth2CredentialIntent {
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub provider: super::super::common::v1::Oauth2Provider,
     /// @inject_tag: validate:"required"
     pub client_id: ::prost::alloc::string::String,
@@ -2035,6 +2056,7 @@ pub struct UpdateOauth2CredentialIntent {
     /// @inject_tag: validate:"required"
     pub oauth2_credential_id: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub provider: super::super::common::v1::Oauth2Provider,
     /// @inject_tag: validate:"required"
     pub client_id: ::prost::alloc::string::String,
@@ -2105,6 +2127,7 @@ pub struct EthSendRawTransactionIntent {
 #[derive(Clone, PartialEq)]
 pub struct CreateFiatOnRampCredentialIntent {
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub onramp_provider: super::super::common::v1::FiatOnRampProvider,
     /// @inject_tag: validate:"omitempty"
     #[serde(default)]
@@ -2130,6 +2153,7 @@ pub struct UpdateFiatOnRampCredentialIntent {
     /// @inject_tag: validate:"required"
     pub fiat_onramp_credential_id: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub onramp_provider: super::super::common::v1::FiatOnRampProvider,
     /// @inject_tag: validate:"omitempty"
     #[serde(default)]
@@ -2222,6 +2246,7 @@ pub struct CreateTvcDeploymentIntent {
     >,
     #[serde(default)]
     pub debug_mode: ::core::option::Option<bool>,
+    #[serde(default)]
     pub health_check_type: super::super::common::v1::TvcHealthCheckType,
     #[serde(default)]
     pub health_check_port: u32,
@@ -2586,6 +2611,7 @@ pub struct PrivateKeyResult {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct Address {
+    #[serde(default)]
     pub format: super::super::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
 }
@@ -3374,6 +3400,7 @@ pub struct ApiKeyParamsV2 {
     pub api_key_name: ::prost::alloc::string::String,
     /// @inject_tag: validate:"hexadecimal,tk_api_key"
     pub public_key: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve_type: super::super::common::v1::ApiKeyCurve,
     #[serde(default)]
     pub expiration_seconds: ::core::option::Option<::prost::alloc::string::String>,
@@ -3389,6 +3416,7 @@ pub struct UserParams {
     #[serde(default)]
     pub user_email: ::core::option::Option<::prost::alloc::string::String>,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub access_type: super::super::common::v1::AccessType,
     /// @inject_tag: validate:"dive,uuid"
     #[serde(default)]
@@ -3528,6 +3556,7 @@ pub struct InvitationParams {
     #[serde(default)]
     pub receiver_user_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub access_type: super::super::common::v1::AccessType,
     /// @inject_tag: validate:"required,uuid"
     pub sender_user_id: ::prost::alloc::string::String,
@@ -3557,6 +3586,7 @@ pub struct PrivateKeyParams {
     /// @inject_tag: validate:"required,tk_label_length,tk_label"
     pub private_key_name: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
     /// @inject_tag: validate:"dive,uuid"
     #[serde(default)]
@@ -3585,12 +3615,15 @@ pub struct WalletParams {
 #[derive(Clone, PartialEq)]
 pub struct WalletAccountParams {
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub path_format: super::super::common::v1::PathFormat,
     /// @inject_tag: validate:"required"
     pub path: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
+    #[serde(default)]
     pub address_format: super::super::common::v1::AddressFormat,
 }
 #[derive(Debug)]
@@ -3982,6 +4015,7 @@ pub struct SparkPrepareLightningReceiveResult {
 #[derive(Clone, PartialEq)]
 pub struct ClientSignature {
     pub public_key: ::prost::alloc::string::String,
+    #[serde(default)]
     pub scheme: super::super::common::v1::ClientSignatureScheme,
     pub message: ::prost::alloc::string::String,
     pub signature: ::prost::alloc::string::String,
@@ -4118,8 +4152,10 @@ pub struct SparkHtlcPreimageDerivation {}
 /// Type of Activity, such as Add User, or Sign Transaction.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum ActivityType {
     #[serde(rename = "ACTIVITY_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "ACTIVITY_TYPE_CREATE_API_KEYS")]
     CreateApiKeys = 1,
@@ -4759,8 +4795,10 @@ impl ActivityType {
 /// The current processing status of an Activity.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum ActivityStatus {
     #[serde(rename = "ACTIVITY_STATUS_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "ACTIVITY_STATUS_CREATED")]
     Created = 1,
@@ -4807,8 +4845,10 @@ impl ActivityStatus {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum UsageVariant {
     #[serde(rename = "USAGE_VARIANT_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "USAGE_VARIANT_ON_RAMP_COINBASE")]
     OnRampCoinbase = 1,
@@ -4843,8 +4883,10 @@ impl UsageVariant {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum ActivityProtectedCategory {
     #[serde(rename = "ACTIVITY_PROTECTED_CATEGORY_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "ACTIVITY_PROTECTED_CATEGORY_SIGN")]
     Sign = 2,
@@ -4881,8 +4923,10 @@ impl ActivityProtectedCategory {
 /// per-account child index in the derivation path m/8797555'/{account}'/{N}'.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum SparkKeyType {
     #[serde(rename = "SPARK_KEY_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// N = 0
     #[serde(rename = "SPARK_KEY_TYPE_IDENTITY")]

--- a/client/src/generated/immutable.common.v1.rs
+++ b/client/src/generated/immutable.common.v1.rs
@@ -4,12 +4,15 @@
 #[derive(Clone, PartialEq)]
 pub struct PolicyEvaluation {
     pub policy_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub outcome: Outcome,
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum PathFormat {
     #[serde(rename = "PATH_FORMAT_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "PATH_FORMAT_BIP32")]
     Bip32 = 1,
@@ -37,8 +40,10 @@ impl PathFormat {
 /// Cryptographic Curve used to generate a given API key
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum ApiKeyCurve {
     #[serde(rename = "API_KEY_CURVE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "API_KEY_CURVE_P256")]
     P256 = 2,
@@ -73,8 +78,10 @@ impl ApiKeyCurve {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum ClientSignatureScheme {
     #[serde(rename = "CLIENT_SIGNATURE_SCHEME_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "CLIENT_SIGNATURE_SCHEME_API_P256")]
     ApiP256 = 1,
@@ -102,8 +109,10 @@ impl ClientSignatureScheme {
 /// Cryptographic Curve used to generate a given Private Key.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Curve {
     #[serde(rename = "CURVE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Curve SECP256K1 as defined in <https://www.secg.org/sec2-v2.pdf>
     #[serde(rename = "CURVE_SECP256K1")]
@@ -141,8 +150,10 @@ impl Curve {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum AddressFormat {
     #[serde(rename = "ADDRESS_FORMAT_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// 04<X_COORDINATE><Y_COORDINATE>
     #[serde(rename = "ADDRESS_FORMAT_UNCOMPRESSED")]
@@ -326,8 +337,10 @@ impl AddressFormat {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum HashFunction {
     #[serde(rename = "HASH_FUNCTION_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "HASH_FUNCTION_NO_OP")]
     NoOp = 1,
@@ -366,9 +379,11 @@ impl HashFunction {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum PayloadEncoding {
     /// Default value if payload encoding is not set explicitly
     #[serde(rename = "PAYLOAD_ENCODING_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Payload is encoded in hexadecimal
     /// We accept 0x-prefixed or non-0x prefixed payloads.
@@ -418,8 +433,10 @@ impl PayloadEncoding {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum MnemonicLanguage {
     #[serde(rename = "MNEMONIC_LANGUAGE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "MNEMONIC_LANGUAGE_ENGLISH")]
     English = 1,
@@ -478,8 +495,10 @@ impl MnemonicLanguage {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Effect {
     #[serde(rename = "EFFECT_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "EFFECT_ALLOW")]
     Allow = 1,
@@ -510,8 +529,10 @@ impl Effect {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum AccessType {
     #[serde(rename = "ACCESS_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "ACCESS_TYPE_WEB")]
     Web = 1,
@@ -546,8 +567,10 @@ impl AccessType {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum CredentialType {
     #[serde(rename = "CREDENTIAL_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "CREDENTIAL_TYPE_WEBAUTHN_AUTHENTICATOR")]
     WebauthnAuthenticator = 1,
@@ -614,8 +637,10 @@ impl CredentialType {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FeatureName {
     #[serde(rename = "FEATURE_NAME_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// to be deprecated in favor of rename: `FEATURE_NAME_EMAIL_RECOVERY`
     #[serde(rename = "FEATURE_NAME_ROOT_USER_EMAIL_RECOVERY")]
@@ -678,8 +703,10 @@ impl FeatureName {
 /// The supported Fiat On Ramp Providers.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FiatOnRampProvider {
     #[serde(rename = "FIAT_ON_RAMP_PROVIDER_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "FIAT_ON_RAMP_PROVIDER_COINBASE")]
     Coinbase = 1,
@@ -710,9 +737,11 @@ impl FiatOnRampProvider {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FiatOnRampCryptoCurrency {
     /// Unspecified
     #[serde(rename = "FIAT_ON_RAMP_CRYPTO_CURRENCY_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Bitcoin
     #[serde(rename = "FIAT_ON_RAMP_CRYPTO_CURRENCY_BTC")]
@@ -755,9 +784,11 @@ impl FiatOnRampCryptoCurrency {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FiatOnRampCurrency {
     /// Unspecified
     #[serde(rename = "FIAT_ON_RAMP_CURRENCY_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Australian Dollar
     #[serde(rename = "FIAT_ON_RAMP_CURRENCY_AUD")]
@@ -950,9 +981,11 @@ impl FiatOnRampCurrency {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FiatOnRampBlockchainNetwork {
     /// Unspecified
     #[serde(rename = "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// bitcoin
     #[serde(rename = "FIAT_ON_RAMP_BLOCKCHAIN_NETWORK_BITCOIN")]
@@ -995,9 +1028,11 @@ impl FiatOnRampBlockchainNetwork {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum FiatOnRampPaymentMethod {
     /// Unspecified
     #[serde(rename = "FIAT_ON_RAMP_PAYMENT_METHOD_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Shared methods (supported by both MoonPay and Coinbase)
     ///
@@ -1103,8 +1138,10 @@ impl FiatOnRampPaymentMethod {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum TransactionType {
     #[serde(rename = "TRANSACTION_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Unsigned Ethereum transaction, RLP-encoded and hex-encoded
     #[serde(rename = "TRANSACTION_TYPE_ETHEREUM")]
@@ -1152,8 +1189,10 @@ impl TransactionType {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum SmartContractInterfaceType {
     #[serde(rename = "SMART_CONTRACT_INTERFACE_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "SMART_CONTRACT_INTERFACE_TYPE_ETHEREUM")]
     Ethereum = 1,
@@ -1184,8 +1223,10 @@ impl SmartContractInterfaceType {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Outcome {
     #[serde(rename = "OUTCOME_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "OUTCOME_ALLOW")]
     Allow = 1,
@@ -1232,8 +1273,10 @@ impl Outcome {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Operator {
     #[serde(rename = "OPERATOR_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "OPERATOR_EQUAL")]
     Equal = 1,
@@ -1301,8 +1344,10 @@ impl Operator {
 /// A list of OAuth 2.0 providers that are supported
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum Oauth2Provider {
     #[serde(rename = "OAUTH2_PROVIDER_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "OAUTH2_PROVIDER_X")]
     X = 1,
@@ -1334,8 +1379,10 @@ impl Oauth2Provider {
 /// Types of health checks supported for customer TVC apps
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum TvcHealthCheckType {
     #[serde(rename = "TVC_HEALTH_CHECK_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "TVC_HEALTH_CHECK_TYPE_HTTP")]
     Http = 1,

--- a/client/src/generated/immutable.data.v1.rs
+++ b/client/src/generated/immutable.data.v1.rs
@@ -12,6 +12,7 @@ pub struct Timestamp {
 #[derive(Clone, PartialEq)]
 pub struct Credential {
     pub public_key: ::prost::alloc::string::String,
+    #[serde(default)]
     pub r#type: super::super::common::v1::CredentialType,
 }
 #[derive(Debug)]
@@ -29,6 +30,7 @@ pub struct Quorum {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct Feature {
+    #[serde(default)]
     pub name: super::super::common::v1::FeatureName,
     #[serde(default)]
     pub value: ::core::option::Option<::prost::alloc::string::String>,

--- a/client/src/generated/immutable.models.v1.rs
+++ b/client/src/generated/immutable.models.v1.rs
@@ -95,9 +95,12 @@ pub struct MerkleLeafNotarization {
 pub struct AccountPayloadV0 {
     pub organization_id: ::prost::alloc::string::String,
     pub wallet_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
+    #[serde(default)]
     pub path_format: super::super::common::v1::PathFormat,
     pub path: ::prost::alloc::string::String,
+    #[serde(default)]
     pub address_format: super::super::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
 }
@@ -110,9 +113,12 @@ pub struct AccountPayloadV0 {
 pub struct AccountPayloadV1 {
     pub organization_id: ::prost::alloc::string::String,
     pub wallet_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
+    #[serde(default)]
     pub path_format: super::super::common::v1::PathFormat,
     pub path: ::prost::alloc::string::String,
+    #[serde(default)]
     pub address_format: super::super::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
     #[serde(default)]
@@ -128,9 +134,12 @@ pub struct AccountPayloadV1 {
 pub struct AccountPayloadV2 {
     pub organization_id: ::prost::alloc::string::String,
     pub wallet_id: ::prost::alloc::string::String,
+    #[serde(default)]
     pub curve: super::super::common::v1::Curve,
+    #[serde(default)]
     pub path_format: super::super::common::v1::PathFormat,
     pub path: ::prost::alloc::string::String,
+    #[serde(default)]
     pub address_format: super::super::common::v1::AddressFormat,
     pub address: ::prost::alloc::string::String,
     #[serde(default)]
@@ -201,6 +210,7 @@ pub struct NotarizedOrganization {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct Signature {
+    #[serde(default)]
     pub scheme: SignatureScheme,
     pub public_key: ::prost::alloc::string::String,
     pub message: ::prost::alloc::string::String,
@@ -217,6 +227,7 @@ pub struct SmartContractInterfacePayload {
     pub smart_contract_address: ::prost::alloc::string::String,
     /// JSON string for an ABI or IDL
     pub smart_contract_interface: ::prost::alloc::string::String,
+    #[serde(default)]
     pub r#type: super::super::common::v1::SmartContractInterfaceType,
     pub label: ::prost::alloc::string::String,
     pub notes: ::prost::alloc::string::String,
@@ -258,8 +269,10 @@ pub struct PolicyEvaluationMetrics {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum SignatureScheme {
     #[serde(rename = "SIGNATURE_SCHEME_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     /// Scheme used for Turnkey's public API
     #[serde(rename = "SIGNATURE_SCHEME_TK_API_P256")]

--- a/client/src/generated/immutable.sdk_models.v1.rs
+++ b/client/src/generated/immutable.sdk_models.v1.rs
@@ -3,6 +3,7 @@
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct TokenUsage {
+    #[serde(default)]
     pub r#type: UsageType,
     pub token_id: ::prost::alloc::string::String,
     #[serde(default)]
@@ -71,8 +72,10 @@ pub struct LoginUsage {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum UsageType {
     #[serde(rename = "USAGE_TYPE_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "USAGE_TYPE_SIGNUP")]
     Signup = 1,

--- a/client/src/generated/immutable.webauthn.v1.rs
+++ b/client/src/generated/immutable.webauthn.v1.rs
@@ -104,8 +104,10 @@ pub struct CredPropsAuthenticationExtensionsClientOutputs {
 }
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Default)]
 pub enum AuthenticatorTransport {
     #[serde(rename = "AUTHENTICATOR_TRANSPORT_UNSPECIFIED")]
+    #[default]
     Unspecified = 0,
     #[serde(rename = "AUTHENTICATOR_TRANSPORT_BLE")]
     Ble = 1,

--- a/codegen/src/transform.rs
+++ b/codegen/src/transform.rs
@@ -94,6 +94,31 @@ fn mutate_enum(enum_item: &syn::ItemEnum) -> TokenStream {
     });
 
     let enum_name_upper = ident.to_string().to_shouty_snake_case();
+    let is_simple_enum = ident != "Inner" && ident != "TokenOrClaims";
+
+    // Identify the variant whose explicit discriminant is `0` (the proto3
+    // unspecified default). It becomes the `#[default]` for `Default`.
+    // Skip the flatten-style sum enums; they aren't simple discriminated enums.
+    let zero_variant_ident: Option<syn::Ident> = if is_simple_enum {
+        enum_item.variants.iter().find_map(|v| {
+            let (_, expr) = v.discriminant.as_ref()?;
+            let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Int(li),
+                ..
+            }) = expr
+            else {
+                return None;
+            };
+            let val: i64 = li.base10_parse().ok()?;
+            if val == 0 {
+                Some(v.ident.clone())
+            } else {
+                None
+            }
+        })
+    } else {
+        None
+    };
 
     let variants = enum_item.variants.iter().map(|v| {
         let mut v = v.clone();
@@ -111,11 +136,17 @@ fn mutate_enum(enum_item: &syn::ItemEnum) -> TokenStream {
         // which are complex enums we flatten at serialization/parsing time.
         // TODO: would be nice to filter this in a more generic way: basically if the enum isn't a "simple" enum, we shouldn't
         // have to individually rename the variants
-        if ident != "Inner" && ident != "TokenOrClaims" {
+        if is_simple_enum {
             let rename_attr: syn::Attribute = syn::parse_quote!(
                 #[serde(rename = #full_name)]
             );
             v.attrs.push(rename_attr);
+        }
+
+        // Mark the zero-discriminant variant as `#[default]` so that
+        // `#[derive(Default)]` (added below) picks it as the default.
+        if zero_variant_ident.as_ref() == Some(&v.ident) {
+            v.attrs.push(syn::parse_quote!(#[default]));
         }
 
         quote! { #v }
@@ -138,6 +169,16 @@ fn mutate_enum(enum_item: &syn::ItemEnum) -> TokenStream {
     if !has_debug {
         attrs.push(quote! {
             #[derive(Debug)]
+        });
+    }
+
+    // Simple enums get `#[derive(Default)]` keyed off the zero-discriminant
+    // variant marked `#[default]` above. This pairs with the field-level
+    // `#[serde(default)]` added in `mutate_struct` so missing enum fields in
+    // proto JSON deserialize to the unspecified variant rather than erroring.
+    if zero_variant_ident.is_some() {
+        attrs.push(quote! {
+            #[derive(Default)]
         });
     }
 
@@ -183,6 +224,16 @@ fn mutate_struct(struct_value: &syn::ItemStruct) -> TokenStream {
                 };
 
                 field.ty = rewritten_ty;
+
+                // Bare enum scalars need `#[serde(default)]` because protobuf
+                // canonical JSON omits enum fields whose value is the zero/
+                // unspecified variant. The `should_add_default` check below
+                // only matches Option/Vec/primitive type names, so bare enum
+                // fields fall through. Push the attribute here while we know
+                // we just rewrote an enum scalar.
+                if !enum_type.repeated && !enum_type.optional {
+                    field.attrs.push(syn::parse_quote!(#[serde(default)]));
+                }
             }
 
             // Remove all #[prost(...)] attributes from the field


### PR DESCRIPTION
## Problem

Bare-enum scalar fields in the generated `turnkey_client` crate fail to deserialize when the server response (legitimately) omits them.

Protobuf's canonical JSON mapping drops enum fields whose value is the zero / `*_UNSPECIFIED` variant. With the current codegen, those fields are emitted as bare enum types with **neither** a `Default` impl on the enum **nor** `#[serde(default)]` on the field, so a spec-compliant response without the key fails with:

```
Failed to decode response { ... } (missing field `<name>` ...)
```

This surfaced live for me on `tvc deploy approve` against a freshly-created deployment: the field was `TvcDeployment.stage` set to `TVC_DEPLOYMENT_STAGE_UNSPECIFIED`. That specific field has since been removed from the proto, but the same defect affects every other bare enum scalar in the current generated client — `Outcome`, `InvitationStatus`, `TagType`, `Curve`, `AddressFormat`, `Effect`, `AccessType`, `Oauth2Provider`, `FiatOnRampProvider`, `CredentialType`, `ApiKeyCurve`, and friends — any of which can fail the same way for the same reason.

## Fix

Both changes live in `codegen/src/transform.rs`; regenerated client files in the second commit.

**`mutate_struct`** — when an enum-scalar field is rewritten from `i32` to the named enum type, push `#[serde(default)]` for the bare (non-`Vec`, non-`Option`) case. The existing `should_add_default` allowlist already covers `Vec<Enum>` / `Option<Enum>`.

**`mutate_enum`** — find the variant whose explicit discriminant is `0` (the proto3 unspecified default), annotate it with `#[default]`, and add `#[derive(Default)]` to the enum. Skip the flatten-style sum enums (`Inner`, `TokenOrClaims`) that already get special treatment — they aren't simple discriminated enums.

The regen diff is purely additive: `#[serde(default)]` on the field, `#[derive(Default)]` on the enum, `#[default]` on the zero variant. No proto changes.

## Verification

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all existing tests pass)
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt -- --check` ✅
- End-to-end: rebuilt `tvc` from this branch and re-ran the originally-failing `tvc deploy approve --deploy-id … --operator-id …` — now decodes the response and reaches the interactive approval prompt instead of erroring on a missing field.

## Notes

- A codegen-template fix is the right level: the generated `.rs` would otherwise be wiped on the next `make generate`.
- `make generate` needed `PROTOC_INCLUDE=/usr/local/include` on my machine to find `google/protobuf/descriptor.proto`. Not a change in this PR; flagging in case it's worth documenting in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)