### PR TITLE
docs: fix duplicate 'the' in proofs comment

### DIFF
--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -174,7 +174,7 @@ pub fn unsafe_attestation_doc_from_der(
 }
 
 /// Extract the DER encoded `AttestationDoc` from the nitro secure module
-/// (nsm) provided COSE Sign1 structure. This function will verify the the
+/// (nsm) provided COSE Sign1 structure. This function will verify the
 /// root certificate authority via the CA bundle and verify that the end
 /// entity certificate signed the COSE Sign1 structure.
 ///


### PR DESCRIPTION
## Summary
Fixed duplicate "the" in function documentation comment.

## Changes
- Changed "verify the the" → "verify the"

## File
- `proofs/src/lib.rs` (line 177)