### PR TITLE
rust codegen to follow new activites.json format

### DIFF
--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -2489,9 +2489,9 @@ impl<S: Stamp> TurnkeyClient<S> {
         organization_id: String,
         timestamp_ms: u128,
         params: immutable_activity::InitOtpIntentV3,
-    ) -> Result<ActivityResult<immutable_activity::InitOtpResult>, TurnkeyClientError> {
+    ) -> Result<ActivityResult<immutable_activity::InitOtpResultV2>, TurnkeyClientError> {
         let request = external_activity::InitOtpRequest {
-            r#type: "ACTIVITY_TYPE_INIT_OTP_V2".to_string(),
+            r#type: "ACTIVITY_TYPE_INIT_OTP_V3".to_string(),
             timestamp_ms: timestamp_ms.to_string(),
             parameters: Some(params),
             organization_id,
@@ -2506,7 +2506,7 @@ impl<S: Stamp> TurnkeyClient<S> {
             .inner
             .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
         let result = match inner {
-            immutable_activity::result::Inner::InitOtpResult(res) => res,
+            immutable_activity::result::Inner::InitOtpResultV2(res) => res,
             other => {
                 return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
                     serde_json::to_string(&other)?,

--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -4119,4 +4119,170 @@ impl<S: Stamp> TurnkeyClient<S> {
         self.process_request(&request, "/public/v1/query/get_ip_allowlist".to_string())
             .await
     }
+    /// Sign Frost Spark
+    ///
+    /// Perform pure FROST partial signing for a Spark wallet. Produces partial signatures without constructing operator packages.
+    pub async fn spark_sign_frost(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::SparkSignFrostIntent,
+    ) -> Result<ActivityResult<immutable_activity::SparkSignFrostResult>, TurnkeyClientError> {
+        let request = external_activity::SparkSignFrostRequest {
+            r#type: "ACTIVITY_TYPE_SPARK_SIGN_FROST".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/spark_sign_frost".to_string())
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::SparkSignFrostResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// Prepare Spark transfer
+    ///
+    /// Construct sender-side encrypted operator packages for a Spark BTC transfer. Does not perform FROST signing.
+    pub async fn spark_prepare_transfer(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::SparkPrepareTransferIntent,
+    ) -> Result<ActivityResult<immutable_activity::SparkPrepareTransferResult>, TurnkeyClientError>
+    {
+        let request = external_activity::SparkPrepareTransferRequest {
+            r#type: "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/spark_prepare_transfer".to_string(),
+            )
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::SparkPrepareTransferResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// Claim Spark transfer
+    ///
+    /// Construct receiver-side encrypted operator packages to claim a Spark transfer. Does not perform FROST signing.
+    pub async fn spark_claim_transfer(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::SparkClaimTransferIntent,
+    ) -> Result<ActivityResult<immutable_activity::SparkClaimTransferResult>, TurnkeyClientError>
+    {
+        let request = external_activity::SparkClaimTransferRequest {
+            r#type: "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/spark_claim_transfer".to_string(),
+            )
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::SparkClaimTransferResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// Spark prepare Lightning receive
+    ///
+    /// Generate a Lightning preimage and distribute Feldman shares to operators for a Spark Lightning receive. Does not perform FROST signing.
+    pub async fn spark_prepare_lightning_receive(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::SparkPrepareLightningReceiveIntent,
+    ) -> Result<
+        ActivityResult<immutable_activity::SparkPrepareLightningReceiveResult>,
+        TurnkeyClientError,
+    > {
+        let request = external_activity::SparkPrepareLightningReceiveRequest {
+            r#type: "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(
+                &request,
+                "/public/v1/submit/spark_prepare_lightning_receive".to_string(),
+            )
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::SparkPrepareLightningReceiveResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
 }

--- a/client/src/generated/external.activity.v1.rs
+++ b/client/src/generated/external.activity.v1.rs
@@ -1593,3 +1593,55 @@ pub struct RestoreTvcDeploymentRequest {
     #[serde(default)]
     pub generate_app_proofs: ::core::option::Option<bool>,
 }
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SparkSignFrostRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::SparkSignFrostIntent,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SparkPrepareTransferRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::SparkPrepareTransferIntent,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SparkClaimTransferRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::SparkClaimTransferIntent,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SparkPrepareLightningReceiveRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::SparkPrepareLightningReceiveIntent,
+    >,
+}

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -3747,7 +3747,7 @@ pub struct SparkClaimLeaf {
 }
 #[derive(Debug)]
 /// Build a transfer: for each leaf, derive the new leaf private key via HD
-/// (SIGNING_HD on new_leaf_derivation), compute the claim tweak scalar
+/// (SigningLeaf on new_leaf_derivation), compute the claim tweak scalar
 /// = old_priv - new_priv (mod n), Feldman-split the tweak across operators,
 /// and ECIES-encrypt the new leaf private key to receiver_public_key as
 /// the per-leaf secret_cipher carried inside each per-operator package.
@@ -3839,6 +3839,8 @@ pub struct SparkSignatureRequest {
     /// @inject_tag: validate:"required,dive"
     #[serde(default)]
     pub operator_commitments: ::prost::alloc::vec::Vec<SparkFrostCommitment>,
+    #[serde(default)]
+    pub adaptor_public_key: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Debug)]
 /// Per-signature output from SPARK_SIGN_FROST: Turnkey's FROST partial
@@ -3853,26 +3855,9 @@ pub struct SparkPartialSignature {
     pub binding: ::prost::alloc::string::String,
 }
 #[derive(Debug)]
-/// Request to derive the public key at a specific Spark key path.
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq)]
-pub struct SparkDerivePublicKeyRequest {
-    /// @inject_tag: validate:"required"
-    #[serde(default)]
-    pub derivation: ::core::option::Option<SparkKeyDerivation>,
-}
-#[derive(Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq)]
-pub struct SparkDerivedPublicKey {
-    pub public_key: ::prost::alloc::string::String,
-}
-#[derive(Debug)]
-/// Pairs a Spark leaf_id with its derived SIGNING_HD public key.
+/// Pairs a Spark leaf_id with its derived SigningLeaf public key.
 /// Returned by transfer and claim flows so callers can avoid a follow-up
-/// per-leaf SIGNING_HD pubkey-derivation round-trip.
+/// per-leaf SigningLeaf pubkey-derivation round-trip.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
@@ -4384,12 +4369,14 @@ pub enum ActivityType {
     DeleteTvcAppAndDeployments = 132,
     #[serde(rename = "ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT")]
     RestoreTvcDeployment = 133,
-    /// Reserving the following for now to preserve ordering with Intent enum.
-    ///
-    /// ACTIVITY_TYPE_SPARK_SIGN_FROST = 134;
-    /// ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER = 135;
-    /// ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER = 136;
-    /// ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE = 137;
+    #[serde(rename = "ACTIVITY_TYPE_SPARK_SIGN_FROST")]
+    SparkSignFrost = 134,
+    #[serde(rename = "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER")]
+    SparkPrepareTransfer = 135,
+    #[serde(rename = "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER")]
+    SparkClaimTransfer = 136,
+    #[serde(rename = "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE")]
+    SparkPrepareLightningReceive = 137,
     #[serde(rename = "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE")]
     PostTvcQuorumKeyShare = 138,
 }
@@ -4554,6 +4541,12 @@ impl ActivityType {
                 "ACTIVITY_TYPE_DELETE_TVC_APP_AND_DEPLOYMENTS"
             }
             Self::RestoreTvcDeployment => "ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT",
+            Self::SparkSignFrost => "ACTIVITY_TYPE_SPARK_SIGN_FROST",
+            Self::SparkPrepareTransfer => "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER",
+            Self::SparkClaimTransfer => "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER",
+            Self::SparkPrepareLightningReceive => {
+                "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"
+            }
             Self::PostTvcQuorumKeyShare => "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
         }
     }
@@ -4746,6 +4739,12 @@ impl ActivityType {
                 Some(Self::DeleteTvcAppAndDeployments)
             }
             "ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT" => Some(Self::RestoreTvcDeployment),
+            "ACTIVITY_TYPE_SPARK_SIGN_FROST" => Some(Self::SparkSignFrost),
+            "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER" => Some(Self::SparkPrepareTransfer),
+            "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER" => Some(Self::SparkClaimTransfer),
+            "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE" => {
+                Some(Self::SparkPrepareLightningReceive)
+            }
             "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE" => {
                 Some(Self::PostTvcQuorumKeyShare)
             }
@@ -4870,57 +4869,6 @@ impl ActivityProtectedCategory {
             "ACTIVITY_PROTECTED_CATEGORY_SIGN" => Some(Self::Sign),
             "ACTIVITY_PROTECTED_CATEGORY_SMS" => Some(Self::Sms),
             "ACTIVITY_PROTECTED_CATEGORY_FIAT_ON_RAMP" => Some(Self::FiatOnRamp),
-            _ => None,
-        }
-    }
-}
-/// The key type addressed within a Spark wallet. Values correspond to the
-/// per-account child index in the derivation path m/8797555'/{account}'/{N}'.
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum SparkKeyType {
-    #[serde(rename = "SPARK_KEY_TYPE_UNSPECIFIED")]
-    Unspecified = 0,
-    /// N = 0
-    #[serde(rename = "SPARK_KEY_TYPE_IDENTITY")]
-    Identity = 1,
-    /// N = 1; per-leaf BIP32 hardened child at u32_be(sha256(leaf_id_utf8)\[0..4\]) % 2^31
-    #[serde(rename = "SPARK_KEY_TYPE_SIGNING_HD")]
-    SigningHd = 2,
-    /// N = 2
-    #[serde(rename = "SPARK_KEY_TYPE_DEPOSIT")]
-    Deposit = 3,
-    /// N = 3
-    #[serde(rename = "SPARK_KEY_TYPE_STATIC_DEPOSIT_HD")]
-    StaticDepositHd = 4,
-    /// N = 4
-    #[serde(rename = "SPARK_KEY_TYPE_HTLC_PREIMAGE_HD")]
-    HtlcPreimageHd = 5,
-}
-impl SparkKeyType {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            Self::Unspecified => "SPARK_KEY_TYPE_UNSPECIFIED",
-            Self::Identity => "SPARK_KEY_TYPE_IDENTITY",
-            Self::SigningHd => "SPARK_KEY_TYPE_SIGNING_HD",
-            Self::Deposit => "SPARK_KEY_TYPE_DEPOSIT",
-            Self::StaticDepositHd => "SPARK_KEY_TYPE_STATIC_DEPOSIT_HD",
-            Self::HtlcPreimageHd => "SPARK_KEY_TYPE_HTLC_PREIMAGE_HD",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "SPARK_KEY_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
-            "SPARK_KEY_TYPE_IDENTITY" => Some(Self::Identity),
-            "SPARK_KEY_TYPE_SIGNING_HD" => Some(Self::SigningHd),
-            "SPARK_KEY_TYPE_DEPOSIT" => Some(Self::Deposit),
-            "SPARK_KEY_TYPE_STATIC_DEPOSIT_HD" => Some(Self::StaticDepositHd),
-            "SPARK_KEY_TYPE_HTLC_PREIMAGE_HD" => Some(Self::HtlcPreimageHd),
             _ => None,
         }
     }

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -2062,8 +2062,8 @@ pub struct Oauth2AuthenticateIntent {
     pub redirect_uri: ::prost::alloc::string::String,
     /// @inject_tag: validate:"required"
     pub code_verifier: ::prost::alloc::string::String,
-    #[serde(default)]
-    pub nonce: ::core::option::Option<::prost::alloc::string::String>,
+    /// @inject_tag: validate:"required"
+    pub nonce: ::prost::alloc::string::String,
     #[serde(default)]
     pub bearer_token_target_public_key: ::core::option::Option<
         ::prost::alloc::string::String,
@@ -3839,9 +3839,6 @@ pub struct SparkSignatureRequest {
     /// @inject_tag: validate:"required,dive"
     #[serde(default)]
     pub operator_commitments: ::prost::alloc::vec::Vec<SparkFrostCommitment>,
-    /// @inject_tag: validate:"omitempty"
-    #[serde(default)]
-    pub adaptor_public_key: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Debug)]
 /// Per-signature output from SPARK_SIGN_FROST: Turnkey's FROST partial

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -23,6 +23,8 @@ const SERDE_CAMEL_CASE: &str = "#[serde(rename_all = \"camelCase\")]";
 struct ActivityDetails {
     intent_type: String,
     result_type: String,
+    #[serde(default)]
+    internal: bool,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -189,6 +191,9 @@ fn main() {
                         .unwrap_or_else(|| {
                             panic!("activity type {activity_type} not found in activities.json")
                         });
+                    if activities_details.internal {
+                        continue;
+                    }
                     let activity_intent = activities_details.intent_type.clone();
                     let activity_result = activities_details.result_type.clone();
                     let app_proofs_field =

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -21,7 +21,6 @@ const SERDE_CAMEL_CASE: &str = "#[serde(rename_all = \"camelCase\")]";
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ActivityDetails {
-    r#type: String,
     intent_type: String,
     result_type: String,
 }
@@ -111,17 +110,16 @@ fn main() {
 
     let mut generated_methods = String::new();
 
-    // We manually have to specify the mapping between activity types, route, intent and result type through a file
-    // Unfortunately this information isn't available in proto directly because this mapping is semantic, not structural.
+    // The activity type is read directly from the enum annotation on each request message in the external activity proto.
+    // Intent and result types are looked up from activities.json using the activity type as the key.
     let activities_mapping_data =
         fs::read_to_string(ACTIVITIES_MAPPING_PATH).expect("cannot read activities.json");
     let parsed_activities: ActivitiesFile =
         serde_json::from_str(&activities_mapping_data).expect("cannot parse activities.json");
 
-    // Collect the set of external activity request types that carry a `generate_app_proofs`
-    // field in the proto, so we know which struct initializers need to populate it.
     let external_activity_proto = fs::read_to_string(EXTERNAL_ACTIVITY_PROTO_PATH)
-        .expect("Failed to read external activity proto");
+        .expect("Failed to read external activity proto file");
+    let request_to_activity_type = request_to_activity_types(&external_activity_proto);
     let requests_with_app_proofs = requests_with_generate_app_proofs(&external_activity_proto);
 
     for service_caps in service_re.captures_iter(&proto) {
@@ -179,15 +177,18 @@ fn main() {
                     .unwrap_or_else(|| panic!("no description found for {route}"))[1];
 
                 if req_type.contains("external.activity.v1") {
-                    let activities_details = parsed_activities
-                        .activities
-                        .get(route)
-                        .unwrap_or_else(|| panic!("route {route} not found in activities.json"));
-                    let activity_type = activities_details.r#type.clone();
-
                     // If the request type is "external.activity.v1.DeletePolicyRequest" the sanitized
                     // request type will be "DeletePolicyRequest", and we'll need to import it from the external activity namespace
                     let short_req_type = req_type.rsplit(".").next().unwrap();
+                    let activity_type = request_to_activity_type
+                        .get(short_req_type)
+                        .unwrap_or_else(|| panic!("no activity type annotation found for {short_req_type} in external activity proto"));
+                    let activities_details = parsed_activities
+                        .activities
+                        .get(activity_type.as_str())
+                        .unwrap_or_else(|| {
+                            panic!("activity type {activity_type} not found in activities.json")
+                        });
                     let activity_intent = activities_details.intent_type.clone();
                     let activity_result = activities_details.result_type.clone();
                     let app_proofs_field =
@@ -353,6 +354,21 @@ fn build_generate_app_proofs_field(
     } else {
         String::new()
     }
+}
+
+fn request_to_activity_types(proto: &str) -> HashMap<String, String> {
+    let message_re = Regex::new(r"(?ms)^message\s+(\w+)\s*\{\n(.*?)\n\}").unwrap();
+    let enum_annotation_re = Regex::new(r#"enum:\s*\["(ACTIVITY_TYPE_[^"]+)"\]"#).unwrap();
+    message_re
+        .captures_iter(proto)
+        .filter_map(|caps| {
+            let name = caps[1].to_string();
+            let body = &caps[2];
+            enum_annotation_re
+                .captures(body)
+                .map(|e| (name, e[1].to_string()))
+        })
+        .collect()
 }
 
 fn requests_with_generate_app_proofs(proto: &str) -> HashSet<String> {

--- a/proto/activities.json
+++ b/proto/activities.json
@@ -360,6 +360,22 @@
       "intentType": "RemoveIpAllowlistIntent",
       "resultType": "RemoveIpAllowlistResult"
     },
+    "ACTIVITY_TYPE_SPARK_SIGN_FROST": {
+      "intentType": "SparkSignFrostIntent",
+      "resultType": "SparkSignFrostResult"
+    },
+    "ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER": {
+      "intentType": "SparkPrepareTransferIntent",
+      "resultType": "SparkPrepareTransferResult"
+    },
+    "ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER": {
+      "intentType": "SparkClaimTransferIntent",
+      "resultType": "SparkClaimTransferResult"
+    },
+    "ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE": {
+      "intentType": "SparkPrepareLightningReceiveIntent",
+      "resultType": "SparkPrepareLightningReceiveResult"
+    },
     "ACTIVITY_TYPE_CREATE_API_KEYS": {
       "intentType": "CreateApiKeysIntent",
       "resultType": "CreateApiKeysResult"
@@ -475,6 +491,86 @@
     "ACTIVITY_TYPE_VERIFY_OTP": {
       "intentType": "VerifyOtpIntent",
       "resultType": "VerifyOtpResult"
+    },
+    "ACTIVITY_TYPE_ACCEPT_INVITATION": {
+      "intentType": "AcceptInvitationIntent",
+      "resultType": "AcceptInvitationResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_ACCEPT_INVITATION_V2": {
+      "intentType": "AcceptInvitationIntentV2",
+      "resultType": "AcceptInvitationResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_DISABLE_PRIVATE_KEY": {
+      "intentType": "DisablePrivateKeyIntent",
+      "resultType": "DisablePrivateKeyResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_DELETE_ORGANIZATION": {
+      "intentType": "DeleteOrganizationIntent",
+      "resultType": "DeleteOrganizationResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_CREATE_ORGANIZATION": {
+      "intentType": "CreateOrganizationIntent",
+      "resultType": "CreateOrganizationResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_CREATE_ORGANIZATION_V2": {
+      "intentType": "CreateOrganizationIntentV2",
+      "resultType": "CreateOrganizationResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_SET_PAYMENT_METHOD": {
+      "intentType": "SetPaymentMethodIntent",
+      "resultType": "SetPaymentMethodResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_SET_PAYMENT_METHOD_V2": {
+      "intentType": "SetPaymentMethodIntentV2",
+      "resultType": "SetPaymentMethodResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_ACTIVATE_BILLING_TIER": {
+      "intentType": "ActivateBillingTierIntent",
+      "resultType": "ActivateBillingTierResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_DELETE_PAYMENT_METHOD": {
+      "intentType": "DeletePaymentMethodIntent",
+      "resultType": "GetDeletePaymentMethodResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_UPDATE_ALLOWED_ORIGINS": {
+      "intentType": "UpdateAllowedOriginsIntent",
+      "resultType": "UpdateAllowedOriginsResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_ENABLE_AUTH_PROXY": {
+      "intentType": "EnableAuthProxyIntent",
+      "resultType": "EnableAuthProxyResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_DISABLE_AUTH_PROXY": {
+      "intentType": "DisableAuthProxyIntent",
+      "resultType": "DisableAuthProxyResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_UPDATE_AUTH_PROXY_CONFIG": {
+      "intentType": "UpdateAuthProxyConfigIntent",
+      "resultType": "UpdateAuthProxyConfigResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_UPSERT_GAS_USAGE_CONFIG": {
+      "intentType": "UpsertGasUsageConfigIntent",
+      "resultType": "UpsertGasUsageConfigResult",
+      "internal": true
+    },
+    "ACTIVITY_TYPE_UNSPECIFIED": {
+      "intentType": "*",
+      "resultType": "*",
+      "internal": true
     }
   }
 }

--- a/proto/activities.json
+++ b/proto/activities.json
@@ -1,454 +1,480 @@
 {
   "activities": {
-    "/public/v1/submit/approve_activity": {
-      "type": "ACTIVITY_TYPE_APPROVE_ACTIVITY",
+    "ACTIVITY_TYPE_APPROVE_ACTIVITY": {
       "intentType": "ApproveActivityIntent",
       "resultType": "*"
     },
-    "/public/v1/submit/reject_activity": {
-      "type": "ACTIVITY_TYPE_REJECT_ACTIVITY",
+    "ACTIVITY_TYPE_REJECT_ACTIVITY": {
       "intentType": "RejectActivityIntent",
       "resultType": "*"
     },
-    "/public/v1/submit/delete_users": {
-      "type": "ACTIVITY_TYPE_DELETE_USERS",
+    "ACTIVITY_TYPE_DELETE_USERS": {
       "intentType": "DeleteUsersIntent",
       "resultType": "DeleteUsersResult"
     },
-    "/public/v1/submit/create_policy": {
-      "type": "ACTIVITY_TYPE_CREATE_POLICY_V3",
+    "ACTIVITY_TYPE_CREATE_POLICY_V3": {
       "intentType": "CreatePolicyIntentV3",
       "resultType": "CreatePolicyResult"
     },
-    "/public/v1/submit/create_smart_contract_interface": {
-      "type": "ACTIVITY_TYPE_CREATE_SMART_CONTRACT_INTERFACE",
+    "ACTIVITY_TYPE_CREATE_SMART_CONTRACT_INTERFACE": {
       "intentType": "CreateSmartContractInterfaceIntent",
       "resultType": "CreateSmartContractInterfaceResult"
     },
-    "/public/v1/submit/delete_smart_contract_interface": {
-      "type": "ACTIVITY_TYPE_DELETE_SMART_CONTRACT_INTERFACE",
+    "ACTIVITY_TYPE_DELETE_SMART_CONTRACT_INTERFACE": {
       "intentType": "DeleteSmartContractInterfaceIntent",
       "resultType": "DeleteSmartContractInterfaceResult"
     },
-    "/public/v1/submit/create_policies": {
-      "type": "ACTIVITY_TYPE_CREATE_POLICIES",
+    "ACTIVITY_TYPE_CREATE_POLICIES": {
       "intentType": "CreatePoliciesIntent",
       "resultType": "CreatePoliciesResult"
     },
-    "/public/v1/submit/update_policy": {
-      "type": "ACTIVITY_TYPE_UPDATE_POLICY_V2",
+    "ACTIVITY_TYPE_UPDATE_POLICY_V2": {
       "intentType": "UpdatePolicyIntentV2",
       "resultType": "UpdatePolicyResultV2"
     },
-    "/public/v1/submit/delete_policy": {
-      "type": "ACTIVITY_TYPE_DELETE_POLICY",
+    "ACTIVITY_TYPE_DELETE_POLICY": {
       "intentType": "DeletePolicyIntent",
       "resultType": "DeletePolicyResult"
     },
-    "/public/v1/submit/create_read_only_session": {
-      "type": "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION",
+    "ACTIVITY_TYPE_CREATE_READ_ONLY_SESSION": {
       "intentType": "CreateReadOnlySessionIntent",
       "resultType": "CreateReadOnlySessionResult"
     },
-    "/public/v1/submit/create_read_write_session": {
-      "type": "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2",
+    "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION_V2": {
       "intentType": "CreateReadWriteSessionIntentV2",
       "resultType": "CreateReadWriteSessionResultV2"
     },
-    "/public/v1/submit/create_private_keys": {
-      "type": "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2",
+    "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS_V2": {
       "intentType": "CreatePrivateKeysIntentV2",
       "resultType": "CreatePrivateKeysResultV2"
     },
-    "/public/v1/submit/create_api_keys": {
-      "type": "ACTIVITY_TYPE_CREATE_API_KEYS_V2",
+    "ACTIVITY_TYPE_CREATE_API_KEYS_V2": {
       "intentType": "CreateApiKeysIntentV2",
       "resultType": "CreateApiKeysResult"
     },
-    "/public/v1/submit/delete_api_keys": {
-      "type": "ACTIVITY_TYPE_DELETE_API_KEYS",
+    "ACTIVITY_TYPE_DELETE_API_KEYS": {
       "intentType": "DeleteApiKeysIntent",
       "resultType": "DeleteApiKeysResult"
     },
-    "/public/v1/submit/create_authenticators": {
-      "type": "ACTIVITY_TYPE_CREATE_AUTHENTICATORS_V2",
+    "ACTIVITY_TYPE_CREATE_AUTHENTICATORS_V2": {
       "intentType": "CreateAuthenticatorsIntentV2",
       "resultType": "CreateAuthenticatorsResult"
     },
-    "/public/v1/submit/delete_authenticators": {
-      "type": "ACTIVITY_TYPE_DELETE_AUTHENTICATORS",
+    "ACTIVITY_TYPE_DELETE_AUTHENTICATORS": {
       "intentType": "DeleteAuthenticatorsIntent",
       "resultType": "DeleteAuthenticatorsResult"
     },
-    "/public/v1/submit/create_invitations": {
-      "type": "ACTIVITY_TYPE_CREATE_INVITATIONS",
+    "ACTIVITY_TYPE_CREATE_INVITATIONS": {
       "intentType": "CreateInvitationsIntent",
       "resultType": "CreateInvitationsResult"
     },
-    "/public/v1/submit/delete_invitation": {
-      "type": "ACTIVITY_TYPE_DELETE_INVITATION",
+    "ACTIVITY_TYPE_DELETE_INVITATION": {
       "intentType": "DeleteInvitationIntent",
       "resultType": "DeleteInvitationResult"
     },
-    "/public/v1/submit/create_users": {
-      "type": "ACTIVITY_TYPE_CREATE_USERS_V4",
+    "ACTIVITY_TYPE_CREATE_USERS_V4": {
       "intentType": "CreateUsersIntentV4",
       "resultType": "CreateUsersResult"
     },
-    "/public/v1/submit/create_api_only_users": {
-      "type": "ACTIVITY_TYPE_CREATE_API_ONLY_USERS",
+    "ACTIVITY_TYPE_CREATE_API_ONLY_USERS": {
       "intentType": "CreateApiOnlyUsersIntent",
       "resultType": "CreateApiOnlyUsersResult"
     },
-    "/public/v1/submit/update_user": {
-      "type": "ACTIVITY_TYPE_UPDATE_USER",
+    "ACTIVITY_TYPE_UPDATE_USER": {
       "intentType": "UpdateUserIntent",
       "resultType": "UpdateUserResult"
     },
-    "/public/v1/submit/update_user_email": {
-      "type": "ACTIVITY_TYPE_UPDATE_USER_EMAIL",
+    "ACTIVITY_TYPE_UPDATE_USER_EMAIL": {
       "intentType": "UpdateUserEmailIntent",
       "resultType": "UpdateUserEmailResult"
     },
-    "/public/v1/submit/update_user_name": {
-      "type": "ACTIVITY_TYPE_UPDATE_USER_NAME",
+    "ACTIVITY_TYPE_UPDATE_USER_NAME": {
       "intentType": "UpdateUserNameIntent",
       "resultType": "UpdateUserNameResult"
     },
-    "/public/v1/submit/update_user_phone_number": {
-      "type": "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER",
+    "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER": {
       "intentType": "UpdateUserPhoneNumberIntent",
       "resultType": "UpdateUserPhoneNumberResult"
     },
-    "/public/v1/submit/create_user_tag": {
-      "type": "ACTIVITY_TYPE_CREATE_USER_TAG",
+    "ACTIVITY_TYPE_CREATE_USER_TAG": {
       "intentType": "CreateUserTagIntent",
       "resultType": "CreateUserTagResult"
     },
-    "/public/v1/submit/create_private_key_tag": {
-      "type": "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG",
+    "ACTIVITY_TYPE_CREATE_PRIVATE_KEY_TAG": {
       "intentType": "CreatePrivateKeyTagIntent",
       "resultType": "CreatePrivateKeyTagResult"
     },
-    "/public/v1/submit/update_user_tag": {
-      "type": "ACTIVITY_TYPE_UPDATE_USER_TAG",
+    "ACTIVITY_TYPE_UPDATE_USER_TAG": {
       "intentType": "UpdateUserTagIntent",
       "resultType": "UpdateUserTagResult"
     },
-    "/public/v1/submit/delete_user_tags": {
-      "type": "ACTIVITY_TYPE_DELETE_USER_TAGS",
+    "ACTIVITY_TYPE_DELETE_USER_TAGS": {
       "intentType": "DeleteUserTagsIntent",
       "resultType": "DeleteUserTagsResult"
     },
-    "/public/v1/submit/update_private_key_tag": {
-      "type": "ACTIVITY_TYPE_UPDATE_PRIVATE_KEY_TAG",
+    "ACTIVITY_TYPE_UPDATE_PRIVATE_KEY_TAG": {
       "intentType": "UpdatePrivateKeyTagIntent",
       "resultType": "UpdatePrivateKeyTagResult"
     },
-    "/public/v1/submit/delete_private_key_tags": {
-      "type": "ACTIVITY_TYPE_DELETE_PRIVATE_KEY_TAGS",
+    "ACTIVITY_TYPE_DELETE_PRIVATE_KEY_TAGS": {
       "intentType": "DeletePrivateKeyTagsIntent",
       "resultType": "DeletePrivateKeyTagsResult"
     },
-    "/public/v1/submit/sign_raw_payload": {
-      "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+    "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2": {
       "intentType": "SignRawPayloadIntentV2",
       "resultType": "SignRawPayloadResult"
     },
-    "/public/v1/submit/sign_raw_payloads": {
-      "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS",
+    "ACTIVITY_TYPE_SIGN_RAW_PAYLOADS": {
       "intentType": "SignRawPayloadsIntent",
       "resultType": "SignRawPayloadsResult"
     },
-    "/public/v1/submit/sign_transaction": {
-      "type": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2",
+    "ACTIVITY_TYPE_SIGN_TRANSACTION_V2": {
       "intentType": "SignTransactionIntentV2",
       "resultType": "SignTransactionResult"
     },
-    "/public/v1/submit/update_root_quorum": {
-      "type": "ACTIVITY_TYPE_UPDATE_ROOT_QUORUM",
+    "ACTIVITY_TYPE_UPDATE_ROOT_QUORUM": {
       "intentType": "UpdateRootQuorumIntent",
       "resultType": "UpdateRootQuorumResult"
     },
-    "/public/v1/submit/create_wallet": {
-      "type": "ACTIVITY_TYPE_CREATE_WALLET",
+    "ACTIVITY_TYPE_CREATE_WALLET": {
       "intentType": "CreateWalletIntent",
       "resultType": "CreateWalletResult"
     },
-    "/public/v1/submit/create_wallet_accounts": {
-      "type": "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS",
+    "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS": {
       "intentType": "CreateWalletAccountsIntent",
       "resultType": "CreateWalletAccountsResult"
     },
-    "/public/v1/submit/create_sub_organization": {
-      "type": "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V8",
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V8": {
       "intentType": "CreateSubOrganizationIntentV8",
       "resultType": "CreateSubOrganizationResultV8"
     },
-    "/public/v1/submit/init_user_email_recovery": {
-      "type": "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY_V2",
+    "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY_V2": {
       "intentType": "InitUserEmailRecoveryIntentV2",
       "resultType": "InitUserEmailRecoveryResult"
     },
-    "/public/v1/submit/recover_user": {
-      "type": "ACTIVITY_TYPE_RECOVER_USER",
+    "ACTIVITY_TYPE_RECOVER_USER": {
       "intentType": "RecoverUserIntent",
       "resultType": "RecoverUserResult"
     },
-    "/public/v1/submit/set_organization_feature": {
-      "type": "ACTIVITY_TYPE_SET_ORGANIZATION_FEATURE",
+    "ACTIVITY_TYPE_SET_ORGANIZATION_FEATURE": {
       "intentType": "SetOrganizationFeatureIntent",
       "resultType": "SetOrganizationFeatureResult"
     },
-    "/public/v1/submit/remove_organization_feature": {
-      "type": "ACTIVITY_TYPE_REMOVE_ORGANIZATION_FEATURE",
+    "ACTIVITY_TYPE_REMOVE_ORGANIZATION_FEATURE": {
       "intentType": "RemoveOrganizationFeatureIntent",
       "resultType": "RemoveOrganizationFeatureResult"
     },
-    "/public/v1/submit/export_private_key": {
-      "type": "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY",
+    "ACTIVITY_TYPE_EXPORT_PRIVATE_KEY": {
       "intentType": "ExportPrivateKeyIntent",
       "resultType": "ExportPrivateKeyResult"
     },
-    "/public/v1/submit/export_wallet": {
-      "type": "ACTIVITY_TYPE_EXPORT_WALLET",
+    "ACTIVITY_TYPE_EXPORT_WALLET": {
       "intentType": "ExportWalletIntent",
       "resultType": "ExportWalletResult"
     },
-    "/public/v1/submit/email_auth": {
-      "type": "ACTIVITY_TYPE_EMAIL_AUTH_V3",
+    "ACTIVITY_TYPE_EMAIL_AUTH_V3": {
       "intentType": "EmailAuthIntentV3",
       "resultType": "EmailAuthResult"
     },
-    "/public/v1/submit/export_wallet_account": {
-      "type": "ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT",
+    "ACTIVITY_TYPE_EXPORT_WALLET_ACCOUNT": {
       "intentType": "ExportWalletAccountIntent",
       "resultType": "ExportWalletAccountResult"
     },
-    "/public/v1/submit/init_fiat_on_ramp": {
-      "type": "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP",
+    "ACTIVITY_TYPE_INIT_FIAT_ON_RAMP": {
       "intentType": "InitFiatOnRampIntent",
       "resultType": "InitFiatOnRampResult"
     },
-    "/public/v1/submit/init_import_wallet": {
-      "type": "ACTIVITY_TYPE_INIT_IMPORT_WALLET",
+    "ACTIVITY_TYPE_INIT_IMPORT_WALLET": {
       "intentType": "InitImportWalletIntent",
       "resultType": "InitImportWalletResult"
     },
-    "/public/v1/submit/import_wallet": {
-      "type": "ACTIVITY_TYPE_IMPORT_WALLET",
+    "ACTIVITY_TYPE_IMPORT_WALLET": {
       "intentType": "ImportWalletIntent",
       "resultType": "ImportWalletResult"
     },
-    "/public/v1/submit/init_import_private_key": {
-      "type": "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY",
+    "ACTIVITY_TYPE_INIT_IMPORT_PRIVATE_KEY": {
       "intentType": "InitImportPrivateKeyIntent",
       "resultType": "InitImportPrivateKeyResult"
     },
-    "/public/v1/submit/import_private_key": {
-      "type": "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY",
+    "ACTIVITY_TYPE_IMPORT_PRIVATE_KEY": {
       "intentType": "ImportPrivateKeyIntent",
       "resultType": "ImportPrivateKeyResult"
     },
-    "/public/v1/submit/oauth": {
-      "type": "ACTIVITY_TYPE_OAUTH",
+    "ACTIVITY_TYPE_OAUTH": {
       "intentType": "OauthIntent",
       "resultType": "OauthResult"
     },
-    "/public/v1/submit/init_otp": {
-      "type": "ACTIVITY_TYPE_INIT_OTP_V2",
+    "ACTIVITY_TYPE_INIT_OTP_V2": {
       "intentType": "InitOtpIntentV3",
       "resultType": "InitOtpResult"
     },
-    "/public/v1/submit/init_otp_auth": {
-      "type": "ACTIVITY_TYPE_INIT_OTP_AUTH_V3",
+    "ACTIVITY_TYPE_INIT_OTP_AUTH_V3": {
       "intentType": "InitOtpAuthIntentV3",
       "resultType": "InitOtpAuthResultV2"
     },
-    "/public/v1/submit/otp_auth": {
-      "type": "ACTIVITY_TYPE_OTP_AUTH",
+    "ACTIVITY_TYPE_OTP_AUTH": {
       "intentType": "OtpAuthIntent",
       "resultType": "OtpAuthResult"
     },
-    "/public/v1/submit/oauth_login": {
-      "type": "ACTIVITY_TYPE_OAUTH_LOGIN",
+    "ACTIVITY_TYPE_OAUTH_LOGIN": {
       "intentType": "OauthLoginIntent",
       "resultType": "OauthLoginResult"
     },
-    "/public/v1/submit/otp_login": {
-      "type": "ACTIVITY_TYPE_OTP_LOGIN_V2",
+    "ACTIVITY_TYPE_OTP_LOGIN_V2": {
       "intentType": "OtpLoginIntentV2",
       "resultType": "OtpLoginResult"
     },
-    "/public/v1/submit/stamp_login": {
-      "type": "ACTIVITY_TYPE_STAMP_LOGIN",
+    "ACTIVITY_TYPE_STAMP_LOGIN": {
       "intentType": "StampLoginIntent",
       "resultType": "StampLoginResult"
     },
-    "/public/v1/submit/verify_otp": {
-      "type": "ACTIVITY_TYPE_VERIFY_OTP_V2",
+    "ACTIVITY_TYPE_VERIFY_OTP_V2": {
       "intentType": "VerifyOtpIntentV2",
       "resultType": "VerifyOtpResult"
     },
-    "/public/v1/submit/create_oauth_providers": {
-      "type": "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS_V2",
+    "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS_V2": {
       "intentType": "CreateOauthProvidersIntentV2",
       "resultType": "CreateOauthProvidersResultV2"
     },
-    "/public/v1/submit/delete_oauth_providers": {
-      "type": "ACTIVITY_TYPE_DELETE_OAUTH_PROVIDERS",
+    "ACTIVITY_TYPE_DELETE_OAUTH_PROVIDERS": {
       "intentType": "DeleteOauthProvidersIntent",
       "resultType": "DeleteOauthProvidersResult"
     },
-    "/public/v1/submit/delete_private_keys": {
-      "type": "ACTIVITY_TYPE_DELETE_PRIVATE_KEYS",
+    "ACTIVITY_TYPE_DELETE_PRIVATE_KEYS": {
       "intentType": "DeletePrivateKeysIntent",
       "resultType": "DeletePrivateKeysResult"
     },
-    "/public/v1/submit/update_wallet": {
-      "type": "ACTIVITY_TYPE_UPDATE_WALLET",
+    "ACTIVITY_TYPE_UPDATE_WALLET": {
       "intentType": "UpdateWalletIntent",
       "resultType": "UpdateWalletResult"
     },
-    "/public/v1/submit/delete_wallets": {
-      "type": "ACTIVITY_TYPE_DELETE_WALLETS",
+    "ACTIVITY_TYPE_DELETE_WALLETS": {
       "intentType": "DeleteWalletsIntent",
       "resultType": "DeleteWalletsResult"
     },
-    "/public/v1/submit/delete_sub_organization": {
-      "type": "ACTIVITY_TYPE_DELETE_SUB_ORGANIZATION",
+    "ACTIVITY_TYPE_DELETE_SUB_ORGANIZATION": {
       "intentType": "DeleteSubOrganizationIntent",
       "resultType": "DeleteSubOrganizationResult"
     },
-    "/public/v1/submit/create_oauth2_credential": {
-      "type": "ACTIVITY_TYPE_CREATE_OAUTH2_CREDENTIAL",
+    "ACTIVITY_TYPE_CREATE_OAUTH2_CREDENTIAL": {
       "intentType": "CreateOauth2CredentialIntent",
       "resultType": "CreateOauth2CredentialResult"
     },
-    "/public/v1/submit/update_oauth2_credential": {
-      "type": "ACTIVITY_TYPE_UPDATE_OAUTH2_CREDENTIAL",
+    "ACTIVITY_TYPE_UPDATE_OAUTH2_CREDENTIAL": {
       "intentType": "UpdateOauth2CredentialIntent",
       "resultType": "UpdateOauth2CredentialResult"
     },
-    "/public/v1/submit/delete_oauth2_credential": {
-      "type": "ACTIVITY_TYPE_DELETE_OAUTH2_CREDENTIAL",
+    "ACTIVITY_TYPE_DELETE_OAUTH2_CREDENTIAL": {
       "intentType": "DeleteOauth2CredentialIntent",
       "resultType": "DeleteOauth2CredentialResult"
     },
-    "/public/v1/submit/oauth2_authenticate": {
-      "type": "ACTIVITY_TYPE_OAUTH2_AUTHENTICATE",
+    "ACTIVITY_TYPE_OAUTH2_AUTHENTICATE": {
       "intentType": "Oauth2AuthenticateIntent",
       "resultType": "Oauth2AuthenticateResult"
     },
-    "/public/v1/submit/delete_wallet_accounts": {
-      "type": "ACTIVITY_TYPE_DELETE_WALLET_ACCOUNTS",
+    "ACTIVITY_TYPE_DELETE_WALLET_ACCOUNTS": {
       "intentType": "DeleteWalletAccountsIntent",
       "resultType": "DeleteWalletAccountsResult"
     },
-    "/public/v1/submit/update_organization_name": {
-      "type": "ACTIVITY_TYPE_UPDATE_ORGANIZATION_NAME",
+    "ACTIVITY_TYPE_UPDATE_ORGANIZATION_NAME": {
       "intentType": "UpdateOrganizationNameIntent",
       "resultType": "UpdateOrganizationNameResult"
     },
-    "/public/v1/submit/delete_policies": {
-      "type": "ACTIVITY_TYPE_DELETE_POLICIES",
+    "ACTIVITY_TYPE_DELETE_POLICIES": {
       "intentType": "DeletePoliciesIntent",
       "resultType": "DeletePoliciesResult"
     },
-    "/public/v1/submit/eth_send_raw_transaction": {
-      "type": "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION",
+    "ACTIVITY_TYPE_ETH_SEND_RAW_TRANSACTION": {
       "intentType": "EthSendRawTransactionIntent",
       "resultType": "EthSendRawTransactionResult"
     },
-    "/public/v1/submit/create_fiat_on_ramp_credential": {
-      "type": "ACTIVITY_TYPE_CREATE_FIAT_ON_RAMP_CREDENTIAL",
+    "ACTIVITY_TYPE_CREATE_FIAT_ON_RAMP_CREDENTIAL": {
       "intentType": "CreateFiatOnRampCredentialIntent",
       "resultType": "CreateFiatOnRampCredentialResult"
     },
-    "/public/v1/submit/delete_fiat_on_ramp_credential": {
-      "type": "ACTIVITY_TYPE_DELETE_FIAT_ON_RAMP_CREDENTIAL",
+    "ACTIVITY_TYPE_DELETE_FIAT_ON_RAMP_CREDENTIAL": {
       "intentType": "DeleteFiatOnRampCredentialIntent",
       "resultType": "DeleteFiatOnRampCredentialResult"
     },
-    "/public/v1/submit/update_fiat_on_ramp_credential": {
-      "type": "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL",
+    "ACTIVITY_TYPE_UPDATE_FIAT_ON_RAMP_CREDENTIAL": {
       "intentType": "UpdateFiatOnRampCredentialIntent",
       "resultType": "UpdateFiatOnRampCredentialResult"
     },
-    "/public/v1/submit/eth_send_transaction": {
-      "type": "ACTIVITY_TYPE_ETH_SEND_TRANSACTION",
+    "ACTIVITY_TYPE_ETH_SEND_TRANSACTION": {
       "intentType": "EthSendTransactionIntent",
       "resultType": "EthSendTransactionResult"
     },
-    "/public/v1/submit/sol_send_transaction": {
-      "type": "ACTIVITY_TYPE_SOL_SEND_TRANSACTION",
+    "ACTIVITY_TYPE_SOL_SEND_TRANSACTION": {
       "intentType": "SolSendTransactionIntent",
       "resultType": "SolSendTransactionResult"
     },
-    "/public/v1/submit/create_tvc_app": {
-      "type": "ACTIVITY_TYPE_CREATE_TVC_APP",
+    "ACTIVITY_TYPE_CREATE_TVC_APP": {
       "intentType": "CreateTvcAppIntent",
       "resultType": "CreateTvcAppResult"
     },
-    "/public/v1/submit/delete_tvc_app_and_deployments": {
-      "type": "ACTIVITY_TYPE_DELETE_TVC_APP_AND_DEPLOYMENTS",
+    "ACTIVITY_TYPE_DELETE_TVC_APP_AND_DEPLOYMENTS": {
       "intentType": "DeleteTvcAppAndDeploymentsIntent",
       "resultType": "DeleteTvcAppAndDeploymentsResult"
     },
-    "/public/v1/submit/create_tvc_deployment": {
-      "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+    "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT": {
       "intentType": "CreateTvcDeploymentIntent",
       "resultType": "CreateTvcDeploymentResult"
     },
-    "/public/v1/submit/delete_tvc_deployment": {
-      "type": "ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT",
+    "ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT": {
       "intentType": "DeleteTvcDeploymentIntent",
       "resultType": "DeleteTvcDeploymentResult"
     },
-    "/public/v1/submit/restore_tvc_deployment": {
-      "type": "ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT",
+    "ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT": {
       "intentType": "RestoreTvcDeploymentIntent",
       "resultType": "RestoreTvcDeploymentResult"
     },
-    "/public/v1/submit/set_tvc_app_live_deployment": {
-      "type": "ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT",
+    "ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT": {
       "intentType": "UpdateTvcAppLiveDeploymentIntent",
       "resultType": "UpdateTvcAppLiveDeploymentResult"
     },
-    "/public/v1/submit/create_tvc_manifest_approvals": {
-      "type": "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS",
+    "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS": {
       "intentType": "CreateTvcManifestApprovalsIntent",
       "resultType": "CreateTvcManifestApprovalsResult"
     },
-    "/public/v1/submit/post_tvc_quorum_key_share": {
-      "type": "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE",
+    "ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE": {
       "intentType": "PostTvcQuorumKeyShareIntent",
       "resultType": "PostTvcQuorumKeyShareResult"
     },
-    "/public/v1/submit/create_webhook_endpoint": {
-      "type": "ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT",
+    "ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT": {
       "intentType": "CreateWebhookEndpointIntent",
       "resultType": "CreateWebhookEndpointResult"
     },
-    "/public/v1/submit/update_webhook_endpoint": {
-      "type": "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT",
+    "ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT": {
       "intentType": "UpdateWebhookEndpointIntent",
       "resultType": "UpdateWebhookEndpointResult"
     },
-    "/public/v1/submit/delete_webhook_endpoint": {
-      "type": "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT",
+    "ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT": {
       "intentType": "DeleteWebhookEndpointIntent",
       "resultType": "DeleteWebhookEndpointResult"
     },
-    "/public/v1/submit/set_ip_allowlist": {
-      "type": "ACTIVITY_TYPE_SET_IP_ALLOWLIST",
+    "ACTIVITY_TYPE_SET_IP_ALLOWLIST": {
       "intentType": "SetIpAllowlistIntent",
       "resultType": "SetIpAllowlistResult"
     },
-    "/public/v1/submit/remove_ip_allowlist": {
-      "type": "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST",
+    "ACTIVITY_TYPE_REMOVE_IP_ALLOWLIST": {
       "intentType": "RemoveIpAllowlistIntent",
       "resultType": "RemoveIpAllowlistResult"
+    },
+    "ACTIVITY_TYPE_CREATE_API_KEYS": {
+      "intentType": "CreateApiKeysIntent",
+      "resultType": "CreateApiKeysResult"
+    },
+    "ACTIVITY_TYPE_CREATE_AUTHENTICATORS": {
+      "intentType": "CreateAuthenticatorsIntent",
+      "resultType": "CreateAuthenticatorsResult"
+    },
+    "ACTIVITY_TYPE_CREATE_OAUTH_PROVIDERS": {
+      "intentType": "CreateOauthProvidersIntent",
+      "resultType": "CreateOauthProvidersResult"
+    },
+    "ACTIVITY_TYPE_CREATE_POLICY": {
+      "intentType": "CreatePolicyIntent",
+      "resultType": "CreatePolicyResult"
+    },
+    "ACTIVITY_TYPE_CREATE_POLICY_V2": {
+      "intentType": "CreatePolicyIntentV2",
+      "resultType": "CreatePolicyResult"
+    },
+    "ACTIVITY_TYPE_CREATE_PRIVATE_KEYS": {
+      "intentType": "CreatePrivateKeysIntent",
+      "resultType": "CreatePrivateKeysResult"
+    },
+    "ACTIVITY_TYPE_CREATE_READ_WRITE_SESSION": {
+      "intentType": "CreateReadWriteSessionIntent",
+      "resultType": "CreateReadWriteSessionResult"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION": {
+      "intentType": "CreateSubOrganizationIntent",
+      "resultType": "CreateSubOrganizationResult"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V2": {
+      "intentType": "CreateSubOrganizationIntentV2",
+      "resultType": "CreateSubOrganizationResult"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V3": {
+      "intentType": "CreateSubOrganizationIntentV3",
+      "resultType": "CreateSubOrganizationResultV3"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V4": {
+      "intentType": "CreateSubOrganizationIntentV4",
+      "resultType": "CreateSubOrganizationResultV4"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V5": {
+      "intentType": "CreateSubOrganizationIntentV5",
+      "resultType": "CreateSubOrganizationResultV5"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V6": {
+      "intentType": "CreateSubOrganizationIntentV6",
+      "resultType": "CreateSubOrganizationResultV6"
+    },
+    "ACTIVITY_TYPE_CREATE_SUB_ORGANIZATION_V7": {
+      "intentType": "CreateSubOrganizationIntentV7",
+      "resultType": "CreateSubOrganizationResultV7"
+    },
+    "ACTIVITY_TYPE_CREATE_USERS": {
+      "intentType": "CreateUsersIntent",
+      "resultType": "CreateUsersResult"
+    },
+    "ACTIVITY_TYPE_CREATE_USERS_V2": {
+      "intentType": "CreateUsersIntentV2",
+      "resultType": "CreateUsersResult"
+    },
+    "ACTIVITY_TYPE_CREATE_USERS_V3": {
+      "intentType": "CreateUsersIntentV3",
+      "resultType": "CreateUsersResult"
+    },
+    "ACTIVITY_TYPE_EMAIL_AUTH": {
+      "intentType": "EmailAuthIntent",
+      "resultType": "EmailAuthResult"
+    },
+    "ACTIVITY_TYPE_EMAIL_AUTH_V2": {
+      "intentType": "EmailAuthIntentV2",
+      "resultType": "EmailAuthResult"
+    },
+    "ACTIVITY_TYPE_INIT_OTP": {
+      "intentType": "InitOtpIntent",
+      "resultType": "InitOtpResult"
+    },
+    "ACTIVITY_TYPE_INIT_OTP_AUTH": {
+      "intentType": "InitOtpAuthIntent",
+      "resultType": "InitOtpAuthResult"
+    },
+    "ACTIVITY_TYPE_INIT_OTP_AUTH_V2": {
+      "intentType": "InitOtpAuthIntentV2",
+      "resultType": "InitOtpAuthResultV2"
+    },
+    "ACTIVITY_TYPE_INIT_OTP_V3": {
+      "intentType": "InitOtpIntentV3",
+      "resultType": "InitOtpResultV2"
+    },
+    "ACTIVITY_TYPE_INIT_USER_EMAIL_RECOVERY": {
+      "intentType": "InitUserEmailRecoveryIntent",
+      "resultType": "InitUserEmailRecoveryResult"
+    },
+    "ACTIVITY_TYPE_OTP_LOGIN": {
+      "intentType": "OtpLoginIntent",
+      "resultType": "OtpLoginResult"
+    },
+    "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD": {
+      "intentType": "SignRawPayloadIntent",
+      "resultType": "SignRawPayloadResult"
+    },
+    "ACTIVITY_TYPE_SIGN_TRANSACTION": {
+      "intentType": "SignTransactionIntent",
+      "resultType": "SignTransactionResult"
+    },
+    "ACTIVITY_TYPE_UPDATE_POLICY": {
+      "intentType": "UpdatePolicyIntent",
+      "resultType": "UpdatePolicyResult"
+    },
+    "ACTIVITY_TYPE_VERIFY_OTP": {
+      "intentType": "VerifyOtpIntent",
+      "resultType": "VerifyOtpResult"
     }
   }
 }

--- a/proto/external/activity/v1/activity.proto
+++ b/proto/external/activity/v1/activity.proto
@@ -2071,3 +2071,75 @@ message RestoreTvcDeploymentRequest {
   immutable.activity.v1.RestoreTvcDeploymentIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
   optional bool generate_app_proofs = 5 [(google.api.field_behavior) = OPTIONAL];
 }
+
+message SparkSignFrostRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_SPARK_SIGN_FROST"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.SparkSignFrostIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message SparkPrepareTransferRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.SparkPrepareTransferIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message SparkClaimTransferRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.SparkClaimTransferIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message SparkPrepareLightningReceiveRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.SparkPrepareLightningReceiveIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}

--- a/proto/external/activity/v1/activity.proto
+++ b/proto/external/activity/v1/activity.proto
@@ -1869,7 +1869,7 @@ message CreateTvcManifestApprovalsRequest {
   string type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      enum: ["ACTIVITY_TYPE_APPROVE_TVC_DEPLOYMENT"]
+      enum: ["ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS"]
     }
   ];
   string timestamp_ms = 2 [

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -3989,9 +3989,10 @@ message Oauth2AuthenticateIntent {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The code verifier used by OAuth 2.0 PKCE providers"}
   ];
-  optional string nonce = 5 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "An optional nonce used by the client to prevent replay/substitution of an ID token"}
+  // @inject_tag: validate:"required"
+  string nonce = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "A nonce value set to sha256(publicKey), used to bind the OIDC token to a specific public key"}
   ];
   optional string bearer_token_target_public_key = 6 [
     (google.api.field_behavior) = OPTIONAL,
@@ -6315,11 +6316,6 @@ message SparkSignatureRequest {
   repeated SparkFrostCommitment operator_commitments = 4 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Commitments for every non-Turnkey participant. MUST NOT include an entry under Turnkey's identifier. Bound into the nonce HMAC."}
-  ];
-  // @inject_tag: validate:"omitempty"
-  optional string adaptor_public_key = 5 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional per-signature adaptor point T (hex-encoded 33-byte compressed secp256k1 pubkey). When set, the result is a Schnorr adaptor pre-signature. Bound into the nonce HMAC."}
   ];
 }
 

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -158,12 +158,10 @@ enum ActivityType {
   ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT = 131;
   ACTIVITY_TYPE_DELETE_TVC_APP_AND_DEPLOYMENTS = 132;
   ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT = 133;
-  // Reserving the following for now to preserve ordering with Intent enum.
-  //
-  // ACTIVITY_TYPE_SPARK_SIGN_FROST = 134;
-  // ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER = 135;
-  // ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER = 136;
-  // ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE = 137;
+  ACTIVITY_TYPE_SPARK_SIGN_FROST = 134;
+  ACTIVITY_TYPE_SPARK_PREPARE_TRANSFER = 135;
+  ACTIVITY_TYPE_SPARK_CLAIM_TRANSFER = 136;
+  ACTIVITY_TYPE_SPARK_PREPARE_LIGHTNING_RECEIVE = 137;
   ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE = 138;
 }
 
@@ -5428,7 +5426,7 @@ message WebhookSubscriptionParams {
   // @inject_tag: validate:"required"
   string event_type = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The event type to subscribe to (for example, ACTIVITY_UPDATES or BALANCE_CONFIRMED_UPDATES)."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The event type to subscribe to (for example, ACTIVITY_UPDATES, BALANCE_CONFIRMED_UPDATES, or BALANCE_FINALIZED_UPDATES)."}
   ];
   // @inject_tag: validate:"omitempty"
   optional string filters_json = 2 [
@@ -6098,17 +6096,6 @@ message RemoveIpAllowlistResult {}
 // SPARK_PREPARE_LIGHTNING_RECEIVE) build the encrypted operator
 // packages that those FROST signatures attach to.
 
-// The key type addressed within a Spark wallet. Values correspond to the
-// per-account child index in the derivation path m/8797555'/{account}'/{N}'.
-enum SparkKeyType {
-  SPARK_KEY_TYPE_UNSPECIFIED = 0;
-  SPARK_KEY_TYPE_IDENTITY = 1; // N = 0
-  SPARK_KEY_TYPE_SIGNING_HD = 2; // N = 1; per-leaf BIP32 hardened child at u32_be(sha256(leaf_id_utf8)[0..4]) % 2^31
-  SPARK_KEY_TYPE_DEPOSIT = 3; // N = 2
-  SPARK_KEY_TYPE_STATIC_DEPOSIT_HD = 4; // N = 3
-  SPARK_KEY_TYPE_HTLC_PREIMAGE_HD = 5; // N = 4
-}
-
 // A FROST commitment pair contributed by one participant in a signing session.
 message SparkFrostCommitment {
   // @inject_tag: validate:"required"
@@ -6152,12 +6139,12 @@ message SparkTransferLeaf {
   // @inject_tag: validate:"required"
   SparkKeyDerivation old_leaf_derivation = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Derivation for the existing (pre-transfer) leaf key. Always a SIGNING_HD derivation."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Derivation for the existing (pre-transfer) leaf key. Always a SigningLeaf derivation."}
   ];
   // @inject_tag: validate:"required"
   SparkKeyDerivation new_leaf_derivation = 3 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Derivation for the new (post-transfer) leaf key. Always a SIGNING_HD derivation. The enclave ECIES-encrypts this private key to receiver_public_key as the per-leaf secret_cipher; HD-derived rather than random so the sender can re-derive on retry (Turnkey's enclave is stateless)."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Derivation for the new (post-transfer) leaf key. Always a SigningLeaf derivation. The enclave ECIES-encrypts this private key to receiver_public_key as the per-leaf secret_cipher; HD-derived rather than random so the sender can re-derive on retry (Turnkey's enclave is stateless)."}
   ];
   // @inject_tag: validate:"omitempty"
   optional string refund_signature = 4 [
@@ -6196,7 +6183,7 @@ message SparkClaimLeaf {
 }
 
 // Build a transfer: for each leaf, derive the new leaf private key via HD
-// (SIGNING_HD on new_leaf_derivation), compute the claim tweak scalar
+// (SigningLeaf on new_leaf_derivation), compute the claim tweak scalar
 // = old_priv - new_priv (mod n), Feldman-split the tweak across operators,
 // and ECIES-encrypt the new leaf private key to receiver_public_key as
 // the per-leaf secret_cipher carried inside each per-operator package.
@@ -6317,6 +6304,7 @@ message SparkSignatureRequest {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Commitments for every non-Turnkey participant. MUST NOT include an entry under Turnkey's identifier. Bound into the nonce HMAC."}
   ];
+  optional string adaptor_public_key = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional adaptor point T (hex-encoded 33-byte compressed secp256k1 pubkey). When set, Turnkey produces a Schnorr adaptor pre-signature with the FROST challenge bound to `R+T` (where `R` is the aggregate group nonce commitment from FROST). The party holding the discrete log `t` completes the pre-sig to a valid BIP-340 signature by adding `t` (or `-t`, for parity) to the signature scalar `s`. This is primarily used by Spark leaves-swap and other adaptor-bound flows; absent or empty leads to plain FROST signing (the typical case)."}];
 }
 
 // Per-signature output from SPARK_SIGN_FROST: Turnkey's FROST partial
@@ -6337,25 +6325,9 @@ message SparkPartialSignature {
   ];
 }
 
-// Request to derive the public key at a specific Spark key path.
-message SparkDerivePublicKeyRequest {
-  // @inject_tag: validate:"required"
-  SparkKeyDerivation derivation = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Which key type and optional leaf_id/index to derive."}
-  ];
-}
-
-message SparkDerivedPublicKey {
-  string public_key = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Hex-encoded compressed secp256k1 point (33 bytes)."}
-  ];
-}
-
-// Pairs a Spark leaf_id with its derived SIGNING_HD public key.
+// Pairs a Spark leaf_id with its derived SigningLeaf public key.
 // Returned by transfer and claim flows so callers can avoid a follow-up
-// per-leaf SIGNING_HD pubkey-derivation round-trip.
+// per-leaf SigningLeaf pubkey-derivation round-trip.
 message SparkLeafPublicKey {
   string leaf_id = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -6363,7 +6335,7 @@ message SparkLeafPublicKey {
   ];
   string public_key = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Hex-encoded compressed secp256k1 point (33 bytes) for the SIGNING_HD derivation at leaf_id."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Hex-encoded compressed secp256k1 point (33 bytes) for the SigningLeaf derivation at leaf_id."}
   ];
 }
 
@@ -6417,7 +6389,7 @@ message SparkPrepareTransferResult {
   ];
   repeated SparkLeafPublicKey new_leaf_public_keys = 3 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Newly-derived SIGNING_HD public keys, one per leaf, in input order."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Newly-derived SigningLeaf public keys, one per leaf, in input order."}
   ];
 }
 
@@ -6443,7 +6415,7 @@ message SparkClaimTransferResult {
   ];
   repeated SparkLeafPublicKey new_leaf_public_keys = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Newly-derived SIGNING_HD public keys, one per leaf, in input order."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Newly-derived SigningLeaf public keys, one per leaf, in input order."}
   ];
 }
 

--- a/proto/services/coordinator/public/v1/public_api.proto
+++ b/proto/services/coordinator/public/v1/public_api.proto
@@ -1959,6 +1959,54 @@ service PublicApiService {
     };
   }
 
+  rpc SparkSignFrost(external.activity.v1.SparkSignFrostRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/spark_sign_frost"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Perform pure FROST partial signing for a Spark wallet. Produces partial signatures without constructing operator packages."
+      summary: "Sign Frost Spark"
+      tags: "Signing"
+    };
+  }
+
+  rpc SparkPrepareTransfer(external.activity.v1.SparkPrepareTransferRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/spark_prepare_transfer"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Construct sender-side encrypted operator packages for a Spark BTC transfer. Does not perform FROST signing."
+      summary: "Prepare Spark transfer"
+      tags: "Signing"
+    };
+  }
+
+  rpc SparkClaimTransfer(external.activity.v1.SparkClaimTransferRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/spark_claim_transfer"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Construct receiver-side encrypted operator packages to claim a Spark transfer. Does not perform FROST signing."
+      summary: "Claim Spark transfer"
+      tags: "Signing"
+    };
+  }
+
+  rpc SparkPrepareLightningReceive(external.activity.v1.SparkPrepareLightningReceiveRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/spark_prepare_lightning_receive"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Generate a Lightning preimage and distribute Feldman shares to operators for a Spark Lightning receive. Does not perform FROST signing."
+      summary: "Spark prepare Lightning receive"
+      tags: "Signing"
+    };
+  }
+
   // This route does nothing and does not need an implementation, but please don't remove it.
   // It's used at compile time for generating extra OpenAPI/TypeScript types
   // that are not directly referenced in requests.


### PR DESCRIPTION
resolve activity type from proto annotation instead of `activities.json`. previously rust looked up activities by route url and read activity type string from `activities.json`, now we read the `enum: ["ACTIVITY_TYPE_*"]` annotation directly from each request message and use it as the key into `activities.json` to find intent and result type