### PR TITLE
ci: build with --locked to catch Cargo.lock drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 
 .PHONY: build
 build:
-	cargo build
+	cargo build --locked
 
 .PHONY: test
 test: build


### PR DESCRIPTION
## Summary

Adds `--locked` to the `build` Makefile target so CI fails when `Cargo.lock` is out of sync with the dependency graph, instead of silently auto-repairing it in the CI workspace and passing green.

## Why

CI currently runs `cargo build` / `cargo test` / `cargo clippy` with no `--locked`/`--frozen` flag. When a checkout has a `Cargo.lock` that doesn't match the dependency graph, cargo **silently repairs the lockfile in the workspace** and proceeds — so a broken lockfile sails through CI green, and the repair is never committed back.

This actually happened: PR #139 (commit 8c8ed63) dropped the `[[package]] thread_local` stanza during a rebase while `tracing-subscriber` still referenced it, leaving the lockfile internally inconsistent. CI didn't catch it; it was later fixed manually in #147.

With `--locked`, cargo errors instead of editing the lockfile, so this class of drift fails CI at the build step.

`--locked` (not `--frozen`) is intentional: it catches lockfile drift while still allowing normal registry/network access, so CI doesn't need a pre-warmed offline crate cache.

## Note

After this lands, any legitimate dependency change must come with an updated, committed `Cargo.lock` — otherwise CI fails. That's the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)