### PR TITLE
Add client-side debug logging to TVC CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2020,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3303,6 +3321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,6 +3561,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3771,9 +3807,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3782,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3793,11 +3829,27 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3941,6 +3993,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "turnkey_api_key_stamper",
  "turnkey_client",
  "turnkey_enclave_encrypt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ zeroize = { version = "1.8.1", default-features = false }
 # Error handling
 thiserror = { version = "2.0.12", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+tracing = { version = "0.1.41", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 
 # Web/HTTP
 mime = { version = "0.3.17", default-features = false }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -32,6 +32,8 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 zeroize = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -34,6 +34,7 @@ impl Cli {
     /// Run the CLI.
     pub async fn run() -> anyhow::Result<()> {
         let args = Cli::parse();
+        tracing::debug!(command = args.command.name(), "dispatching command");
 
         match args.command {
             Commands::Deploy { command } => match command {
@@ -93,6 +94,17 @@ enum Commands {
     },
 }
 
+impl Commands {
+    fn name(&self) -> &'static str {
+        match self {
+            Commands::Login(_) => "login",
+            Commands::Deploy { command } => command.name(),
+            Commands::App { command } => command.name(),
+            Commands::Keys { command } => command.name(),
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 enum DeployCommands {
     /// Approve a deployment manifest.
@@ -112,6 +124,21 @@ enum DeployCommands {
     Delete(commands::deploy::delete::Args),
     /// Restore a deleted deployment.
     Restore(commands::deploy::restore::Args),
+}
+
+impl DeployCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            DeployCommands::Approve(_) => "deploy approve",
+            DeployCommands::GetStatus(_) => "deploy get-status",
+            DeployCommands::ProvisioningDetails(_) => "deploy provisioning-details",
+            DeployCommands::Status(_) => "deploy status",
+            DeployCommands::Create(_) => "deploy create",
+            DeployCommands::Init(_) => "deploy init",
+            DeployCommands::Delete(_) => "deploy delete",
+            DeployCommands::Restore(_) => "deploy restore",
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -138,4 +165,27 @@ enum KeysCommands {
     InitQuorumKey(commands::keys::init_quorum_key::Args),
     /// Re-encrypt a share for enclave provisioning.
     ReEncryptShare(commands::keys::re_encrypt_share::Args),
+}
+
+impl AppCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            AppCommands::Status(_) => "app status",
+            AppCommands::List(_) => "app list",
+            AppCommands::Create(_) => "app create",
+            AppCommands::Init(_) => "app init",
+            AppCommands::SetLiveDeploy(_) => "app set-live-deploy",
+            AppCommands::Delete(_) => "app delete",
+        }
+    }
+}
+
+impl KeysCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            KeysCommands::GenerateQuorumKey(_) => "keys generate-quorum-key",
+            KeysCommands::InitQuorumKey(_) => "keys init-quorum-key",
+            KeysCommands::ReEncryptShare(_) => "keys re-encrypt-share",
+        }
+    }
 }

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -35,11 +35,20 @@ pub struct AuthenticatedClient {
 /// If only some of the three required env vars are set, errors with the list of
 /// missing names — no merged resolve between env and disk vars.
 pub async fn build_client() -> Result<AuthenticatedClient> {
+    tracing::debug!("building authenticated Turnkey client");
+
     let (org_id, api_base_url, api_key_public, api_key_private) =
         match load_credentials_from_env_vars()? {
-            Some(creds) => creds,
-            None => load_credentials_from_config().await?,
+            Some(creds) => {
+                tracing::debug!(auth_source = "env", "using env auth credentials");
+                creds
+            }
+            None => {
+                tracing::debug!(auth_source = "config", "using local config credentials");
+                load_credentials_from_config().await?
+            }
         };
+
     build_authed_client(&org_id, &api_base_url, &api_key_public, &api_key_private)
 }
 
@@ -49,6 +58,13 @@ async fn load_credentials_from_config() -> Result<(String, String, String, Strin
     let (alias, org_config) = config
         .active_org_config()
         .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?;
+
+    tracing::debug!(
+        org_alias = %alias,
+        api_base_url = %org_config.api_base_url,
+        api_key_path = %org_config.api_key_path.display(),
+        "resolved active organization config"
+    );
 
     let api_key = StoredApiKey::load(org_config)
         .await?
@@ -68,14 +84,18 @@ fn build_authed_client(
     api_key_public: &str,
     api_key_private: &str,
 ) -> Result<AuthenticatedClient> {
+    tracing::debug!("constructing API key stamper");
     let stamper = TurnkeyP256ApiKey::from_strings(api_key_private, Some(api_key_public))
         .context("failed to load API key")?;
 
+    tracing::debug!(api_base_url = %api_base_url, "building Turnkey API client");
     let client = TurnkeyClient::builder()
         .api_key(stamper)
         .base_url(api_base_url)
         .build()
         .context("failed to build Turnkey client")?;
+
+    tracing::debug!("authenticated Turnkey client ready");
 
     Ok(AuthenticatedClient {
         client,
@@ -114,6 +134,15 @@ fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, St
     if api_key_private.is_none() {
         missing.push(ENV_API_KEY_PRIVATE);
     }
+
+    tracing::debug!(
+        tvc_org_id_set = org_id.is_some(),
+        tvc_api_key_public_set = api_key_public.is_some(),
+        tvc_api_key_private_set = api_key_private.is_some(),
+        tvc_api_base_url_set = read_env_var(ENV_API_BASE_URL).is_some(),
+        missing = ?missing,
+        "read auth env vars"
+    );
 
     // Acceptable to have none set: fall back to disk.
     if missing.len() == NUM_AUTH_ENV_VARS {

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -23,6 +23,11 @@ pub struct Args {
 
 /// Run the login command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
+    tracing::debug!(
+        org_arg_present = args.org.is_some(),
+        "running login command"
+    );
+
     // Load existing config
     let mut config = Config::load().await?;
 
@@ -75,11 +80,20 @@ async fn select_or_create_org(
     config: &mut Config,
     org_arg: Option<&str>,
 ) -> Result<(String, OrgConfig)> {
+    tracing::debug!(
+        org_arg_present = org_arg.is_some(),
+        configured_org_count = config.orgs.len(),
+        active_org = ?config.active_org,
+        "selecting organization"
+    );
+
     // If --org provided, try to find it by alias or ID
     if let Some(org) = org_arg {
         if let Some((alias, org_config)) = find_org(config, org) {
+            tracing::debug!(org_alias = %alias, "selected existing organization from argument");
             return Ok((alias.clone(), org_config.clone()));
         }
+        tracing::debug!("organization argument did not match configured organizations");
         bail!("Organization '{org}' not found. Run `tvc login` without --org to set up a new organization.");
     }
 
@@ -88,6 +102,7 @@ async fn select_or_create_org(
 
     if org_count == 0 {
         // No orgs configured - prompt for new org
+        tracing::debug!("no organizations configured; prompting for new organization");
         println!("No organization configured.");
         return prompt_for_new_org(config).await;
     }
@@ -109,18 +124,23 @@ async fn select_or_create_org(
     println!();
 
     if selection == "new" {
+        tracing::debug!("user selected new organization");
         return prompt_for_new_org(config).await;
     }
 
     if let Some(org_config) = config.orgs.get(&selection) {
+        tracing::debug!(org_alias = %selection, "user selected existing organization");
         return Ok((selection, org_config.clone()));
     }
 
+    tracing::debug!("user selected unknown organization alias");
     bail!("Organization '{}' not found", selection)
 }
 
 /// Prompt the user to enter a new organization ID and alias.
 async fn prompt_for_new_org(config: &mut Config) -> Result<(String, OrgConfig)> {
+    tracing::debug!("prompting for new organization");
+
     println!("You can find your Organization ID at: https://app.turnkey.com/dashboard/welcome");
     println!();
 
@@ -133,6 +153,7 @@ async fn prompt_for_new_org(config: &mut Config) -> Result<(String, OrgConfig)> 
 
     // Prompt for API base URL
     let api_base_url = prompt_for_api_url()?;
+    tracing::debug!(org_alias = %alias, api_base_url = %api_base_url, "adding prompted organization");
 
     config.add_org(&alias, org_id, api_base_url)?;
     let org_config = config.orgs.get(&alias).unwrap().clone();
@@ -159,6 +180,8 @@ fn prompt_for_api_url() -> Result<String> {
         _ => bail!("Invalid selection: {selection}"),
     };
 
+    tracing::debug!(api_base_url = %url, "selected API base URL");
+
     Ok(url.to_string())
 }
 
@@ -166,13 +189,17 @@ fn prompt_for_api_url() -> Result<String> {
 /// If an API key exists, it's returned directly.
 /// If not, a new key is generated, saved, and the user is prompted to add it to the dashboard.
 async fn get_or_generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
+    tracing::debug!(api_key_path = %org_config.api_key_path.display(), "resolving API key");
+
     // Check if API key already exists
     if let Some(api_key) = StoredApiKey::load(org_config).await? {
+        tracing::debug!("using existing API key");
         println!("Using existing API key.");
         return Ok(api_key);
     }
 
     // Generate new API key
+    tracing::debug!("generating new API key");
     println!();
     println!("Generating API key...");
 
@@ -208,13 +235,17 @@ async fn get_or_generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey>
 
 /// Get an existing operator key or generate a new one.
 async fn get_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQosOperatorKey> {
+    tracing::debug!(operator_key_path = %org_config.operator_key_path.display(), "resolving operator key");
+
     // Check if operator key already exists
     if let Some(operator_key) = StoredQosOperatorKey::load(org_config).await? {
+        tracing::debug!("using existing operator key");
         println!("Using existing operator key.");
         return Ok(operator_key);
     }
 
     // Generate new operator key
+    tracing::debug!("generating new operator key");
     println!();
     println!("Generating operator key...");
 
@@ -311,6 +342,8 @@ async fn verify_credentials(
     org_id: &str,
     api_base_url: &str,
 ) -> Result<WhoamiResult> {
+    tracing::debug!(api_base_url = %api_base_url, "verifying credentials with whoami");
+
     // Build the API key stamper from stored keys
     let stamper = TurnkeyP256ApiKey::from_strings(&api_key.private_key, Some(&api_key.public_key))
         .context("failed to load API key")?;
@@ -331,6 +364,8 @@ async fn verify_credentials(
         .get_whoami(request)
         .await
         .context("whoami request failed")?;
+
+    tracing::debug!("whoami verification succeeded");
 
     Ok(WhoamiResult {
         organization_name: response.organization_name,

--- a/tvc/src/config/turnkey/api_key.rs
+++ b/tvc/src/config/turnkey/api_key.rs
@@ -27,7 +27,9 @@ impl StoredApiKey {
     /// Load API key from the path specified in org config
     pub async fn load(org_config: &OrgConfig) -> Result<Option<Self>> {
         let path = &org_config.api_key_path;
+        tracing::debug!(api_key_path = %path.display(), "loading stored API key");
         if !path.exists() {
+            tracing::debug!(api_key_path = %path.display(), "stored API key not found");
             return Ok(None);
         }
 
@@ -38,12 +40,20 @@ impl StoredApiKey {
         let key: StoredApiKey = serde_json::from_str(&content)
             .with_context(|| format!("failed to parse API key: {}", path.display()))?;
 
+        tracing::debug!(
+            api_key_path = %path.display(),
+            curve = ?key.curve,
+            has_public_key = !key.public_key.is_empty(),
+            "loaded stored API key"
+        );
+
         Ok(Some(key))
     }
 
     /// Save API key to the path specified in org config
     pub async fn save(&self, org_config: &OrgConfig) -> Result<()> {
         let path = &org_config.api_key_path;
+        tracing::debug!(api_key_path = %path.display(), curve = ?self.curve, "saving stored API key");
 
         // Ensure parent directory exists
         if let Some(parent) = path.parent() {
@@ -57,6 +67,8 @@ impl StoredApiKey {
         tokio::fs::write(path, content)
             .await
             .with_context(|| format!("failed to write API key: {}", path.display()))?;
+
+        tracing::debug!(api_key_path = %path.display(), "saved stored API key");
 
         Ok(())
     }

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -99,7 +99,9 @@ impl Config {
     /// Load config from disk, or return default if it doesn't exist
     pub async fn load() -> Result<Self> {
         let path = config_file_path()?;
+        tracing::debug!(config_path = %path.display(), "loading tvc config");
         if !path.exists() {
+            tracing::debug!(config_path = %path.display(), "tvc config not found; using defaults");
             return Ok(Config::default());
         }
 
@@ -110,12 +112,25 @@ impl Config {
         let config: Config = toml::from_str(&content)
             .with_context(|| format!("failed to parse config file: {}", path.display()))?;
 
+        tracing::debug!(
+            config_path = %path.display(),
+            active_org = ?config.active_org,
+            org_count = config.orgs.len(),
+            "loaded tvc config"
+        );
+
         Ok(config)
     }
 
     /// Save config to disk
     pub async fn save(&self) -> Result<()> {
         let path = config_file_path()?;
+        tracing::debug!(
+            config_path = %path.display(),
+            active_org = ?self.active_org,
+            org_count = self.orgs.len(),
+            "saving tvc config"
+        );
 
         // Ensure parent directory exists
         if let Some(parent) = path.parent() {
@@ -130,6 +145,8 @@ impl Config {
             .await
             .with_context(|| format!("failed to write config file: {}", path.display()))?;
 
+        tracing::debug!(config_path = %path.display(), "saved tvc config");
+
         Ok(())
     }
 
@@ -141,6 +158,7 @@ impl Config {
 
     /// Add or update an organization with default key paths
     pub fn add_org(&mut self, alias: &str, org_id: String, api_base_url: String) -> Result<()> {
+        tracing::debug!(org_alias = alias, api_base_url = %api_base_url, "adding organization config");
         let org_config = OrgConfig {
             id: org_id,
             api_key_path: default_api_key_path(alias)?,
@@ -153,6 +171,7 @@ impl Config {
 
     /// Set the active organization
     pub fn set_active_org(&mut self, alias: &str) -> Result<()> {
+        tracing::debug!(org_alias = alias, "setting active organization");
         if !self.orgs.contains_key(alias) {
             bail!("organization '{}' not found in config", alias);
         }

--- a/tvc/src/config/turnkey/qos_operator_key.rs
+++ b/tvc/src/config/turnkey/qos_operator_key.rs
@@ -17,7 +17,9 @@ impl StoredQosOperatorKey {
     /// Load operator key from the path specified in org config
     pub async fn load(org_config: &OrgConfig) -> Result<Option<Self>> {
         let path = &org_config.operator_key_path;
+        tracing::debug!(operator_key_path = %path.display(), "loading stored operator key");
         if !path.exists() {
+            tracing::debug!(operator_key_path = %path.display(), "stored operator key not found");
             return Ok(None);
         }
 
@@ -28,12 +30,19 @@ impl StoredQosOperatorKey {
         let key: StoredQosOperatorKey = serde_json::from_str(&content)
             .with_context(|| format!("failed to parse operator key: {}", path.display()))?;
 
+        tracing::debug!(
+            operator_key_path = %path.display(),
+            has_public_key = !key.public_key.is_empty(),
+            "loaded stored operator key"
+        );
+
         Ok(Some(key))
     }
 
     /// Save operator key to the path specified in org config
     pub async fn save(&self, org_config: &OrgConfig) -> Result<()> {
         let path = &org_config.operator_key_path;
+        tracing::debug!(operator_key_path = %path.display(), "saving stored operator key");
 
         // Ensure parent directory exists
         if let Some(parent) = path.parent() {
@@ -48,6 +57,8 @@ impl StoredQosOperatorKey {
         tokio::fs::write(path, content)
             .await
             .with_context(|| format!("failed to write operator key: {}", path.display()))?;
+
+        tracing::debug!(operator_key_path = %path.display(), "saved stored operator key");
 
         Ok(())
     }

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod logging;
 pub(crate) mod operator_key;
 pub mod pair;
 pub(crate) mod provisioning;

--- a/tvc/src/logging.rs
+++ b/tvc/src/logging.rs
@@ -1,0 +1,19 @@
+//! Logging setup for the `tvc` binary.
+
+use tracing_subscriber::EnvFilter;
+
+/// Initialize process-wide diagnostic logging.
+///
+/// Logging is disabled by default to keep normal CLI output unchanged. Set
+/// `RUST_LOG`, for example `RUST_LOG=tvc=debug`, to enable structured debug
+/// diagnostics on stderr.
+pub fn init() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
+
+    tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .init();
+}

--- a/tvc/src/main.rs
+++ b/tvc/src/main.rs
@@ -2,5 +2,8 @@ use tvc::cli::Cli;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tvc::logging::init();
+    tracing::debug!(version = env!("CARGO_PKG_VERSION"), "starting tvc");
+
     Cli::run().await
 }


### PR DESCRIPTION
Adds client-side debug logging to the TVC CLI, focused on making auth/config issues easier to diagnose without changing normal CLI output.

Main changes:
* initialize `tracing-subscriber` with `env-filter`, disabled by default unless `RUST_LOG` is set
* add debug events around command dispatch, config load/save, auth source selection, key path checks, and Turnkey client construction
* keep secret material out of logs; debug output records presence/path/source metadata only

Validated manually with:
```bash
RUST_LOG=debug cargo run -p tvc -- login
```