### PR TITLE
feat(tvc): interactive CLI mode for `tvc app ...` and `tvc deploy...`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,15 +1193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +1810,6 @@ dependencies = [
  "bitflags 2.9.0",
  "crossterm",
  "dyn-clone",
- "fuzzy-matcher",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3736,15 +3726,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,10 +566,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -604,6 +619,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -790,6 +832,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +880,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1117,6 +1190,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1729,6 +1811,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +2003,15 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1945,6 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -1984,6 +2096,20 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2921,6 +3047,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
+name = "rexpect"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ff60778f96fb5a48adbe421d21bf6578ed58c0872d712e7e08593c195adff8"
+dependencies = [
+ "comma",
+ "nix 0.25.1",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,6 +3105,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -3135,6 +3283,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3334,6 +3488,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3982,12 +4157,14 @@ dependencies = [
  "clap",
  "hex",
  "hpke",
+ "inquire",
  "p256 0.13.2",
  "predicates",
  "qos_core",
  "qos_crypto",
  "qos_nsm",
  "qos_p256",
+ "rexpect",
  "serde",
  "serde_json",
  "tempfile",
@@ -4012,6 +4189,18 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -4259,6 +4448,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4471,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,7 @@ walkdir = { version = "2.5", default-features = false }
 # Environment and configuration
 dotenvy = { version = "0.15.0", default-features = false }
 clap = { version = "4.5", features = ["std", "derive", "help", "usage", "error-context"], default-features = false }
-inquire = { version = "0.9" }
-
+inquire = { version = "0.9", default-features = false, features = ["crossterm"] }
 # Development dependencies
 assert_cmd = { version = "2", default-features = false }
 predicates = { version = "3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,12 @@ walkdir = { version = "2.5", default-features = false }
 # Environment and configuration
 dotenvy = { version = "0.15.0", default-features = false }
 clap = { version = "4.5", features = ["std", "derive", "help", "usage", "error-context"], default-features = false }
+inquire = { version = "0.9" }
 
 # Development dependencies
 assert_cmd = { version = "2", default-features = false }
 predicates = { version = "3", default-features = false }
+rexpect = { version = "0.5", default-features = false }
 tempfile = { version = "3.19.1", default-features = false }
 signature = "2"
 wiremock = { version = "0.6", default-features = false }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -26,6 +26,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 hex = { workspace = true }
+inquire = { workspace = true }
 p256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -40,4 +41,5 @@ assert_cmd = { workspace = true }
 hpke = { workspace = true }
 predicates = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
+rexpect = { workspace = true }
 tempfile = { workspace = true }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -2,10 +2,11 @@
 
 use crate::client::build_client;
 use crate::config::app::{AppConfig, OperatorSetParams};
-use crate::config::turnkey;
-use anyhow::{Context, Result};
+use crate::config::turnkey::{self, StoredQosOperatorKey};
+use crate::prompts;
+use anyhow::{anyhow, Context, Result};
 use clap::Args as ClapArgs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperatorSetParams};
 
@@ -20,16 +21,7 @@ pub struct Args {
 
 /// Run the app create command.
 pub async fn run(args: Args) -> Result<()> {
-    // Read and parse config file
-    let config_content = std::fs::read_to_string(&args.config_file)
-        .with_context(|| format!("failed to read config file: {}", args.config_file.display()))?;
-
-    let app_config: AppConfig = serde_json::from_str(&config_content).with_context(|| {
-        format!(
-            "failed to parse config file: {}",
-            args.config_file.display()
-        )
-    })?;
+    let app_config = load_or_fill_app_config(&args.config_file).await?;
 
     app_config
         .validate()
@@ -81,6 +73,57 @@ pub async fn run(args: Args) -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Load the app config, walking placeholders interactively when allowed.
+async fn load_or_fill_app_config(path: &Path) -> Result<AppConfig> {
+    let read = std::fs::read_to_string(path);
+    let (config, file_existed) = match read {
+        Ok(content) => {
+            let config: AppConfig = serde_json::from_str(&content)
+                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+            (config, true)
+        }
+        Err(_) if prompts::is_interactive() => (AppConfig::template(None), false),
+        Err(e) => {
+            return Err(anyhow!(e))
+                .with_context(|| format!("failed to read config file: {}", path.display()));
+        }
+    };
+
+    if file_existed && !config.has_placeholders() {
+        return Ok(config);
+    }
+
+    if !prompts::is_interactive() {
+        anyhow::bail!(
+            "Config file contains placeholder values (<FILL_IN_...>). \
+             Please edit {} and fill in all required values.",
+            path.display()
+        );
+    }
+
+    let saved_operator_public_key = load_saved_operator_public_key().await;
+    let filled = config.fill_interactively(saved_operator_public_key.as_deref())?;
+
+    let save = prompts::confirm(&format!("Save filled config to {}?", path.display()), true)?;
+    if save {
+        let json = serde_json::to_string_pretty(&filled).context("failed to serialize config")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write config file: {}", path.display()))?;
+        println!("Wrote {}", path.display());
+    }
+
+    Ok(filled)
+}
+
+/// Best-effort load of the operator public key from the active org's config
+/// so we can offer it as the default for new-operator prompts.
+async fn load_saved_operator_public_key() -> Option<String> {
+    let config = turnkey::Config::load().await.ok()?;
+    let (_, org_config) = config.active_org_config()?;
+    let operator_key = StoredQosOperatorKey::load(org_config).await.ok()??;
+    Some(operator_key.public_key)
 }
 
 fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -78,7 +78,7 @@ pub async fn run(args: Args) -> Result<()> {
 /// Load the app config, walking placeholders interactively when allowed.
 async fn load_or_fill_app_config(path: &Path) -> Result<AppConfig> {
     let read = std::fs::read_to_string(path);
-    let (config, file_existed) = match read {
+    let (mut config, file_existed) = match read {
         Ok(content) => {
             let config: AppConfig = serde_json::from_str(&content)
                 .with_context(|| format!("failed to parse config file: {}", path.display()))?;
@@ -104,17 +104,17 @@ async fn load_or_fill_app_config(path: &Path) -> Result<AppConfig> {
     }
 
     let saved_operator_public_key = load_saved_operator_public_key().await;
-    let filled = config.fill_interactively(saved_operator_public_key.as_deref())?;
+    config.fill_interactively(saved_operator_public_key.as_deref())?;
 
     let save = prompts::confirm(&format!("Save filled config to {}?", path.display()), true)?;
     if save {
-        let json = serde_json::to_string_pretty(&filled).context("failed to serialize config")?;
+        let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
         std::fs::write(path, json)
             .with_context(|| format!("failed to write config file: {}", path.display()))?;
         println!("Wrote {}", path.display());
     }
 
-    Ok(filled)
+    Ok(config)
 }
 
 /// Best-effort load of the operator public key from the active org's config

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -45,12 +45,10 @@ pub async fn run(args: Args) -> Result<()> {
     let operator_public_key = load_operator_public_key().await;
 
     // Generate template (optionally walking prompts to fill it in)
-    let template = AppConfig::template(operator_public_key.as_deref());
-    let config = if args.interactive {
-        template.fill_interactively(operator_public_key.as_deref())?
-    } else {
-        template
-    };
+    let mut config = AppConfig::template(operator_public_key.as_deref());
+    if args.interactive {
+        config.fill_interactively(operator_public_key.as_deref())?;
+    }
 
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
 

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -2,7 +2,8 @@
 
 use crate::config::app::AppConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use anyhow::{Context, Result};
+use crate::prompts;
+use anyhow::{bail, Context, Result};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
 
@@ -19,30 +20,57 @@ pub struct Args {
         env = "TVC_APP_CONFIG_OUT"
     )]
     pub output: PathBuf,
+
+    /// Walk through prompts for each field and write a filled config instead
+    /// of a placeholder template.
+    #[arg(long)]
+    pub interactive: bool,
 }
 
 /// Run the app init command.
 pub async fn run(args: Args) -> Result<()> {
+    if args.interactive && prompts::non_interactive_forced() {
+        bail!(
+            "--interactive conflicts with {}=1",
+            prompts::NON_INTERACTIVE_ENV
+        );
+    }
+
     // Check if file already exists
     if args.output.exists() {
-        anyhow::bail!("File already exists: {}", args.output.display());
+        bail!("File already exists: {}", args.output.display());
     }
 
     // Try to load operator public key from config
     let operator_public_key = load_operator_public_key().await;
 
-    // Generate template
-    let config = AppConfig::template(operator_public_key.as_deref());
+    // Generate template (optionally walking prompts to fill it in)
+    let template = AppConfig::template(operator_public_key.as_deref());
+    let config = if args.interactive {
+        template.fill_interactively(operator_public_key.as_deref())?
+    } else {
+        template
+    };
+
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
 
     // Write to file
     std::fs::write(&args.output, json)
         .with_context(|| format!("failed to write file: {}", args.output.display()))?;
 
-    println!("Created app config template: {}", args.output.display());
-    println!();
-    println!("Edit the file to fill in your values, then run:");
-    println!("  tvc app create --config-file {}", args.output.display());
+    if args.interactive {
+        println!("Created app config: {}", args.output.display());
+        println!();
+        println!(
+            "Run: tvc app create --config-file {}",
+            args.output.display()
+        );
+    } else {
+        println!("Created app config template: {}", args.output.display());
+        println!();
+        println!("Edit the file to fill in your values, then run:");
+        println!("  tvc app create --config-file {}", args.output.display());
+    }
 
     Ok(())
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -77,9 +77,10 @@ pub struct Args {
 
 /// Run the approve deploy command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    // Guard: running without --dangerous-skip-interactive means we'd prompt;
-    // refuse to stall when the user has explicitly opted out of prompts.
-    if !args.dangerous_skip_interactive {
+    let do_prompt_user = !args.dangerous_skip_interactive;
+
+    // Guard: Bail fast before fetching the manifest if we cannot prompt the user
+    if do_prompt_user {
         prompts::bail_if_non_interactive("--dangerous-skip-interactive")?;
     }
 
@@ -93,7 +94,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         (None, None) => bail!("a manifest source is required"),
     };
 
-    if !args.dangerous_skip_interactive {
+    if do_prompt_user {
         interactive_approve(&manifest)?;
     }
 
@@ -158,9 +159,8 @@ async fn post_approval_to_api(
                 _ if prompts::is_interactive() => {
                     prompts::select("Select approving operator", saved_ids.clone())?
                 }
-                // Non-interactive with multiple saved IDs: keep legacy behavior
-                // of picking the first entry. Users who want a specific operator
-                // should pass --operator-id.
+                // Non-interactive with multiple saved IDs: pick the first entry.
+                // Users who want a specific operator should pass --operator-id.
                 _ => saved_ids[0].clone(),
             }
         }
@@ -279,7 +279,7 @@ fn render_enclave(enclave: &NitroConfig) -> String {
     let _ = writeln!(s, "  PCR1 (kernel):    {}", hex::encode(&enclave.pcr1));
     let _ = writeln!(s, "  PCR2 (app):       {}", hex::encode(&enclave.pcr2));
     let _ = writeln!(s, "  PCR3 (IAM role):  {}", hex::encode(&enclave.pcr3));
-    // Skip the QOS commit since its not cryptographically linked
+    // Skip the QOS commit since it's not cryptographically linked
     let _ = writeln!(s);
     s
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -1,8 +1,8 @@
 //! Approve deploy command - cryptographically approve a QOS manifest.
 
-use crate::commands::confirmation::confirm_yes_no;
 use crate::config::turnkey::Config;
 use crate::operator_key::load_operator_pair;
+use crate::prompts;
 use crate::util::{read_file_to_string, write_file};
 use anyhow::{anyhow, bail, Context};
 use clap::{ArgGroup, Args as ClapArgs};
@@ -11,6 +11,7 @@ use qos_core::protocol::services::boot::{
     Manifest, ManifestSet, Namespace, NitroConfig, PivotConfig, QuorumMember, ShareSet,
 };
 use qos_core::protocol::QosHash;
+use std::fmt::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -76,6 +77,12 @@ pub struct Args {
 
 /// Run the approve deploy command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
+    // Guard: running without --dangerous-skip-interactive means we'd prompt;
+    // refuse to stall when the user has explicitly opted out of prompts.
+    if !args.dangerous_skip_interactive {
+        prompts::bail_if_non_interactive("--dangerous-skip-interactive")?;
+    }
+
     // Fetch manifest - track manifest_id if fetched from API
     let (manifest, fetched_manifest_id) = match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => (read_manifest_from_path(path).await?, None),
@@ -136,7 +143,6 @@ async fn post_approval_to_api(
     let operator_id = match &args.operator_id {
         Some(id) => id.clone(),
         None => {
-            // Try to load from config
             let config = Config::load().await?;
             let saved_ids = config.get_last_operator_ids().ok_or_else(|| {
                 anyhow!(
@@ -146,11 +152,17 @@ async fn post_approval_to_api(
                 )
             })?;
 
-            // Use the first operator Id from the list
-            saved_ids
-                .first()
-                .ok_or_else(|| anyhow!("No operator IDs available"))?
-                .clone()
+            match saved_ids.len() {
+                0 => bail!("No operator IDs available"),
+                1 => saved_ids[0].clone(),
+                _ if prompts::is_interactive() => {
+                    prompts::select("Select approving operator", saved_ids.clone())?
+                }
+                // Non-interactive with multiple saved IDs: keep legacy behavior
+                // of picking the first entry. Users who want a specific operator
+                // should pass --operator-id.
+                _ => saved_ids[0].clone(),
+            }
         }
     };
 
@@ -236,70 +248,104 @@ fn interactive_approve(manifest: &Manifest) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn review_namespace(namespace: &Namespace) -> anyhow::Result<()> {
-    println!("NAMESPACE");
-    println!("─────────────────────────────────────");
-    println!("  Name:       {}", namespace.name);
-    println!("  Nonce:      {}", namespace.nonce);
-    println!("  Quorum Key: {}", hex::encode(&namespace.quorum_key));
-    println!();
+fn confirm_or_bail(prompt: &str) -> anyhow::Result<()> {
+    if !prompts::confirm(prompt, false)? {
+        bail!("approval cancelled by user");
+    }
+    Ok(())
+}
 
-    confirm_yes_no("Approve namespace?")
+fn render_namespace(namespace: &Namespace) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "NAMESPACE");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  Name:       {}", namespace.name);
+    let _ = writeln!(s, "  Nonce:      {}", namespace.nonce);
+    let _ = writeln!(s, "  Quorum Key: {}", hex::encode(&namespace.quorum_key));
+    let _ = writeln!(s);
+    s
+}
+
+fn review_namespace(namespace: &Namespace) -> anyhow::Result<()> {
+    print!("{}", render_namespace(namespace));
+    confirm_or_bail("Approve namespace?")
+}
+
+fn render_enclave(enclave: &NitroConfig) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "ENCLAVE (AWS Nitro)");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  PCR0 (image):     {}", hex::encode(&enclave.pcr0));
+    let _ = writeln!(s, "  PCR1 (kernel):    {}", hex::encode(&enclave.pcr1));
+    let _ = writeln!(s, "  PCR2 (app):       {}", hex::encode(&enclave.pcr2));
+    let _ = writeln!(s, "  PCR3 (IAM role):  {}", hex::encode(&enclave.pcr3));
+    // Skip the QOS commit since its not cryptographically linked
+    let _ = writeln!(s);
+    s
 }
 
 fn review_enclave(enclave: &NitroConfig) -> anyhow::Result<()> {
-    println!("ENCLAVE (AWS Nitro)");
-    println!("─────────────────────────────────────");
-    println!("  PCR0 (image):     {}", hex::encode(&enclave.pcr0));
-    println!("  PCR1 (kernel):    {}", hex::encode(&enclave.pcr1));
-    println!("  PCR2 (app):       {}", hex::encode(&enclave.pcr2));
-    println!("  PCR3 (IAM role):  {}", hex::encode(&enclave.pcr3));
-    // Skip the QOS commit since its not cryptographically linked
-    println!();
+    print!("{}", render_enclave(enclave));
+    confirm_or_bail("Approve enclave configuration?")
+}
 
-    confirm_yes_no("Approve enclave configuration?")
+fn render_pivot(pivot: &PivotConfig) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "PIVOT BINARY");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  Pivot Binary Hash: {}", hex::encode(pivot.hash));
+    if pivot.args.is_empty() {
+        let _ = writeln!(s, "  CLI Args: (none)");
+    } else {
+        let _ = writeln!(s, "  CLI Args:\n   {}", pivot.args.join("\n   "));
+    }
+    let _ = writeln!(s);
+    s
 }
 
 fn review_pivot(pivot: &PivotConfig) -> anyhow::Result<()> {
-    println!("PIVOT BINARY");
-    println!("─────────────────────────────────────");
-    println!("  Pivot Binary Hash: {}", hex::encode(pivot.hash));
-    if pivot.args.is_empty() {
-        println!("  CLI Args: (none)");
-    } else {
-        println!("  CLI Args:\n   {}", pivot.args.join("\n   "));
-    }
-    println!();
-
-    confirm_yes_no("Approve pivot binary?")
+    print!("{}", render_pivot(pivot));
+    confirm_or_bail("Approve pivot binary?")
 }
 
-fn print_quorum_members(members: &[QuorumMember]) {
+fn render_quorum_members(members: &[QuorumMember]) -> String {
+    let mut s = String::new();
     for member in members.iter() {
-        println!("    {} ({})", member.alias, hex::encode(&member.pub_key));
+        let _ = writeln!(s, "    {} ({})", member.alias, hex::encode(&member.pub_key));
     }
+    s
+}
+
+fn render_manifest_set(set: &ManifestSet) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "MANIFEST SET");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  Threshold: {} of {}", set.threshold, set.members.len());
+    let _ = writeln!(s, "  Members:");
+    s.push_str(&render_quorum_members(&set.members));
+    let _ = writeln!(s);
+    s
 }
 
 fn review_manifest_set(set: &ManifestSet) -> anyhow::Result<()> {
-    println!("MANIFEST SET");
-    println!("─────────────────────────────────────");
-    println!("  Threshold: {} of {}", set.threshold, set.members.len());
-    println!("  Members:");
-    print_quorum_members(&set.members);
-    println!();
+    print!("{}", render_manifest_set(set));
+    confirm_or_bail("Approve manifest set?")
+}
 
-    confirm_yes_no("Approve manifest set?")
+fn render_share_set(set: &ShareSet) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "SHARE SET");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  Threshold: {} of {}", set.threshold, set.members.len());
+    let _ = writeln!(s, "  Members:");
+    s.push_str(&render_quorum_members(&set.members));
+    let _ = writeln!(s);
+    s
 }
 
 fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
-    println!("SHARE SET");
-    println!("─────────────────────────────────────");
-    println!("  Threshold: {} of {}", set.threshold, set.members.len());
-    println!("  Members:");
-    print_quorum_members(&set.members);
-    println!();
-
-    confirm_yes_no("Approve share set?")
+    print!("{}", render_share_set(set));
+    confirm_or_bail("Approve share set?")
 }
 
 async fn read_manifest_from_path(path: &Path) -> anyhow::Result<Manifest> {
@@ -341,4 +387,56 @@ async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(Manifest
     println!("✓ Manifest loaded (manifest_id: {})", tvc_manifest.id);
 
     Ok((manifest, tvc_manifest.id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_manifest() -> Manifest {
+        serde_json::from_str(include_str!("../../../fixtures/manifest.json"))
+            .expect("fixture manifest should parse")
+    }
+
+    #[test]
+    fn render_namespace_includes_name_nonce_and_quorum_key() {
+        let manifest = fixture_manifest();
+        let rendered = render_namespace(&manifest.namespace);
+        assert!(rendered.contains("NAMESPACE"));
+        assert!(rendered.contains("turnkey-prod"));
+        assert!(rendered.contains("Nonce:"));
+        assert!(rendered.contains("Quorum Key:"));
+    }
+
+    #[test]
+    fn render_enclave_includes_all_four_pcrs() {
+        let manifest = fixture_manifest();
+        let rendered = render_enclave(&manifest.enclave);
+        assert!(rendered.contains("ENCLAVE (AWS Nitro)"));
+        assert!(rendered.contains("PCR0"));
+        assert!(rendered.contains("PCR1"));
+        assert!(rendered.contains("PCR2"));
+        assert!(rendered.contains("PCR3"));
+    }
+
+    #[test]
+    fn render_pivot_includes_header_and_args() {
+        let manifest = fixture_manifest();
+        let rendered = render_pivot(&manifest.pivot);
+        assert!(rendered.contains("PIVOT BINARY"));
+        assert!(rendered.contains("Pivot Binary Hash:"));
+        assert!(rendered.contains("--flag"));
+        assert!(rendered.contains("positional"));
+    }
+
+    #[test]
+    fn render_manifest_set_includes_threshold_and_each_member() {
+        let manifest = fixture_manifest();
+        let rendered = render_manifest_set(&manifest.manifest_set);
+        assert!(rendered.contains("MANIFEST SET"));
+        assert!(rendered.contains("Threshold: 2 of 3"));
+        assert!(rendered.contains("operator-alice"));
+        assert!(rendered.contains("operator-bob"));
+        assert!(rendered.contains("operator-charlie"));
+    }
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -248,13 +248,6 @@ fn interactive_approve(manifest: &Manifest) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn confirm_or_bail(prompt: &str) -> anyhow::Result<()> {
-    if !prompts::confirm(prompt, false)? {
-        bail!("approval cancelled by user");
-    }
-    Ok(())
-}
-
 fn render_namespace(namespace: &Namespace) -> String {
     let mut s = String::new();
     let _ = writeln!(s, "NAMESPACE");
@@ -268,7 +261,7 @@ fn render_namespace(namespace: &Namespace) -> String {
 
 fn review_namespace(namespace: &Namespace) -> anyhow::Result<()> {
     print!("{}", render_namespace(namespace));
-    confirm_or_bail("Approve namespace?")
+    prompts::confirm_or_bail("Approve namespace?", "approval")
 }
 
 fn render_enclave(enclave: &NitroConfig) -> String {
@@ -286,7 +279,7 @@ fn render_enclave(enclave: &NitroConfig) -> String {
 
 fn review_enclave(enclave: &NitroConfig) -> anyhow::Result<()> {
     print!("{}", render_enclave(enclave));
-    confirm_or_bail("Approve enclave configuration?")
+    prompts::confirm_or_bail("Approve enclave configuration?", "approval")
 }
 
 fn render_pivot(pivot: &PivotConfig) -> String {
@@ -305,7 +298,7 @@ fn render_pivot(pivot: &PivotConfig) -> String {
 
 fn review_pivot(pivot: &PivotConfig) -> anyhow::Result<()> {
     print!("{}", render_pivot(pivot));
-    confirm_or_bail("Approve pivot binary?")
+    prompts::confirm_or_bail("Approve pivot binary?", "approval")
 }
 
 fn render_quorum_members(members: &[QuorumMember]) -> String {
@@ -329,7 +322,7 @@ fn render_manifest_set(set: &ManifestSet) -> String {
 
 fn review_manifest_set(set: &ManifestSet) -> anyhow::Result<()> {
     print!("{}", render_manifest_set(set));
-    confirm_or_bail("Approve manifest set?")
+    prompts::confirm_or_bail("Approve manifest set?", "approval")
 }
 
 fn render_share_set(set: &ShareSet) -> String {
@@ -345,7 +338,7 @@ fn render_share_set(set: &ShareSet) -> String {
 
 fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
     print!("{}", render_share_set(set));
-    confirm_or_bail("Approve share set?")
+    prompts::confirm_or_bail("Approve share set?", "approval")
 }
 
 async fn read_manifest_from_path(path: &Path) -> anyhow::Result<Manifest> {

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -2,10 +2,12 @@
 
 use crate::client::build_client;
 use crate::config::deploy::DeployConfig;
+use crate::config::turnkey::Config;
+use crate::prompts;
 use crate::pull_secret::encrypt_pivot_pull_secret;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::Args as ClapArgs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
 
@@ -174,36 +176,76 @@ fn apply_overrides(config: &mut DeployConfig, args: &Args) {
     }
 }
 
-fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
-    let mut config = match &args.config_file {
-        Some(path) => {
-            let content = std::fs::read_to_string(path)
-                .with_context(|| format!("failed to read config file: {}", path.display()))?;
-            serde_json::from_str(&content)
-                .with_context(|| format!("failed to parse config file: {}", path.display()))?
+/// Read a config from the given path, returning the parsed DeployConfig and
+/// a flag indicating whether the file existed (interactive flow may treat
+/// missing files as "start from template" when --config-file was provided).
+fn read_config_file(path: &Path) -> Result<Option<DeployConfig>> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => {
+            let config: DeployConfig = serde_json::from_str(&content)
+                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+            Ok(Some(config))
         }
+        Err(_) if prompts::is_interactive() => Ok(None),
+        Err(e) => Err(anyhow!(e))
+            .with_context(|| format!("failed to read config file: {}", path.display())),
+    }
+}
+
+async fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
+    let (mut config, file_loaded) = match &args.config_file {
+        Some(path) => match read_config_file(path)? {
+            Some(c) => (c, true),
+            None => (DeployConfig::template(None), false),
+        },
         None => {
             let mut t = DeployConfig::template(None);
             // Strip the template's "<REMOVE_ME...>" hint so flag-only mode
             // doesn't ship it to the API for public images.
             t.pivot_container_encrypted_pull_secret = None;
-            t
+            (t, false)
         }
     };
 
     apply_overrides(&mut config, args);
 
-    let missing = config.missing_required_fields();
-    if !missing.is_empty() {
-        let suggestion = if args.config_file.is_some() {
-            "Edit the config file or override via flag/TVC_* env."
-        } else {
-            "Provide via flag, TVC_* env, or --config-file."
-        };
-        bail!(
-            "missing required values: {}. {suggestion}",
-            missing.join(", ")
-        );
+    // After flag/env overrides, anything still placeholder-shaped needs to
+    // come from somewhere. Non-interactive: bail with the flag-list. Interactive:
+    // walk prompts for the remaining holes.
+    if !config.missing_required_fields().is_empty() {
+        if !prompts::is_interactive() {
+            let missing = config.missing_required_fields();
+            let suggestion = if args.config_file.is_some() {
+                "Edit the config file or override via flag/TVC_* env."
+            } else {
+                "Provide via flag, TVC_* env, or --config-file."
+            };
+            bail!(
+                "missing required values: {}. {suggestion}",
+                missing.join(", ")
+            );
+        }
+
+        let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
+        config = config.fill_interactively(saved_app_id.as_deref())?;
+
+        // If the user passed a --config-file and we walked any prompts (either
+        // because the file was missing or had placeholders), offer to write the
+        // filled config back so the next run is hands-free.
+        if let Some(path) = &args.config_file {
+            let prompt = if file_loaded {
+                format!("Save filled config to {}?", path.display())
+            } else {
+                format!("Write a new config file at {}?", path.display())
+            };
+            if prompts::confirm(&prompt, true)? {
+                let json =
+                    serde_json::to_string_pretty(&config).context("failed to serialize config")?;
+                std::fs::write(path, json)
+                    .with_context(|| format!("failed to write config file: {}", path.display()))?;
+                println!("Wrote {}", path.display());
+            }
+        }
     }
 
     Ok(config)
@@ -211,7 +253,7 @@ fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
 
 /// Run the deploy create command.
 pub async fn run(args: Args) -> Result<()> {
-    let deploy_config = resolve_deploy_config(&args)?;
+    let deploy_config = resolve_deploy_config(&args).await?;
 
     println!("Creating deployment for app '{}'...", deploy_config.app_id);
 
@@ -365,6 +407,17 @@ mod tests {
         f
     }
 
+    // Resolution tests run inside the tokio runtime since resolve_deploy_config
+    // now reaches into Config::load(). They're wired to call .block_on() via
+    // a small helper.
+    fn run_resolve(args: &Args) -> Result<DeployConfig> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(resolve_deploy_config(args))
+    }
+
     #[test]
     fn flag_overrides_file_value() {
         let file = write_config(&file_config());
@@ -373,7 +426,7 @@ mod tests {
             app_id: Some("flag-app-id".into()),
             ..empty_args()
         };
-        let resolved = resolve_deploy_config(&args).unwrap();
+        let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.app_id, "flag-app-id");
         // Untouched fields keep their file values.
         assert_eq!(resolved.qos_version, "file-qos");
@@ -387,7 +440,7 @@ mod tests {
             config_file: Some(file.path().to_path_buf()),
             ..empty_args()
         };
-        let resolved = resolve_deploy_config(&args).unwrap();
+        let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.app_id, "file-app-id");
         assert_eq!(resolved.qos_version, "file-qos");
         assert_eq!(resolved.health_check_port, 4000);
@@ -395,7 +448,7 @@ mod tests {
 
     #[test]
     fn no_file_uses_flag_only_with_template_defaults() {
-        let resolved = resolve_deploy_config(&all_required_flags()).unwrap();
+        let resolved = run_resolve(&all_required_flags()).unwrap();
         // Required fields come from flags.
         assert_eq!(resolved.app_id, "flag-app-id");
         assert_eq!(resolved.qos_version, "flag-qos");
@@ -413,7 +466,9 @@ mod tests {
 
     #[test]
     fn no_file_no_required_flags_bails_naming_each_flag() {
-        let err = resolve_deploy_config(&empty_args()).unwrap_err();
+        // Force non-interactive so the test never tries to prompt.
+        let _guard = NonInteractiveGuard::set();
+        let err = run_resolve(&empty_args()).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("--app-id"), "{msg}");
         assert!(msg.contains("--qos-version"), "{msg}");
@@ -430,7 +485,23 @@ mod tests {
             pivot_args: vec!["c".into()],
             ..empty_args()
         };
-        let resolved = resolve_deploy_config(&args).unwrap();
+        let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.pivot_args, vec!["c"]);
+    }
+
+    /// Sets `TVC_NON_INTERACTIVE=1` for the lifetime of the value so a test
+    /// can exercise the "non-interactive bails with flag list" branch
+    /// regardless of how the test runner is invoked.
+    struct NonInteractiveGuard;
+    impl NonInteractiveGuard {
+        fn set() -> Self {
+            std::env::set_var(prompts::NON_INTERACTIVE_ENV, "1");
+            Self
+        }
+    }
+    impl Drop for NonInteractiveGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(prompts::NON_INTERACTIVE_ENV);
+        }
     }
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -32,6 +32,11 @@ Special rules:
   --pivot-pull-secret reads an unencrypted pull secret file, encrypts it for the
   active org's API environment, and overrides the encrypted secret in the config.
 
+Interactive vs non-interactive:
+  By default, missing required values are filled by interactive prompts when
+  stdin is a TTY. Set TVC_NON_INTERACTIVE=1 to disable all prompts, like in CI; the command then
+  bails with a precise list of missing fields instead of waiting on input.
+
 Examples:
   tvc deploy create --config-file deploy.json
 
@@ -255,6 +260,9 @@ async fn resolve_placeholders(config: &mut DeployConfig, args: &Args) -> Result<
 /// `file_loaded` distinguishes "saving over an existing file" from
 /// "creating a new file at this path" in the prompt wording.
 fn offer_to_save_config(path: &Path, config: &DeployConfig, file_loaded: bool) -> Result<()> {
+    if !is_interactive() {
+        return Ok(());
+    }
     let prompt = if file_loaded {
         format!("Save filled config to {}?", path.display())
     } else {

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -4,6 +4,7 @@ use crate::client::build_client;
 use crate::config::deploy::DeployConfig;
 use crate::config::turnkey::Config;
 use crate::prompts;
+use crate::prompts::is_interactive;
 use crate::pull_secret::encrypt_pivot_pull_secret;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Args as ClapArgs;
@@ -176,7 +177,7 @@ fn apply_overrides(config: &mut DeployConfig, args: &Args) {
     }
 }
 
-/// Read a config from the given path, returning the parsed DeployConfig and
+/// Read a config from the given path, returning the parsed [`DeployConfig`] and
 /// a flag indicating whether the file existed (interactive flow may treat
 /// missing files as "start from template" when --config-file was provided).
 fn read_config_file(path: &Path) -> Result<Option<DeployConfig>> {
@@ -209,12 +210,24 @@ async fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
 
     apply_overrides(&mut config, args);
 
-    // After flag/env overrides, anything still placeholder-shaped needs to
-    // come from somewhere. Non-interactive: bail with the flag-list. Interactive:
-    // walk prompts for the remaining holes.
-    if !config.missing_required_fields().is_empty() {
-        if !prompts::is_interactive() {
-            let missing = config.missing_required_fields();
+    let config_updated = resolve_placeholders(&mut config, args).await?;
+    if config_updated {
+        if let Some(path) = &args.config_file {
+            offer_to_save_config(path, &config, file_loaded)?;
+        }
+    }
+    Ok(config)
+}
+
+/// Address any remaining placeholders in `config`. Returns `true` iff the
+/// resolution required walking interactive prompts
+async fn resolve_placeholders(config: &mut DeployConfig, args: &Args) -> Result<bool> {
+    if !config.has_placeholders() {
+        return Ok(false);
+    }
+    if !is_interactive() {
+        let missing = config.missing_required_fields();
+        if !missing.is_empty() {
             let suggestion = if args.config_file.is_some() {
                 "Edit the config file or override via flag/TVC_* env."
             } else {
@@ -226,29 +239,34 @@ async fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
             );
         }
 
-        let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
-        config = config.fill_interactively(saved_app_id.as_deref())?;
-
-        // If the user passed a --config-file and we walked any prompts (either
-        // because the file was missing or had placeholders), offer to write the
-        // filled config back so the next run is hands-free.
-        if let Some(path) = &args.config_file {
-            let prompt = if file_loaded {
-                format!("Save filled config to {}?", path.display())
-            } else {
-                format!("Write a new config file at {}?", path.display())
-            };
-            if prompts::confirm(&prompt, true)? {
-                let json =
-                    serde_json::to_string_pretty(&config).context("failed to serialize config")?;
-                std::fs::write(path, json)
-                    .with_context(|| format!("failed to write config file: {}", path.display()))?;
-                println!("Wrote {}", path.display());
-            }
+        if config.pull_secret_is_placeholder() {
+            bail!("pivotContainerEncryptedPullSecret is placeholder. Set the field to null in the config file (public image), or pass --pivot-pull-secret <PATH> (private image).")
         }
+        return Ok(false);
     }
 
-    Ok(config)
+    let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
+    config.fill_interactively(saved_app_id.as_deref())?;
+
+    Ok(true)
+}
+
+/// Ask the user whether to write the updated config back to disk.
+/// `file_loaded` distinguishes "saving over an existing file" from
+/// "creating a new file at this path" in the prompt wording.
+fn offer_to_save_config(path: &Path, config: &DeployConfig, file_loaded: bool) -> Result<()> {
+    let prompt = if file_loaded {
+        format!("Save filled config to {}?", path.display())
+    } else {
+        format!("Write a new config file at {}?", path.display())
+    };
+    if prompts::confirm(&prompt, true)? {
+        let json = serde_json::to_string_pretty(config).context("failed to serialize config")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write config file: {}", path.display()))?;
+        println!("Wrote {}", path.display());
+    }
+    Ok(())
 }
 
 /// Run the deploy create command.
@@ -487,6 +505,34 @@ mod tests {
         };
         let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.pivot_args, vec!["c"]);
+    }
+
+    /// All required fields are filled but the pull-secret sentinel is still
+    /// present. In non-interactive mode we can't prompt the user about it, so
+    /// the resolve bails rather than silently mutating the config or shipping
+    /// the sentinel to the API.
+    #[test]
+    fn pull_secret_placeholder_bails_when_non_interactive() {
+        let _guard = NonInteractiveGuard::set();
+
+        let mut cfg = file_config();
+        cfg.pivot_container_encrypted_pull_secret =
+            Some("<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>".to_string());
+        let file = write_config(&cfg);
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            ..empty_args()
+        };
+
+        let err = run_resolve(&args).unwrap_err().to_string();
+        assert!(
+            err.contains("pivotContainerEncryptedPullSecret"),
+            "error should name the offending field: {err}"
+        );
+        assert!(
+            err.contains("--pivot-pull-secret"),
+            "error should point the user at the resolution flag: {err}"
+        );
     }
 
     /// Sets `TVC_NON_INTERACTIVE=1` for the lifetime of the value so a test

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -2,7 +2,8 @@
 
 use crate::config::deploy::DeployConfig;
 use crate::config::turnkey;
-use anyhow::{Context, Result};
+use crate::prompts;
+use anyhow::{bail, Context, Result};
 use chrono::Local;
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
@@ -14,10 +15,22 @@ pub struct Args {
     /// Output file path.
     #[arg(short, long, value_name = "PATH", env = "TVC_DEPLOY_CONFIG_OUT")]
     pub output: Option<PathBuf>,
+
+    /// Walk through prompts for each field and write a filled config instead
+    /// of a placeholder template.
+    #[arg(long)]
+    pub interactive: bool,
 }
 
 /// Run the deploy init command.
 pub async fn run(args: Args) -> Result<()> {
+    if args.interactive && prompts::non_interactive_forced() {
+        bail!(
+            "--interactive conflicts with {}=1",
+            prompts::NON_INTERACTIVE_ENV
+        );
+    }
+
     // Generate output filename with timestamp if not provided
     let output = args.output.unwrap_or_else(|| {
         let timestamp = Local::now().format("%Y-%m-%d-%H%M%S");
@@ -26,25 +39,37 @@ pub async fn run(args: Args) -> Result<()> {
 
     // Check if file already exists
     if output.exists() {
-        anyhow::bail!("File already exists: {}", output.display());
+        bail!("File already exists: {}", output.display());
     }
 
     // Try to get the last created app ID
     let config = turnkey::Config::load().await?;
     let last_app_id = config.get_last_app_id();
 
-    // Generate template
-    let config = DeployConfig::template(last_app_id.as_deref());
+    // Generate template (optionally walking prompts to fill it in)
+    let template = DeployConfig::template(last_app_id.as_deref());
+    let config = if args.interactive {
+        template.fill_interactively(last_app_id.as_deref())?
+    } else {
+        template
+    };
+
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
 
     // Write to file
     std::fs::write(&output, json)
         .with_context(|| format!("failed to write file: {}", output.display()))?;
 
-    println!("Created deployment config template: {}", output.display());
-    println!();
-    println!("Edit the file to fill in your values, then run:");
-    println!("  tvc deploy create --config-file {}", output.display());
+    if args.interactive {
+        println!("Created deployment config: {}", output.display());
+        println!();
+        println!("Run: tvc deploy create --config-file {}", output.display());
+    } else {
+        println!("Created deployment config template: {}", output.display());
+        println!();
+        println!("Edit the file to fill in your values, then run:");
+        println!("  tvc deploy create --config-file {}", output.display());
+    }
 
     Ok(())
 }

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -47,12 +47,10 @@ pub async fn run(args: Args) -> Result<()> {
     let last_app_id = config.get_last_app_id();
 
     // Generate template (optionally walking prompts to fill it in)
-    let template = DeployConfig::template(last_app_id.as_deref());
-    let config = if args.interactive {
-        template.fill_interactively(last_app_id.as_deref())?
-    } else {
-        template
-    };
+    let mut config = DeployConfig::template(last_app_id.as_deref());
+    if args.interactive {
+        config.fill_interactively(last_app_id.as_deref())?;
+    }
 
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
 

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -4,6 +4,7 @@ use crate::config::turnkey::{
     Config, KeyCurve, OrgConfig, StoredApiKey, StoredQosOperatorKey, API_BASE_URL_DEV,
     API_BASE_URL_LOCAL, API_BASE_URL_PREPROD, API_BASE_URL_PROD,
 };
+use crate::prompts;
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
@@ -11,6 +12,37 @@ use std::io::{BufRead, Write};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
+
+/// Turnkey API environment selectable during login.
+#[derive(Debug, Clone, Copy)]
+enum ApiEnv {
+    Prod,
+    Preprod,
+    Dev,
+    Local,
+}
+
+impl ApiEnv {
+    fn url(self) -> &'static str {
+        match self {
+            ApiEnv::Prod => API_BASE_URL_PROD,
+            ApiEnv::Preprod => API_BASE_URL_PREPROD,
+            ApiEnv::Dev => API_BASE_URL_DEV,
+            ApiEnv::Local => API_BASE_URL_LOCAL,
+        }
+    }
+}
+
+impl std::fmt::Display for ApiEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiEnv::Prod => write!(f, "prod     ({API_BASE_URL_PROD})"),
+            ApiEnv::Preprod => write!(f, "preprod  ({API_BASE_URL_PREPROD})"),
+            ApiEnv::Dev => write!(f, "dev      ({API_BASE_URL_DEV})"),
+            ApiEnv::Local => write!(f, "local    ({API_BASE_URL_LOCAL})"),
+        }
+    }
+}
 
 /// Authenticate with Turnkey and set up local credentials.
 #[derive(Debug, ClapArgs)]
@@ -98,6 +130,9 @@ async fn select_or_create_org(
         bail!("Organization '{org}' not found. Run `tvc login` without --org to set up a new organization.");
     }
 
+    // No --org provided — we'd need to prompt. Honor explicit opt-out.
+    prompts::bail_if_non_interactive("--org")?;
+
     // No --org provided, check existing orgs
     let org_count = config.orgs.len();
 
@@ -108,34 +143,46 @@ async fn select_or_create_org(
         return prompt_for_new_org(config).await;
     }
 
-    // Show existing orgs and let user select or add new
-    println!("Organization choices:");
-    for (alias, org) in &config.orgs {
-        let active = if config.active_org.as_ref() == Some(alias) {
-            " (active)"
-        } else {
-            ""
-        };
-        println!("  - {} ({}){}", alias, org.id, active);
+    // Show existing orgs in a `Select` list
+    let mut options: Vec<OrgChoice> = config
+        .orgs
+        .iter()
+        .map(|(alias, org)| {
+            let suffix = if config.active_org.as_ref() == Some(alias) {
+                " (active)"
+            } else {
+                ""
+            };
+            OrgChoice::Existing {
+                display: format!("{alias} ({}){suffix}", org.id),
+                alias: alias.clone(),
+            }
+        })
+        .collect();
+    options.push(OrgChoice::New);
+
+    match prompts::select("Select organization", options)? {
+        OrgChoice::Existing { alias, .. } => {
+            let org_config = config.orgs.get(&alias).unwrap().clone();
+            Ok((alias, org_config))
+        }
+        OrgChoice::New => prompt_for_new_org(config).await,
     }
-    println!("  - [new] Add a new organization");
-    println!();
+}
 
-    let selection = prompt("Enter organization alias or 'new'")?;
-    println!();
+/// Choices rendered by the org-selection `Select` widget.
+enum OrgChoice {
+    Existing { display: String, alias: String },
+    New,
+}
 
-    if selection == "new" {
-        debug!("user selected new organization");
-        return prompt_for_new_org(config).await;
+impl std::fmt::Display for OrgChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrgChoice::Existing { display, .. } => write!(f, "{display}"),
+            OrgChoice::New => write!(f, "[new] Add a new organization"),
+        }
     }
-
-    if let Some(org_config) = config.orgs.get(&selection) {
-        debug!(org_alias = %selection, "user selected existing organization");
-        return Ok((selection, org_config.clone()));
-    }
-
-    debug!("user selected unknown organization alias");
-    bail!("Organization '{}' not found", selection)
 }
 
 /// Prompt the user to enter a new organization ID and alias.
@@ -145,12 +192,13 @@ async fn prompt_for_new_org(config: &mut Config) -> Result<(String, OrgConfig)> 
     println!("You can find your Organization ID at: https://app.turnkey.com/dashboard/welcome");
     println!();
 
-    let org_id = prompt("Organization ID")?;
+    let org_id = prompts::text("Organization ID", None)?;
     if org_id.is_empty() {
         bail!("Organization ID is required");
     }
 
-    let alias = prompt_with_default("Organization alias", "default")?;
+    let alias = prompts::text("Organization alias", Some("default"))?;
+    debug!(org_alias = %alias, "user selected organization");
 
     // Prompt for API base URL
     let api_base_url = prompt_for_api_url()?;
@@ -162,28 +210,15 @@ async fn prompt_for_new_org(config: &mut Config) -> Result<(String, OrgConfig)> 
 }
 
 /// Prompt the user to select a Turnkey API URL.
+///
+/// Only reachable in TTY mode — `select_or_create_org` calls
+/// `bail_if_non_interactive` upstream before we get here.
 fn prompt_for_api_url() -> Result<String> {
-    println!();
-    println!("Select Turnkey API URL:");
-    println!("  1. prod (default) - {API_BASE_URL_PROD}");
-    println!("  2. preprod        - {API_BASE_URL_PREPROD}");
-    println!("  3. dev            - {API_BASE_URL_DEV}");
-    println!("  4. local          - {API_BASE_URL_LOCAL}");
-    println!();
-
-    let selection = prompt_with_default("API URL [1/2/3/4]", "1")?;
-
-    let url = match selection.as_str() {
-        "1" | "prod" | "" => API_BASE_URL_PROD,
-        "2" | "preprod" => API_BASE_URL_PREPROD,
-        "3" | "dev" => API_BASE_URL_DEV,
-        "4" | "local" => API_BASE_URL_LOCAL,
-        _ => bail!("Invalid selection: {selection}"),
-    };
-
-    debug!(api_base_url = %url, "selected API base URL");
-
-    Ok(url.to_string())
+    let env = prompts::select(
+        "Select Turnkey API URL",
+        vec![ApiEnv::Prod, ApiEnv::Preprod, ApiEnv::Dev, ApiEnv::Local],
+    )?;
+    Ok(env.url().to_string())
 }
 
 /// Get an existing API key or generate a new one.
@@ -291,37 +326,17 @@ fn find_org<'a>(config: &'a Config, org: &str) -> Option<(&'a String, &'a OrgCon
     None
 }
 
-/// Prompt the user for input and return the trimmed response.
-fn prompt(message: &str) -> Result<String> {
-    print!("{message}: ");
-    std::io::stdout().flush()?;
-
-    let mut input = String::new();
-    std::io::stdin().lock().read_line(&mut input)?;
-    Ok(input.trim().to_string())
-}
-
-/// Prompt the user for input with a default value.
-/// If the user enters nothing, returns the default.
-fn prompt_with_default(message: &str, default: &str) -> Result<String> {
-    print!("{message} [{default}]: ");
-    std::io::stdout().flush()?;
-
-    let mut input = String::new();
-    std::io::stdin().lock().read_line(&mut input)?;
-    let input = input.trim();
-
-    if input.is_empty() {
-        Ok(default.to_string())
-    } else {
-        Ok(input.to_string())
-    }
-}
-
-/// Wait for the user to press Enter.
+/// Wait for the user to press Enter. Skips the blocking read when
+/// `TVC_NON_INTERACTIVE` is set so non-interactive callers don't stall after
+/// the dashboard-registration instructions.
 fn wait_for_enter(message: &str) -> Result<()> {
     print!("{message}");
     std::io::stdout().flush()?;
+
+    if prompts::non_interactive_forced() {
+        println!();
+        return Ok(());
+    }
 
     let mut input = String::new();
     std::io::stdin().lock().read_line(&mut input)?;

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -97,7 +97,7 @@ impl AppConfig {
     ///
     /// `saved_operator_public_key` is offered as the default when prompting
     /// for a `<FILL_IN>` operator public key.
-    pub fn fill_interactively(mut self, saved_operator_public_key: Option<&str>) -> Result<Self> {
+    pub fn fill_interactively(&mut self, saved_operator_public_key: Option<&str>) -> Result<()> {
         if self.name.starts_with("<FILL_IN") {
             self.name = prompts::required_text("App name", None)?;
         }
@@ -123,7 +123,7 @@ impl AppConfig {
                 }
             }
         }
-        Ok(self)
+        Ok(())
     }
 
     /// Check if config contains placeholder values.

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -1,5 +1,7 @@
 //! App configuration file format for `tvc app create`.
 
+use crate::prompts;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
@@ -88,6 +90,40 @@ impl AppConfig {
                 .collect(),
             existing_operator_ids: vec![],
         }
+    }
+
+    /// Walk the user through any placeholder fields and fill them in.
+    /// Non-placeholder fields are preserved unchanged so partial edits work.
+    ///
+    /// `saved_operator_public_key` is offered as the default when prompting
+    /// for a `<FILL_IN>` operator public key.
+    pub fn fill_interactively(mut self, saved_operator_public_key: Option<&str>) -> Result<Self> {
+        if self.name.starts_with("<FILL_IN") {
+            self.name = prompts::required_text("App name", None)?;
+        }
+        if let Some(set_params) = self.manifest_set_params.as_mut() {
+            if set_params.name.starts_with("<FILL_IN") {
+                set_params.name = prompts::required_text("Manifest set name", None)?;
+            }
+            for op in set_params.new_operators.iter_mut() {
+                if op.public_key.starts_with("<FILL_IN") {
+                    let prompt = format!("Operator '{}' public key", op.name);
+                    op.public_key = prompts::required_text(&prompt, saved_operator_public_key)?;
+                }
+            }
+        }
+        if let Some(set_params) = self.share_set_params.as_mut() {
+            if set_params.name.starts_with("<FILL_IN") {
+                set_params.name = prompts::required_text("Share set name", None)?;
+            }
+            for op in set_params.new_operators.iter_mut() {
+                if op.public_key.starts_with("<FILL_IN") {
+                    let prompt = format!("Share set operator '{}' public key", op.name);
+                    op.public_key = prompts::required_text(&prompt, None)?;
+                }
+            }
+        }
+        Ok(self)
     }
 
     /// Check if config contains placeholder values.

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -53,7 +53,7 @@ impl DeployConfig {
     /// Non-placeholder fields are preserved unchanged so partial edits work.
     ///
     /// `saved_app_id` is offered as the default for the App ID prompt when set.
-    pub fn fill_interactively(mut self, saved_app_id: Option<&str>) -> Result<Self> {
+    pub fn fill_interactively(&mut self, saved_app_id: Option<&str>) -> Result<()> {
         if self.app_id.starts_with("<FILL_IN") {
             self.app_id = prompts::required_text("App ID", saved_app_id)?;
         }
@@ -81,7 +81,7 @@ impl DeployConfig {
                 );
             }
         }
-        Ok(self)
+        Ok(())
     }
 
     /// Check if config contains placeholder values.
@@ -115,6 +115,10 @@ impl DeployConfig {
             missing.push("--expected-pivot-digest");
         }
         missing
+    }
+
+    pub fn pull_secret_is_placeholder(&self) -> bool {
+        self.pivot_container_encrypted_pull_secret.as_deref() == Some(PULL_SECRET_PLACEHOLDER)
     }
 }
 
@@ -157,13 +161,13 @@ mod tests {
         config.expected_pivot_digest = "sha256:abc".into();
         config.pivot_container_encrypted_pull_secret = None;
 
-        let filled = config.clone().fill_interactively(None).unwrap();
-        assert_eq!(filled.app_id, "app_xyz");
-        assert_eq!(filled.qos_version, "0.6.1");
-        assert_eq!(filled.pivot_container_image_url, "ghcr.io/x/y:v1");
-        assert_eq!(filled.pivot_path, "/bin/pivot");
-        assert_eq!(filled.expected_pivot_digest, "sha256:abc");
-        assert_eq!(filled.pivot_container_encrypted_pull_secret, None);
+        config.fill_interactively(None).unwrap();
+        assert_eq!(config.app_id, "app_xyz");
+        assert_eq!(config.qos_version, "0.6.1");
+        assert_eq!(config.pivot_container_image_url, "ghcr.io/x/y:v1");
+        assert_eq!(config.pivot_path, "/bin/pivot");
+        assert_eq!(config.expected_pivot_digest, "sha256:abc");
+        assert_eq!(config.pivot_container_encrypted_pull_secret, None);
     }
 
     #[test]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -1,7 +1,14 @@
 //! Deployment configuration file format for `tvc deploy create`.
 
+use crate::prompts;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
+
+/// Sentinel written by `tvc deploy init` to remind the user to either remove
+/// the field (public image) or replace it with an encrypted pull secret
+/// (private image). Treated as a placeholder by [`DeployConfig::has_placeholders`].
+const PULL_SECRET_PLACEHOLDER: &str = "<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>";
 
 /// Deployment configuration loaded from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,13 +42,57 @@ impl DeployConfig {
             pivot_args: vec![],
             expected_pivot_digest: "<FILL_IN_EXPECTED_PIVOT_DIGEST>".to_string(),
             debug_mode: Some(false),
-            pivot_container_encrypted_pull_secret: Some(
-                "<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>".to_string(),
-            ),
+            pivot_container_encrypted_pull_secret: Some(PULL_SECRET_PLACEHOLDER.to_string()),
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,
             public_ingress_port: 3000,
         }
+    }
+
+    /// Walk the user through any placeholder fields and fill them in.
+    /// Non-placeholder fields are preserved unchanged so partial edits work.
+    ///
+    /// `saved_app_id` is offered as the default for the App ID prompt when set.
+    pub fn fill_interactively(mut self, saved_app_id: Option<&str>) -> Result<Self> {
+        if self.app_id.starts_with("<FILL_IN") {
+            self.app_id = prompts::required_text("App ID", saved_app_id)?;
+        }
+        if self.qos_version.starts_with("<FILL_IN") {
+            self.qos_version = prompts::required_text("QOS version", None)?;
+        }
+        if self.pivot_container_image_url.starts_with("<FILL_IN") {
+            self.pivot_container_image_url =
+                prompts::required_text("Pivot container image URL", None)?;
+        }
+        if self.pivot_path.starts_with("<FILL_IN") {
+            self.pivot_path = prompts::required_text("Pivot path (inside container)", None)?;
+        }
+        if self.expected_pivot_digest.starts_with("<FILL_IN") {
+            self.expected_pivot_digest =
+                prompts::required_text("Expected pivot digest (sha256:...)", None)?;
+        }
+        if self.pivot_container_encrypted_pull_secret.as_deref() == Some(PULL_SECRET_PLACEHOLDER) {
+            let is_public = prompts::confirm("Is the container image in a public registry?", true)?;
+            self.pivot_container_encrypted_pull_secret = None;
+            if !is_public {
+                println!(
+                    "Note: pass `--pivot-pull-secret <PATH>` when running \
+                     `tvc deploy create` to encrypt and attach the pull secret."
+                );
+            }
+        }
+        Ok(self)
+    }
+
+    /// Check if config contains placeholder values.
+    pub fn has_placeholders(&self) -> bool {
+        self.app_id.starts_with("<FILL_IN")
+            || self.qos_version.starts_with("<FILL_IN")
+            || self.pivot_container_image_url.starts_with("<FILL_IN")
+            || self.pivot_path.starts_with("<FILL_IN")
+            || self.expected_pivot_digest.starts_with("<FILL_IN")
+            || self.pivot_container_encrypted_pull_secret.as_deref()
+                == Some(PULL_SECRET_PLACEHOLDER)
     }
 
     /// Return the user-facing flag names of fields still containing
@@ -64,5 +115,66 @@ impl DeployConfig {
             missing.push("--expected-pivot-digest");
         }
         missing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_template_is_all_placeholders() {
+        let config = DeployConfig::template(None);
+        assert!(config.has_placeholders());
+    }
+
+    #[test]
+    fn filled_config_with_pull_secret_still_placeholder_is_detected() {
+        // Previously this case slipped through: all FILL_IN fields replaced,
+        // but the pull-secret sentinel left intact.
+        let mut config = DeployConfig::template(None);
+        config.app_id = "app_123".into();
+        config.qos_version = "0.6.1".into();
+        config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
+        config.pivot_path = "/bin/pivot".into();
+        config.expected_pivot_digest = "sha256:abc".into();
+        assert!(
+            config.has_placeholders(),
+            "pull-secret sentinel must count as a placeholder"
+        );
+    }
+
+    #[test]
+    fn fill_interactively_is_noop_when_config_has_no_placeholders() {
+        // If every field is already set, fill_interactively must not attempt
+        // to prompt — this is the contract that lets unit tests run without
+        // injecting stdin.
+        let mut config = DeployConfig::template(None);
+        config.app_id = "app_xyz".into();
+        config.qos_version = "0.6.1".into();
+        config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
+        config.pivot_path = "/bin/pivot".into();
+        config.expected_pivot_digest = "sha256:abc".into();
+        config.pivot_container_encrypted_pull_secret = None;
+
+        let filled = config.clone().fill_interactively(None).unwrap();
+        assert_eq!(filled.app_id, "app_xyz");
+        assert_eq!(filled.qos_version, "0.6.1");
+        assert_eq!(filled.pivot_container_image_url, "ghcr.io/x/y:v1");
+        assert_eq!(filled.pivot_path, "/bin/pivot");
+        assert_eq!(filled.expected_pivot_digest, "sha256:abc");
+        assert_eq!(filled.pivot_container_encrypted_pull_secret, None);
+    }
+
+    #[test]
+    fn fully_filled_config_has_no_placeholders() {
+        let mut config = DeployConfig::template(None);
+        config.app_id = "app_123".into();
+        config.qos_version = "0.6.1".into();
+        config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
+        config.pivot_path = "/bin/pivot".into();
+        config.expected_pivot_digest = "sha256:abc".into();
+        config.pivot_container_encrypted_pull_secret = None;
+        assert!(!config.has_placeholders());
     }
 }

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod logging;
 pub(crate) mod operator_key;
 pub mod pair;
+pub mod prompts;
 pub(crate) mod provisioning;
 pub mod pull_secret;
 pub(crate) mod quorum_key_metadata;

--- a/tvc/src/prompts.rs
+++ b/tvc/src/prompts.rs
@@ -1,0 +1,154 @@
+//! Interactive prompts for the TVC CLI.
+//!
+//! Thin wrappers over [`inquire`]. Every primitive requires a real TTY; callers
+//! that expect to drive prompts from CI or scripts must use the corresponding
+//! flag, set `TVC_NON_INTERACTIVE=1`, or both.
+//!
+//! Non-interactive awareness:
+//!
+//! - [`is_interactive`] — true only when stdin is a TTY **and**
+//!   `TVC_NON_INTERACTIVE` is unset.
+//! - [`bail_if_non_interactive`] — errors with a clear message naming the
+//!   flag the caller should set instead. Used at the top of any function
+//!   that's about to prompt.
+//! - [`require_or_prompt`] — single-value variant: take the flag if set,
+//!   prompt if interactive, otherwise error.
+
+use anyhow::{bail, Result};
+use inquire::{Confirm, Password, Select, Text};
+use std::fmt::Display;
+use std::io::IsTerminal;
+
+/// Env var that forces non-interactive mode.
+pub const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+
+/// True when we are in a full interactive session: stdin is a TTY and
+/// `TVC_NON_INTERACTIVE` is unset.
+pub fn is_interactive() -> bool {
+    if non_interactive_forced() {
+        return false;
+    }
+    std::io::stdin().is_terminal()
+}
+
+/// True when the user has explicitly set `TVC_NON_INTERACTIVE`.
+pub fn non_interactive_forced() -> bool {
+    std::env::var_os(NON_INTERACTIVE_ENV).is_some()
+}
+
+/// Error with a clear message when we cannot prompt — either the env var is
+/// set, or stdin is not a TTY.
+///
+/// `flag_hint` is the flag the user should set instead (e.g. `"--org"`).
+pub fn bail_if_non_interactive(flag_hint: &str) -> Result<()> {
+    if !is_interactive() {
+        bail!(
+            "{flag_hint} is required in non-interactive mode \
+             (set {flag_hint} or run in a TTY without {NON_INTERACTIVE_ENV})"
+        );
+    }
+    Ok(())
+}
+
+/// Prompt for a non-empty line of text. Bails with `{message} cannot be empty`
+/// if the user submits an empty (or whitespace-only) value.
+pub fn required_text(message: &str, default: Option<&str>) -> Result<String> {
+    let value = text(message, default)?;
+    if value.trim().is_empty() {
+        bail!("{message} cannot be empty");
+    }
+    Ok(value)
+}
+
+/// Prompt for a line of text, optionally with a default value.
+pub fn text(message: &str, default: Option<&str>) -> Result<String> {
+    let mut prompt = Text::new(message);
+    if let Some(d) = default {
+        prompt = prompt.with_default(d);
+    }
+    Ok(prompt.prompt()?)
+}
+
+/// Prompt for a yes/no confirmation with a default.
+pub fn confirm(message: &str, default: bool) -> Result<bool> {
+    Ok(Confirm::new(message).with_default(default).prompt()?)
+}
+
+/// Prompt for a selection from a list.
+pub fn select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
+    Ok(Select::new(message, options).prompt()?)
+}
+
+/// Prompt for a secret value with masked input.
+pub fn password(message: &str) -> Result<String> {
+    Ok(Password::new(message).without_confirmation().prompt()?)
+}
+
+/// Returns the flag value if set; otherwise prompts the user when interactive;
+/// otherwise errors with a message naming the flag to set.
+///
+/// `flag_name` is the literal CLI flag (e.g. `"--deploy-id"`) shown in the
+/// non-interactive error message.
+pub fn require_or_prompt<T>(
+    value: Option<T>,
+    flag_name: &str,
+    prompt_fn: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    require_or_prompt_impl(value, flag_name, is_interactive(), prompt_fn)
+}
+
+fn require_or_prompt_impl<T>(
+    value: Option<T>,
+    flag_name: &str,
+    interactive: bool,
+    prompt_fn: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    if let Some(v) = value {
+        return Ok(v);
+    }
+    if !interactive {
+        bail!(
+            "flag {flag_name} is required in non-interactive mode \
+             (set {flag_name} or unset {NON_INTERACTIVE_ENV})"
+        );
+    }
+    prompt_fn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_or_prompt_returns_supplied_value_without_prompting() {
+        let result: Result<String> =
+            require_or_prompt_impl(Some("hello".to_string()), "--foo", false, || {
+                panic!("should not prompt when value is present")
+            });
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn require_or_prompt_errors_when_non_interactive_and_names_flag() {
+        let result: Result<String> = require_or_prompt_impl(None, "--deploy-id", false, || {
+            panic!("should not prompt when non-interactive")
+        });
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("--deploy-id"), "error names the flag: {err}");
+        assert!(
+            err.contains("non-interactive"),
+            "error mentions non-interactive: {err}"
+        );
+        assert!(
+            err.contains(NON_INTERACTIVE_ENV),
+            "error names the env var: {err}"
+        );
+    }
+
+    #[test]
+    fn require_or_prompt_runs_prompt_when_interactive() {
+        let result: Result<String> =
+            require_or_prompt_impl(None, "--foo", true, || Ok("prompted".to_string()));
+        assert_eq!(result.unwrap(), "prompted");
+    }
+}

--- a/tvc/src/prompts.rs
+++ b/tvc/src/prompts.rs
@@ -11,8 +11,6 @@
 //! - [`bail_if_non_interactive`] — errors with a clear message naming the
 //!   flag the caller should set instead. Used at the top of any function
 //!   that's about to prompt.
-//! - [`require_or_prompt`] — single-value variant: take the flag if set,
-//!   prompt if interactive, otherwise error.
 
 use anyhow::{bail, Result};
 use inquire::{Confirm, Password, Select, Text};
@@ -82,73 +80,4 @@ pub fn select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
 /// Prompt for a secret value with masked input.
 pub fn password(message: &str) -> Result<String> {
     Ok(Password::new(message).without_confirmation().prompt()?)
-}
-
-/// Returns the flag value if set; otherwise prompts the user when interactive;
-/// otherwise errors with a message naming the flag to set.
-///
-/// `flag_name` is the literal CLI flag (e.g. `"--deploy-id"`) shown in the
-/// non-interactive error message.
-pub fn require_or_prompt<T>(
-    value: Option<T>,
-    flag_name: &str,
-    prompt_fn: impl FnOnce() -> Result<T>,
-) -> Result<T> {
-    require_or_prompt_impl(value, flag_name, is_interactive(), prompt_fn)
-}
-
-fn require_or_prompt_impl<T>(
-    value: Option<T>,
-    flag_name: &str,
-    interactive: bool,
-    prompt_fn: impl FnOnce() -> Result<T>,
-) -> Result<T> {
-    if let Some(v) = value {
-        return Ok(v);
-    }
-    if !interactive {
-        bail!(
-            "flag {flag_name} is required in non-interactive mode \
-             (set {flag_name} or unset {NON_INTERACTIVE_ENV})"
-        );
-    }
-    prompt_fn()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn require_or_prompt_returns_supplied_value_without_prompting() {
-        let result: Result<String> =
-            require_or_prompt_impl(Some("hello".to_string()), "--foo", false, || {
-                panic!("should not prompt when value is present")
-            });
-        assert_eq!(result.unwrap(), "hello");
-    }
-
-    #[test]
-    fn require_or_prompt_errors_when_non_interactive_and_names_flag() {
-        let result: Result<String> = require_or_prompt_impl(None, "--deploy-id", false, || {
-            panic!("should not prompt when non-interactive")
-        });
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("--deploy-id"), "error names the flag: {err}");
-        assert!(
-            err.contains("non-interactive"),
-            "error mentions non-interactive: {err}"
-        );
-        assert!(
-            err.contains(NON_INTERACTIVE_ENV),
-            "error names the env var: {err}"
-        );
-    }
-
-    #[test]
-    fn require_or_prompt_runs_prompt_when_interactive() {
-        let result: Result<String> =
-            require_or_prompt_impl(None, "--foo", true, || Ok("prompted".to_string()));
-        assert_eq!(result.unwrap(), "prompted");
-    }
 }

--- a/tvc/src/prompts.rs
+++ b/tvc/src/prompts.rs
@@ -72,6 +72,19 @@ pub fn confirm(message: &str, default: bool) -> Result<bool> {
     Ok(Confirm::new(message).with_default(default).prompt()?)
 }
 
+/// Prompt for yes/no confirmation; bail with `"operation cancelled by user:
+/// {operation}"` on No. Default is No (safer for destructive prompts).
+///
+/// `operation` names the action being confirmed (e.g. `"approval"`,
+/// `"deletion"`) so the error string identifies which step the user backed out
+/// of when multiple confirmation prompts run in sequence.
+pub fn confirm_or_bail(message: &str, operation: &str) -> Result<()> {
+    if !confirm(message, false)? {
+        bail!("operation cancelled by user: {operation}");
+    }
+    Ok(())
+}
+
 /// Prompt for a selection from a list.
 pub fn select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
     Ok(Select::new(message, options).prompt()?)

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -29,53 +29,6 @@ fn dangerous_approve_with_file() {
 }
 
 #[test]
-fn approve_interactive_prompts() {
-    // Simulate user typing "yes" or "y" for each of the 5 prompts:
-    // namespace, enclave, pivot, manifest set, share set
-    let input = "yes\nyes\ny\nyes\ny\n";
-
-    cargo_bin_cmd!("tvc")
-        .arg("deploy")
-        .arg("approve")
-        .arg("--manifest")
-        .arg("fixtures/manifest.json")
-        .arg("--operator-seed")
-        .arg("fixtures/seed.hex")
-        .arg("--skip-post")
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("MANIFEST APPROVAL"))
-        .stdout(predicate::str::contains("NAMESPACE"))
-        .stdout(predicate::str::contains("turnkey-prod"))
-        .stdout(predicate::str::contains("ENCLAVE (AWS Nitro)"))
-        .stdout(predicate::str::contains("PIVOT BINARY"))
-        .stdout(predicate::str::contains("MANIFEST SET"))
-        .stdout(predicate::str::contains("operator-alice"))
-        .stdout(predicate::str::contains("SHARE SET"))
-        .stdout(predicate::str::contains("ALL SECTIONS APPROVED"))
-        .stdout(predicate::str::contains("\"signature\""));
-}
-
-#[test]
-fn approve_interactive_reject() {
-    // User rejects at first prompt
-    let input = "no\n";
-
-    cargo_bin_cmd!("tvc")
-        .arg("deploy")
-        .arg("approve")
-        .arg("--manifest")
-        .arg("fixtures/manifest.json")
-        .arg("--operator-seed")
-        .arg("fixtures/seed.hex")
-        .write_stdin(input)
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("operation cancelled by user"));
-}
-
-#[test]
 fn manifest_and_deploy_id_are_mutually_exclusive() {
     cargo_bin_cmd!("tvc")
         .arg("deploy")

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -2,18 +2,21 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
+/// When `--org <alias>` points to an alias that is not present in the local
+/// config, we fail fast without entering any interactive flow. Exercises the
+/// early-return branch in `select_or_create_org`.
 #[test]
-fn login_empty_org_id_fails() {
+fn login_errors_when_provided_org_not_found() {
     let temp = TempDir::new().unwrap();
-
-    // User enters empty org ID
-    let input = "\n";
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
         .arg("login")
-        .write_stdin(input)
+        .arg("--org")
+        .arg("does-not-exist")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Organization ID is required"));
+        .stderr(predicate::str::contains(
+            "Organization 'does-not-exist' not found",
+        ));
 }

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -1,0 +1,109 @@
+//! Non-interactive regression fence.
+//!
+//! When `TVC_NON_INTERACTIVE=1` is set, every command that would otherwise
+//! prompt must fail fast with a clear "flag X is required in non-interactive
+//! mode" error instead of hanging.
+//!
+//! Commands join this fence as they gain prompting behavior. Commit 2 covers
+//! `login` and `deploy approve`.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+
+#[test]
+fn login_without_org_errors_when_non_interactive_forced() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--org is required in non-interactive mode",
+        ))
+        .stderr(predicate::str::contains(NON_INTERACTIVE_ENV));
+}
+
+#[test]
+fn approve_without_skip_interactive_errors_when_non_interactive_forced() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--skip-post")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--dangerous-skip-interactive is required in non-interactive mode",
+        ))
+        .stderr(predicate::str::contains(NON_INTERACTIVE_ENV));
+}
+
+#[test]
+fn deploy_init_interactive_conflicts_with_non_interactive_env() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .current_dir(temp.path())
+        .arg("deploy")
+        .arg("init")
+        .arg("--interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--interactive conflicts with TVC_NON_INTERACTIVE",
+        ));
+}
+
+#[test]
+fn app_init_interactive_conflicts_with_non_interactive_env() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .current_dir(temp.path())
+        .arg("app")
+        .arg("init")
+        .arg("--interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--interactive conflicts with TVC_NON_INTERACTIVE",
+        ));
+}
+
+/// Guardrail: `--dangerous-skip-interactive` continues to bypass prompts
+/// cleanly even with `TVC_NON_INTERACTIVE=1` set.
+#[test]
+fn approve_dangerous_skip_interactive_bypasses_prompts_when_non_interactive_forced() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--dangerous-skip-interactive")
+        .arg("--skip-post")
+        .assert()
+        .success();
+}

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -1,11 +1,10 @@
-//! Non-interactive regression fence.
+//! Regression tests for non-interactive mode for CI
 //!
 //! When `TVC_NON_INTERACTIVE=1` is set, every command that would otherwise
 //! prompt must fail fast with a clear "flag X is required in non-interactive
 //! mode" error instead of hanging.
 //!
-//! Commands join this fence as they gain prompting behavior. Commit 2 covers
-//! `login` and `deploy approve`.
+//! Commands join this fence as they gain prompting behavior.
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -66,8 +66,8 @@ fn approve_walks_all_sections_with_yeses() {
 }
 
 /// Rejecting at the third section (pivot) bails immediately with the exact
-/// "approval cancelled by user" string and never reaches the manifest-set
-/// section.
+/// "operation cancelled by user: approval" string and never reaches the
+/// manifest-set section.
 ///
 /// Replaces the deleted `tests/deploy_approve.rs::approve_interactive_reject`.
 #[test]
@@ -88,7 +88,9 @@ fn approve_bails_when_user_rejects_pivot() {
     session.exp_string("Approve pivot binary?").unwrap();
     session.send_line("n").unwrap();
 
-    session.exp_string("approval cancelled by user").unwrap();
+    session
+        .exp_string("operation cancelled by user: approval")
+        .unwrap();
     session.exp_eof().unwrap();
 }
 

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -1,9 +1,9 @@
 //! PTY-based integration tests.
 //!
-//! Drives the real `tvc` binary through a pseudo-terminal so inquire's TTY
+//! Drives the real `tvc` binary through a pseudo-terminal so `inquire`'s TTY
 //! code path is exercised end-to-end.
 //!
-//! Gated `#[cfg(unix)]` because rexpect uses Unix PTYs; Windows users hit
+//! Gated `#[cfg(unix)]` because `rexpect` uses Unix PTYs; Windows users hit
 //! inquire via ConPTY in production, but we don't test that surface here.
 
 #![cfg(unix)]

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -1,0 +1,120 @@
+//! PTY-based integration tests.
+//!
+//! Drives the real `tvc` binary through a pseudo-terminal so inquire's TTY
+//! code path is exercised end-to-end.
+//!
+//! Gated `#[cfg(unix)]` because rexpect uses Unix PTYs; Windows users hit
+//! inquire via ConPTY in production, but we don't test that surface here.
+
+#![cfg(unix)]
+
+use rexpect::session::PtySession;
+
+/// Default per-step timeout. Generous enough for CI-runner cold cargo builds
+/// of the binary; tight enough to fail fast if an `exp_string` mismatches.
+const TIMEOUT_MS: u64 = 10_000;
+
+fn spawn(args: &str) -> PtySession {
+    let bin = env!("CARGO_BIN_EXE_tvc");
+    let cmd = format!("{bin} {args}");
+    rexpect::spawn(&cmd, Some(TIMEOUT_MS))
+        .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {cmd}"))
+}
+
+/// `tvc deploy approve` walks all five section confirmations in order and
+/// emits the signed approval JSON when the user accepts every section.
+///
+/// Replaces the deleted `tests/deploy_approve.rs::approve_interactive_prompts`
+/// integration test which used piped stdin.
+#[test]
+fn approve_walks_all_sections_with_yeses() {
+    let mut session = spawn(
+        "deploy approve \
+         --manifest fixtures/manifest.json \
+         --operator-seed fixtures/seed.hex \
+         --skip-post",
+    );
+
+    session.exp_string("MANIFEST APPROVAL").unwrap();
+    session.exp_string("NAMESPACE").unwrap();
+    session.exp_string("turnkey-prod").unwrap();
+    session.exp_string("Approve namespace?").unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("ENCLAVE (AWS Nitro)").unwrap();
+    session
+        .exp_string("Approve enclave configuration?")
+        .unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("PIVOT BINARY").unwrap();
+    session.exp_string("Approve pivot binary?").unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("MANIFEST SET").unwrap();
+    session.exp_string("operator-alice").unwrap();
+    session.exp_string("Approve manifest set?").unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("SHARE SET").unwrap();
+    session.exp_string("Approve share set?").unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("ALL SECTIONS APPROVED").unwrap();
+    session.exp_string("\"signature\"").unwrap();
+    session.exp_eof().unwrap();
+}
+
+/// Rejecting at the third section (pivot) bails immediately with the exact
+/// "approval cancelled by user" string and never reaches the manifest-set
+/// section.
+///
+/// Replaces the deleted `tests/deploy_approve.rs::approve_interactive_reject`.
+#[test]
+fn approve_bails_when_user_rejects_pivot() {
+    let mut session = spawn(
+        "deploy approve \
+         --manifest fixtures/manifest.json \
+         --operator-seed fixtures/seed.hex \
+         --skip-post",
+    );
+
+    session.exp_string("Approve namespace?").unwrap();
+    session.send_line("y").unwrap();
+    session
+        .exp_string("Approve enclave configuration?")
+        .unwrap();
+    session.send_line("y").unwrap();
+    session.exp_string("Approve pivot binary?").unwrap();
+    session.send_line("n").unwrap();
+
+    session.exp_string("approval cancelled by user").unwrap();
+    session.exp_eof().unwrap();
+}
+
+/// Submitting an empty Organization ID at the new-org prompt errors with the
+/// exact bail string.
+///
+/// Replaces the deleted `tests/login.rs::login_empty_org_id_fails`.
+#[test]
+fn login_with_empty_org_id_bails() {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_tvc");
+    let cmd = format!("{bin} login");
+
+    let mut session = rexpect::session::spawn_command(
+        {
+            let mut c = std::process::Command::new(bin);
+            c.arg("login").env("HOME", temp.path());
+            c
+        },
+        Some(TIMEOUT_MS),
+    )
+    .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {cmd}"));
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line("").unwrap();
+    session.exp_string("Organization ID is required").unwrap();
+    session.exp_eof().unwrap();
+}

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -68,8 +68,6 @@ fn approve_walks_all_sections_with_yeses() {
 /// Rejecting at the third section (pivot) bails immediately with the exact
 /// "operation cancelled by user: approval" string and never reaches the
 /// manifest-set section.
-///
-/// Replaces the deleted `tests/deploy_approve.rs::approve_interactive_reject`.
 #[test]
 fn approve_bails_when_user_rejects_pivot() {
     let mut session = spawn(


### PR DESCRIPTION
Adds interactive mode for some TVC commands, and supports filling placeholders step by step. 

`delete` commands were untouched


AI generated content below: 
___
## Summary

Make `tvc` interactive in a TTY without breaking CI. Users in a terminal get walked through missing values; CI runners get a clear "flag X is required in non-interactive mode" error instead of a hang.

## What's new

**Prompts module (`src/prompts.rs`)**
- `inquire`-backed `text` / `required_text` / `confirm` / `select` / `password`
- `is_interactive()` — true only when stdin is a TTY and `TVC_NON_INTERACTIVE` is unset
- `bail_if_non_interactive(flag_hint)` — fails fast with a message naming the flag to set instead of stalling
- `confirm_or_bail(message, operation)` — wraps `confirm` and bails with `"operation cancelled by user: {operation}"` on No; used by all 5 `deploy approve` section confirmations

**Interactive walking in commands**
- `tvc login` — `Select` widget for org choice; `Text` for new org ID/alias; `Select` for API environment (prod/preprod/dev/local)
- `tvc deploy approve` — refuses to run without `--dangerous-skip-interactive` in non-interactive mode; uses `Select` when multiple saved operator IDs are available (was: silently picked the first)
- `tvc {app,deploy} init` — new `--interactive` flag walks every placeholder and writes a filled config instead of a template
- `tvc {app,deploy} create` — if the config file is missing or has `<FILL_IN_...>` placeholders, walks the gaps in a TTY and offers to save the filled config back. Non-interactive behavior is unchanged for required fields: bails with the list of missing flags

**Non-interactive guard**
- `TVC_NON_INTERACTIVE=1` forces non-interactive everywhere
- Commands that would prompt instead bail with `--<flag> is required in non-interactive mode (set --<flag> or run in a TTY without TVC_NON_INTERACTIVE)`
- `--interactive` on init commands conflicts with `TVC_NON_INTERACTIVE` and errors loudly
- The `<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>` sentinel in `deploy create` configs now bails non-interactively with a message that names the JSON field and the resolution flag, instead of silently shipping the placeholder to the API

## Dependencies

- `inquire = "0.9"` (runtime)
- `rexpect = "0.5"` (dev-only, for PTY tests)

Both added to workspace `Cargo.toml` and `tvc/Cargo.toml`.

## Testing
- build `cargo build -p tvc` locally and alias your tvc command via `alias tvc='./target/debug/tvc'`
- Run `tvc login`, `tvc deploy`, and `tvc app` commands 