### PR TITLE
feat(tvc): add deploy post-share command

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -43,6 +43,7 @@ impl Cli {
                 DeployCommands::ProvisioningDetails(args) => {
                     commands::deploy::provisioning_details::run(args).await
                 }
+                DeployCommands::PostShare(args) => commands::deploy::post_share::run(args).await,
                 DeployCommands::Status(args) => commands::deploy::status::run(args).await,
                 DeployCommands::Create(args) => commands::deploy::create::run(args).await,
                 DeployCommands::Init(args) => commands::deploy::init::run(args).await,
@@ -113,6 +114,8 @@ enum DeployCommands {
     GetStatus(commands::deploy::get_status::Args),
     /// Get provisioning details for a deployment.
     ProvisioningDetails(commands::deploy::provisioning_details::Args),
+    /// Post a re-encrypted quorum key share for a deployment.
+    PostShare(commands::deploy::post_share::Args),
     /// Get the status of a deployment.
     Status(commands::deploy::status::Args),
     /// Create a new deployment from a config file.
@@ -132,6 +135,7 @@ impl DeployCommands {
             DeployCommands::Approve(_) => "deploy approve",
             DeployCommands::GetStatus(_) => "deploy get-status",
             DeployCommands::ProvisioningDetails(_) => "deploy provisioning-details",
+            DeployCommands::PostShare(_) => "deploy post-share",
             DeployCommands::Status(_) => "deploy status",
             DeployCommands::Create(_) => "deploy create",
             DeployCommands::Init(_) => "deploy init",

--- a/tvc/src/commands/deploy/mod.rs
+++ b/tvc/src/commands/deploy/mod.rs
@@ -5,6 +5,7 @@ pub mod create;
 pub mod delete;
 pub mod get_status;
 pub mod init;
+pub mod post_share;
 pub mod provisioning_details;
 pub mod restore;
 pub mod status;

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -1,0 +1,123 @@
+//! Deploy post-share command.
+
+use crate::commands::keys::re_encrypt_share::ReEncryptedShareOutput;
+use crate::util::read_json_file;
+use anyhow::Context;
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use turnkey_client::generated::{PostTvcQuorumKeyShareIntent, QuorumKeyShareApprovalBundle};
+
+/// Post a re-encrypted quorum key share for a deployment.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Path to the re-encrypted share output from `tvc keys re-encrypt-share`.
+    #[arg(long, value_name = "PATH", env = "TVC_RE_ENCRYPTED_SHARE")]
+    pub re_encrypted_share: PathBuf,
+
+    /// Turnkey share set operator ID (UUID) for the operator posting this share.
+    #[arg(long, env = "TVC_SHARE_OPERATOR_ID")]
+    pub share_operator_id: String,
+}
+
+/// Run the deploy post-share command.
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    let re_encrypted_share: ReEncryptedShareOutput =
+        read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;
+    let intent =
+        build_post_tvc_quorum_key_share_intent(&re_encrypted_share, &args.share_operator_id);
+
+    let auth = crate::client::build_client().await?;
+    let timestamp_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system time before unix epoch")?
+        .as_millis();
+
+    let result = auth
+        .client
+        .post_tvc_quorum_key_share(auth.org_id, timestamp_ms, intent)
+        .await
+        .context("failed to post quorum key share")?;
+
+    println!(
+        "Provisioning Share ID: {}",
+        result.result.provisioning_share_id
+    );
+
+    Ok(())
+}
+
+fn build_post_tvc_quorum_key_share_intent(
+    re_encrypted_share: &ReEncryptedShareOutput,
+    share_operator_id: &str,
+) -> PostTvcQuorumKeyShareIntent {
+    PostTvcQuorumKeyShareIntent {
+        deployment_id: re_encrypted_share.deployment_id.clone(),
+        ephemeral_public_key_hex: re_encrypted_share.ephemeral_public_key_hex.clone(),
+        share_approval_bundle: Some(QuorumKeyShareApprovalBundle {
+            operator_id: share_operator_id.to_string(),
+            re_encrypted_share_hex: re_encrypted_share.re_encrypted_share.clone(),
+            signature: hex::encode(&re_encrypted_share.share_approval.signature),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_post_tvc_quorum_key_share_intent;
+    use crate::commands::keys::re_encrypt_share::ReEncryptedShareOutput;
+    use qos_core::protocol::services::boot::{Approval, QuorumMember};
+    use serde_json::json;
+    use turnkey_client::generated::QuorumKeyShareApprovalBundle;
+
+    fn sample_re_encrypted_share(deployment_id: &str) -> ReEncryptedShareOutput {
+        ReEncryptedShareOutput {
+            deployment_id: deployment_id.to_string(),
+            ephemeral_public_key_hex: "04abcd".to_string(),
+            re_encrypted_share: "010203".to_string(),
+            share_approval: Approval {
+                signature: vec![0xde, 0xad, 0xbe, 0xef],
+                member: QuorumMember {
+                    alias: "operator-1".to_string(),
+                    pub_key: vec![0xaa, 0xbb, 0xcc],
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn builds_expected_intent_shape() {
+        let output = sample_re_encrypted_share("deploy-from-file");
+        let intent = build_post_tvc_quorum_key_share_intent(&output, "share-operator-id");
+
+        assert_eq!(intent.deployment_id, "deploy-from-file");
+        assert_eq!(intent.ephemeral_public_key_hex, "04abcd");
+        assert_eq!(
+            intent.share_approval_bundle,
+            Some(QuorumKeyShareApprovalBundle {
+                operator_id: "share-operator-id".to_string(),
+                re_encrypted_share_hex: "010203".to_string(),
+                signature: "deadbeef".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_re_encrypt_share_json_without_deployment_id() {
+        let err = serde_json::from_value::<ReEncryptedShareOutput>(json!({
+            "ephemeralPublicKeyHex": "04abcd",
+            "reEncryptedShare": "010203",
+            "shareApproval": {
+                "signature": "deadbeef",
+                "member": {
+                    "alias": "operator-1",
+                    "pubKey": "aabbcc",
+                },
+            },
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("deploymentId"));
+    }
+}

--- a/tvc/src/commands/keys/re_encrypt_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_share.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, ManifestEnvelope, QuorumMember};
 use qos_core::protocol::QosHash;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
@@ -42,11 +42,13 @@ pub struct Args {
     pub re_encrypted_out: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ReEncryptedShareOutput {
-    re_encrypted_share: String,
-    share_approval: Approval,
+pub(crate) struct ReEncryptedShareOutput {
+    pub(crate) deployment_id: String,
+    pub(crate) ephemeral_public_key_hex: String,
+    pub(crate) re_encrypted_share: String,
+    pub(crate) share_approval: Approval,
 }
 
 /// Run the re-encrypt-share command.
@@ -114,6 +116,8 @@ async fn build_re_encrypted_share_output(
     let share_approval = Approval { signature, member };
 
     Ok(ReEncryptedShareOutput {
+        deployment_id: provision_bundle.deployment_id().to_string(),
+        ephemeral_public_key_hex: hex::encode(ephemeral_public_key.to_bytes()),
         re_encrypted_share: hex::encode(re_encrypted_share),
         share_approval,
     })
@@ -272,6 +276,8 @@ mod tests {
     #[test]
     fn output_serializes_expected_json_shape_with_hex() {
         let output = ReEncryptedShareOutput {
+            deployment_id: "deploy-123".to_string(),
+            ephemeral_public_key_hex: "04abcd".to_string(),
             re_encrypted_share: "010203".to_string(),
             share_approval: Approval {
                 signature: vec![0xde, 0xad, 0xbe, 0xef],
@@ -287,6 +293,8 @@ mod tests {
         assert_eq!(
             value,
             json!({
+                "deploymentId": "deploy-123",
+                "ephemeralPublicKeyHex": "04abcd",
                 "reEncryptedShare": "010203",
                 "shareApproval": {
                     "signature": "deadbeef",
@@ -425,6 +433,11 @@ mod tests {
                 .await
                 .unwrap();
 
+        assert_eq!(output.deployment_id, "deploy-123");
+        assert_eq!(
+            output.ephemeral_public_key_hex,
+            hex::encode(ephemeral_pair.public_key().to_bytes())
+        );
         let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
         let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
         assert_eq!(decrypted_share, plaintext_share);

--- a/tvc/src/provisioning.rs
+++ b/tvc/src/provisioning.rs
@@ -36,6 +36,14 @@ impl ProvisionBundle {
         }
     }
 
+    pub(crate) fn deployment_id(&self) -> &str {
+        &self.deployment_id
+    }
+
+    pub(crate) fn ephemeral_public_key_hex(&self) -> &str {
+        &self.ephemeral_public_key_hex
+    }
+
     pub(crate) fn manifest_envelope(&self) -> &ManifestEnvelope {
         &self.manifest_envelope
     }
@@ -52,7 +60,7 @@ impl ProvisionBundle {
         dangerous_skip_verification: bool,
         validation_time_override: Option<u64>,
     ) -> anyhow::Result<P256Public> {
-        let bundled_public_key = decode_ephemeral_public_key_hex(&self.ephemeral_public_key_hex)?;
+        let bundled_public_key = decode_ephemeral_public_key_hex(self.ephemeral_public_key_hex())?;
 
         if dangerous_skip_verification {
             return Ok(bundled_public_key);
@@ -338,5 +346,18 @@ mod tests {
         let public_key = bundle.ephemeral_public_key(true).unwrap();
 
         assert_eq!(public_key.to_bytes(), expected_public_key.to_bytes());
+    }
+
+    #[test]
+    fn provision_bundle_rejects_missing_deployment_id() {
+        let err = serde_json::from_value::<ProvisionBundle>(json!({
+            "attestationDocumentCoseSign1Base64": "not base64",
+            "manifestEnvelope": sample_manifest_envelope(),
+            "fetchedAtUnixMs": 1_712_345_678_901_u64,
+            "ephemeralPublicKeyHex": "04abcd",
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("deploymentId"));
     }
 }

--- a/tvc/tests/deploy_post_share.rs
+++ b/tvc/tests/deploy_post_share.rs
@@ -1,0 +1,46 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn deploy_help_lists_post_share_subcommand() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("post-share"))
+        .stdout(predicate::str::contains(
+            "Post a re-encrypted quorum key share for a deployment",
+        ));
+}
+
+#[test]
+fn post_share_help_lists_expected_flags() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("post-share")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--re-encrypted-share <PATH>"))
+        .stdout(predicate::str::contains(
+            "--share-operator-id <SHARE_OPERATOR_ID>",
+        ))
+        .stdout(predicate::str::contains("--deploy-id").not());
+}
+
+#[test]
+fn post_share_requires_re_encrypted_share_and_share_operator_id() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("post-share")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the following required arguments were not provided",
+        ))
+        .stderr(predicate::str::contains("--re-encrypted-share <PATH>"))
+        .stderr(predicate::str::contains(
+            "--share-operator-id <SHARE_OPERATOR_ID>",
+        ));
+}

--- a/tvc/tests/keys_re_encrypt_share.rs
+++ b/tvc/tests/keys_re_encrypt_share.rs
@@ -14,6 +14,8 @@ use tempfile::TempDir;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ReEncryptedShareOutput {
+    deployment_id: String,
+    ephemeral_public_key_hex: String,
     re_encrypted_share: String,
     share_approval: Approval,
 }
@@ -183,12 +185,22 @@ fn re_encrypt_share_round_trips_metadata_share() {
 
     let value: serde_json::Value =
         serde_json::from_slice(&fs::read(&output_path).unwrap()).unwrap();
+    assert_eq!(value["deploymentId"], json!("deploy-123"));
+    assert_eq!(
+        value["ephemeralPublicKeyHex"],
+        json!(hex::encode(ephemeral_pair.public_key().to_bytes()))
+    );
     assert!(value.get("reEncryptedShare").is_some());
     assert!(value.get("shareApproval").is_some());
     assert!(value.get("re_encrypted_share").is_none());
     assert!(value.get("share_approval").is_none());
 
     let output: ReEncryptedShareOutput = serde_json::from_value(value).unwrap();
+    assert_eq!(output.deployment_id, "deploy-123");
+    assert_eq!(
+        output.ephemeral_public_key_hex,
+        hex::encode(ephemeral_pair.public_key().to_bytes())
+    );
     let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
     let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
     assert_eq!(decrypted_share, plaintext_share);


### PR DESCRIPTION
The `tvc deploy post-share` command takes the output of `tvc keys re-encrypt-share` and wraps it into a call to the `post_tvc_quorum_key_share` activity. This PR also alters `re-encrypt-share` a smidge to persist the ephemeral key and deployment id from the provision bundle into the re-encrypted output for easy share posting.