### PR TITLE
TVC-66: Make non-interactive mode explicit in tvc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -30,6 +30,7 @@ inquire = { workspace = true }
 p256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 zeroize = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI parsing and dispatch.
 
 use crate::commands;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser};
 use tracing::debug;
 
 const LONG_ABOUT: &str = "\
@@ -26,12 +26,26 @@ Authentication:
   Local: run `tvc login` once; commands then read ~/.config/turnkey/.
   CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
          to authenticate without files. Env vars take precedence over local
-         config files. Setting some but not all three required vars will error.";
+         config files. Setting some but not all three required vars will error.
+
+Interactive behavior:
+  By default, commands may prompt when stdin is a TTY. Use --non-interactive
+  or set TVC_NON_INTERACTIVE=true to disable prompts and fail fast instead.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]
 #[command(about = "CLI for building with Turnkey Verifiable Cloud", long_about = LONG_ABOUT)]
 pub struct Cli {
+    /// Disable interactive prompts and fail fast when required values are missing.
+    #[arg(
+        long,
+        global = true,
+        env = "TVC_NON_INTERACTIVE",
+        action = ArgAction::SetTrue,
+        value_parser = BoolishValueParser::new()
+    )]
+    non_interactive: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -40,27 +54,41 @@ impl Cli {
     /// Run the CLI.
     pub async fn run() -> anyhow::Result<()> {
         let args = Cli::parse();
-        debug!(command = args.command.name(), "dispatching");
+        debug!(
+            command = args.command.name(),
+            non_interactive = args.non_interactive,
+            "dispatching"
+        );
+
+        let non_interactive = args.non_interactive;
 
         match args.command {
             Commands::Deploy { command } => match command {
-                DeployCommands::Approve(args) => commands::deploy::approve::run(args).await,
+                DeployCommands::Approve(args) => {
+                    commands::deploy::approve::run(args, non_interactive).await
+                }
                 DeployCommands::GetStatus(args) => commands::deploy::get_status::run(args).await,
                 DeployCommands::ProvisioningDetails(args) => {
                     commands::deploy::provisioning_details::run(args).await
                 }
                 DeployCommands::PostShare(args) => commands::deploy::post_share::run(args).await,
                 DeployCommands::Status(args) => commands::deploy::status::run(args).await,
-                DeployCommands::Create(args) => commands::deploy::create::run(args).await,
-                DeployCommands::Init(args) => commands::deploy::init::run(args).await,
+                DeployCommands::Create(args) => {
+                    commands::deploy::create::run(args, non_interactive).await
+                }
+                DeployCommands::Init(args) => {
+                    commands::deploy::init::run(args, non_interactive).await
+                }
                 DeployCommands::Delete(args) => commands::deploy::delete::run(args).await,
                 DeployCommands::Restore(args) => commands::deploy::restore::run(args).await,
             },
             Commands::App { command } => match command {
                 AppCommands::Status(args) => commands::app::status::run(args).await,
                 AppCommands::List(args) => commands::app::list::run(args).await,
-                AppCommands::Create(args) => commands::app::create::run(args).await,
-                AppCommands::Init(args) => commands::app::init::run(args).await,
+                AppCommands::Create(args) => {
+                    commands::app::create::run(args, non_interactive).await
+                }
+                AppCommands::Init(args) => commands::app::init::run(args, non_interactive).await,
                 AppCommands::SetLiveDeploy(args) => commands::app::set_live_deploy::run(args).await,
                 AppCommands::Delete(args) => commands::app::delete::run(args).await,
             },
@@ -75,7 +103,7 @@ impl Cli {
                     commands::keys::re_encrypt_share::run(args).await
                 }
             },
-            Commands::Login(args) => commands::login::run(args).await,
+            Commands::Login(args) => commands::login::run(args, non_interactive).await,
         }
     }
 }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -1,9 +1,13 @@
 //! App create command - creates an app from a config file.
 
-use crate::client::build_client;
-use crate::config::app::{AppConfig, OperatorSetParams};
-use crate::config::turnkey::{self, StoredQosOperatorKey};
-use crate::prompts;
+use crate::{
+    client::build_client,
+    config::{
+        app::{AppConfig, AppConfigValidationErrors, OperatorSetParams},
+        turnkey::{self, StoredQosOperatorKey},
+    },
+    prompts,
+};
 use anyhow::{Context, Result, anyhow};
 use clap::Args as ClapArgs;
 use std::path::{Path, PathBuf};
@@ -12,12 +16,20 @@ use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperat
 
 /// Create a new TVC application from a config file.
 #[derive(Debug, ClapArgs)]
+#[cfg_attr(test, derive(Default))]
 #[command(about, long_about = None)]
 pub struct Args {
     /// Path to the app configuration file (JSON).
     #[arg(short = 'c', long, value_name = "PATH", env = "TVC_APP_CONFIG")]
     pub config_file: PathBuf,
 
+    #[command(flatten)]
+    overrides: Overrides,
+}
+
+#[derive(Debug, ClapArgs)]
+#[cfg_attr(test, derive(Default))]
+struct Overrides {
     /// Permit debug-mode deployments for this app. Debug-mode deployments expose
     /// secure-enclave logs and emit zero'd attestation PCRs, so remote
     /// attestation cannot succeed. Cannot be changed after app creation; setting
@@ -26,29 +38,103 @@ pub struct Args {
     pub dangerous_enable_debug_mode_deployments: bool,
 }
 
-/// Run the app create command.
-pub async fn run(args: Args) -> Result<()> {
-    let app_config = apply_overrides(load_or_fill_app_config(&args.config_file).await?, &args);
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
+    let config = if is_non_interactive {
+        build_app_config_non_interactive(&args).await?
+    } else {
+        build_app_config_interactive(&args).await?
+    };
 
-    app_config
-        .validate()
-        .with_context(|| format!("invalid config file: {}", args.config_file.display()))?;
+    let app_config = apply_overrides(config, &args.overrides);
+    run_with_config(args, app_config).await
+}
 
+async fn build_app_config_interactive(args: &Args) -> Result<AppConfig> {
+    let mut config = match read_app_config_file_bytes(&args.config_file).await {
+        Ok(bytes) => parse_app_config(&bytes, &args.config_file)?,
+        Err(_) => AppConfig::template(None),
+    };
+
+    let mut changed = false;
+    loop {
+        match config.validate() {
+            Ok(()) => break,
+            Err(errors) if errors.has_non_placeholder_error() => {
+                return Err(invalid_app_config_error(&args.config_file, errors));
+            }
+            _ => {
+                changed = true;
+                let saved_operator_public_key = load_saved_operator_public_key().await;
+                config.fill_interactively(saved_operator_public_key.as_deref())?;
+            }
+        }
+    }
+
+    if changed {
+        offer_to_save_app_config(&args.config_file, &config)?;
+    }
+
+    Ok(config)
+}
+
+async fn build_app_config_non_interactive(args: &Args) -> Result<AppConfig> {
+    let bytes = read_app_config_file_bytes(&args.config_file).await?;
+    let config = parse_app_config(&bytes, &args.config_file)?;
+
+    if let Err(errors) = config.validate() {
+        return Err(invalid_app_config_error(&args.config_file, errors));
+    }
+
+    Ok(config)
+}
+
+async fn read_app_config_file_bytes(path: &Path) -> Result<String> {
+    tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read config file: {}", path.display()))
+}
+
+fn parse_app_config(content: &str, path: &Path) -> Result<AppConfig> {
+    serde_json::from_str(content)
+        .with_context(|| format!("failed to parse config file: {}", path.display()))
+}
+
+fn invalid_app_config_error(path: &Path, errors: AppConfigValidationErrors) -> anyhow::Error {
+    anyhow!("invalid config file: {}: {}", path.display(), errors)
+}
+
+fn offer_to_save_app_config(path: &Path, config: &AppConfig) -> Result<()> {
+    let save = prompts::confirm(&format!("Save filled config to {}?", path.display()), true)?;
+    if save {
+        let json = serde_json::to_string_pretty(config).context("failed to serialize config")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write config file: {}", path.display()))?;
+        println!("Wrote {}", path.display());
+    }
+    Ok(())
+}
+
+/// Best-effort load of the operator public key from the active org's config
+/// so we can offer it as the default for new-operator prompts.
+async fn load_saved_operator_public_key() -> Option<String> {
+    let config = turnkey::Config::load().await.ok()?;
+    let (_, org_config) = config.active_org_config()?;
+    let operator_key = StoredQosOperatorKey::load(org_config).await.ok()??;
+    Some(operator_key.public_key)
+}
+
+async fn run_with_config(args: Args, app_config: AppConfig) -> Result<()> {
     println!("Creating app '{}'...", app_config.name);
 
-    // Build authenticated client
     let auth = build_client().await?;
 
-    // Convert config to API intent
     let intent = build_create_tvc_app_intent(&app_config);
 
-    // Get timestamp
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system time before unix epoch")?
         .as_millis();
 
-    // Create the app
     let result = auth
         .client
         .create_tvc_app(auth.org_id, timestamp_ms, intent)
@@ -58,7 +144,6 @@ pub async fn run(args: Args) -> Result<()> {
     let app_id = result.result.app_id;
     let operator_ids = result.result.manifest_set_operator_ids;
 
-    // save the app ID and operator_ids to config
     let mut config = turnkey::Config::load().await?;
     config.set_last_app_id(&app_id)?;
     config.set_last_operator_ids(&operator_ids)?;
@@ -82,57 +167,6 @@ pub async fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
-/// Load the app config, walking placeholders interactively when allowed.
-async fn load_or_fill_app_config(path: &Path) -> Result<AppConfig> {
-    let read = std::fs::read_to_string(path);
-    let (mut config, file_existed) = match read {
-        Ok(content) => {
-            let config: AppConfig = serde_json::from_str(&content)
-                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
-            (config, true)
-        }
-        Err(_) if prompts::is_interactive() => (AppConfig::template(None), false),
-        Err(e) => {
-            return Err(anyhow!(e))
-                .with_context(|| format!("failed to read config file: {}", path.display()));
-        }
-    };
-
-    if file_existed && !config.has_placeholders() {
-        return Ok(config);
-    }
-
-    if !prompts::is_interactive() {
-        anyhow::bail!(
-            "Config file contains placeholder values (<FILL_IN_...>). \
-             Please edit {} and fill in all required values.",
-            path.display()
-        );
-    }
-
-    let saved_operator_public_key = load_saved_operator_public_key().await;
-    config.fill_interactively(saved_operator_public_key.as_deref())?;
-
-    let save = prompts::confirm(&format!("Save filled config to {}?", path.display()), true)?;
-    if save {
-        let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
-        std::fs::write(path, json)
-            .with_context(|| format!("failed to write config file: {}", path.display()))?;
-        println!("Wrote {}", path.display());
-    }
-
-    Ok(config)
-}
-
-/// Best-effort load of the operator public key from the active org's config
-/// so we can offer it as the default for new-operator prompts.
-async fn load_saved_operator_public_key() -> Option<String> {
-    let config = turnkey::Config::load().await.ok()?;
-    let (_, org_config) = config.active_org_config()?;
-    let operator_key = StoredQosOperatorKey::load(org_config).await.ok()??;
-    Some(operator_key.public_key)
-}
-
 fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
     let share_set_params = app_config.effective_share_set_params();
 
@@ -151,10 +185,10 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
     }
 }
 
-fn apply_overrides(mut config: AppConfig, args: &Args) -> AppConfig {
-    if args.dangerous_enable_debug_mode_deployments {
+fn apply_overrides(mut config: AppConfig, overrides: &Overrides) -> AppConfig {
+    if overrides.dangerous_enable_debug_mode_deployments {
         config.dangerous_enable_debug_mode_deployments =
-            args.dangerous_enable_debug_mode_deployments;
+            overrides.dangerous_enable_debug_mode_deployments;
     }
     config
 }
@@ -261,12 +295,11 @@ mod tests {
     #[test]
     fn dangerous_flag_enables_debug_mode_when_config_unset() {
         let config = valid_config();
-        let args = Args {
-            config_file: PathBuf::new(),
+        let overrides = Overrides {
             dangerous_enable_debug_mode_deployments: true,
         };
 
-        let config = apply_overrides(config, &args);
+        let config = apply_overrides(config, &overrides);
         assert!(config.dangerous_enable_debug_mode_deployments);
     }
 
@@ -277,13 +310,51 @@ mod tests {
     fn absent_dangerous_flag_preserves_config_debug_mode() {
         let mut config = valid_config();
         config.dangerous_enable_debug_mode_deployments = true;
-        let args = Args {
-            config_file: PathBuf::new(),
+        let overrides = Overrides {
             dangerous_enable_debug_mode_deployments: false,
         };
 
-        let config = apply_overrides(config, &args);
+        let config = apply_overrides(config, &overrides);
         assert!(config.dangerous_enable_debug_mode_deployments);
+    }
+
+    /// Exercises every override flag via clap parsing so flag renames or
+    /// removals fail this test. The other override tests construct `Args` by
+    /// field name and would silently pass.
+    #[test]
+    fn every_override_flag_changes_config_value() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            args: Args,
+        }
+
+        let config_path = "/tmp/test-app.json";
+        let args = TestCli::try_parse_from([
+            "tvc-app-create",
+            "--config-file",
+            config_path,
+            "--dangerous-enable-debug-mode-deployments",
+        ])
+        .unwrap()
+        .args;
+
+        let baseline = valid_config();
+        let resolved = apply_overrides(valid_config(), &args.overrides);
+
+        // Each override moved off its config default ...
+        assert_ne!(
+            resolved.dangerous_enable_debug_mode_deployments,
+            baseline.dangerous_enable_debug_mode_deployments
+        );
+
+        // ... to the value passed on the CLI.
+        assert!(resolved.dangerous_enable_debug_mode_deployments);
+
+        // config_file isn't an override; verify clap captured the path.
+        assert_eq!(args.config_file, PathBuf::from(config_path));
     }
 
     #[test]

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -2,7 +2,7 @@
 
 use crate::config::app::AppConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::prompts;
+use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
 use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
@@ -28,14 +28,18 @@ pub struct Args {
 }
 
 /// Run the app init command.
-pub async fn run(args: Args) -> Result<()> {
-    if args.interactive && prompts::non_interactive_forced() {
-        bail!(
-            "--interactive conflicts with {}=1",
-            prompts::NON_INTERACTIVE_ENV
-        );
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
+    if args.interactive {
+        if is_non_interactive {
+            bail_interactive_conflicts_with_non_interactive()?;
+        } else {
+            ensure_stdin_is_tty()?;
+        }
     }
+    execute(args).await
+}
 
+async fn execute(args: Args) -> Result<()> {
     // Check if file already exists
     if args.output.exists() {
         bail!("File already exists: {}", args.output.display());

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -3,6 +3,7 @@
 use crate::config::turnkey::Config;
 use crate::operator_key::load_operator_pair;
 use crate::prompts;
+use crate::prompts::{bail_required_in_non_interactive, stdin_can_prompt};
 use crate::util::{read_file_to_string, write_file};
 use anyhow::{Context, anyhow, bail};
 use clap::{ArgGroup, Args as ClapArgs};
@@ -75,63 +76,190 @@ pub struct Args {
     pub skip_post: bool,
 }
 
-/// Run the approve deploy command.
-pub async fn run(args: Args) -> anyhow::Result<()> {
+struct PostApprovalPlan<'a, 'b> {
+    manifest_id: &'a str,
+    operator_id: &'b str,
+}
+
+struct PostTarget {
+    manifest_id: String,
+    operator_id: String,
+}
+
+struct ResolvedApproveInputs {
+    manifest: Manifest,
+    operator_seed: Option<PathBuf>,
+    approval_out: Option<PathBuf>,
+    dry_run: bool,
+    post_target: Option<PostTarget>,
+}
+
+pub async fn run(args: Args, is_non_interactive: bool) -> anyhow::Result<()> {
+    let inputs = if is_non_interactive {
+        build_inputs_non_interactive(args).await?
+    } else {
+        build_inputs_interactive(args).await?
+    };
+
+    run_with_resolved_inputs(inputs).await
+}
+
+async fn build_inputs_interactive(args: Args) -> anyhow::Result<ResolvedApproveInputs> {
     let do_prompt_user = !args.dangerous_skip_interactive;
 
-    // Guard: Bail fast before fetching the manifest if we cannot prompt the user
-    if do_prompt_user {
-        prompts::bail_if_non_interactive("--dangerous-skip-interactive")?;
+    // Guard: bail fast before fetching the manifest if review prompts are
+    // required but the caller has no TTY to answer them.
+    if do_prompt_user && !stdin_can_prompt() {
+        bail_required_in_non_interactive("--dangerous-skip-interactive")?;
     }
 
-    // Fetch manifest - track manifest_id if fetched from API
-    let (manifest, fetched_manifest_id) = match (&args.manifest, &args.deploy_id) {
-        (Some(path), _) => (read_manifest_from_path(path).await?, None),
-        (_, Some(deploy_id)) => {
-            let (manifest, manifest_id) = fetch_manifest_from_deploy(deploy_id).await?;
-            (manifest, Some(manifest_id))
-        }
-        (None, None) => bail!("a manifest source is required"),
-    };
+    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
 
     if do_prompt_user {
         interactive_approve(&manifest)?;
     }
 
-    if args.dry_run {
+    let post_target = if !args.dry_run && !args.skip_post {
+        let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
+        let operator_id = match &args.operator_id {
+            Some(id) => id.clone(),
+            None => {
+                let saved_ids = load_saved_operator_ids().await?;
+                match &*saved_ids {
+                    [] => bail!(
+                        "--operator-id is required to post approval to API. \
+                         No saved operator IDs found. \
+                         Use --skip-post to only generate the approval locally."
+                    ),
+                    [id] => id.clone(),
+                    _ if stdin_can_prompt() => prompts::select(
+                        "Select approving operator",
+                        saved_ids.iter().map(String::as_str).collect::<Vec<_>>(),
+                    )?
+                    .to_string(),
+                    _ => bail!(
+                        "--operator-id is required to post approval to API when multiple saved operator IDs are available"
+                    ),
+                }
+            }
+        };
+        Some(PostTarget {
+            manifest_id,
+            operator_id,
+        })
+    } else {
+        None
+    };
+
+    Ok(ResolvedApproveInputs {
+        manifest,
+        operator_seed: args.operator_seed,
+        approval_out: args.approval_out,
+        dry_run: args.dry_run,
+        post_target,
+    })
+}
+
+async fn build_inputs_non_interactive(args: Args) -> anyhow::Result<ResolvedApproveInputs> {
+    if !args.dangerous_skip_interactive {
+        bail_required_in_non_interactive("--dangerous-skip-interactive")?;
+    }
+
+    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
+
+    let post_target = if !args.dry_run && !args.skip_post {
+        let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
+        let operator_id = match &args.operator_id {
+            Some(id) => id.clone(),
+            None => {
+                let saved_ids = load_saved_operator_ids().await?;
+                match &*saved_ids {
+                    [] => bail!(
+                        "--operator-id is required to post approval to API. \
+                         No saved operator IDs found. \
+                         Use --skip-post to only generate the approval locally."
+                    ),
+                    [id] => id.clone(),
+                    _ => bail!(
+                        "--operator-id is required to post approval to API when multiple saved operator IDs are available"
+                    ),
+                }
+            }
+        };
+        Some(PostTarget {
+            manifest_id,
+            operator_id,
+        })
+    } else {
+        None
+    };
+
+    Ok(ResolvedApproveInputs {
+        manifest,
+        operator_seed: args.operator_seed,
+        approval_out: args.approval_out,
+        dry_run: args.dry_run,
+        post_target,
+    })
+}
+
+async fn run_with_resolved_inputs(inputs: ResolvedApproveInputs) -> anyhow::Result<()> {
+    if inputs.dry_run {
         println!("Dry run complete. No approval generated.");
         return Ok(());
     }
 
-    let pair: Box<dyn crate::pair::Pair> =
-        Box::new(load_operator_pair(args.operator_seed.as_deref()).await?);
+    let approval = sign_and_output(
+        inputs.operator_seed.as_deref(),
+        inputs.approval_out.as_deref(),
+        &inputs.manifest,
+    )
+    .await?;
 
-    let approval = generate_approval(pair, &manifest).await?;
+    if let Some(target) = inputs.post_target {
+        let plan = PostApprovalPlan {
+            manifest_id: target.manifest_id.as_str(),
+            operator_id: target.operator_id.as_str(),
+        };
+        post_approval_to_api(plan, &approval).await?;
+    }
+
+    Ok(())
+}
+
+async fn load_manifest(args: &Args) -> anyhow::Result<(Manifest, Option<String>)> {
+    match (&args.manifest, &args.deploy_id) {
+        (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
+        (_, Some(deploy_id)) => {
+            let (manifest, manifest_id) = fetch_manifest_from_deploy(deploy_id).await?;
+            Ok((manifest, Some(manifest_id)))
+        }
+        (None, None) => bail!("a manifest source is required"),
+    }
+}
+
+async fn sign_and_output(
+    operator_seed: Option<&Path>,
+    approval_out: Option<&Path>,
+    manifest: &Manifest,
+) -> anyhow::Result<Approval> {
+    let pair: Box<dyn crate::pair::Pair> = Box::new(load_operator_pair(operator_seed).await?);
+
+    let approval = generate_approval(pair, manifest).await?;
     let json = serde_json::to_string_pretty(&approval)?;
 
-    // Write to file or stdout
-    if let Some(ref path) = args.approval_out {
+    if let Some(path) = approval_out {
         write_file(path, &json).await?;
         println!("Approval written to: {}", path.display());
     } else {
         println!("{json}");
     }
 
-    // Post to API if not skipped
-    if !args.skip_post {
-        post_approval_to_api(&args, &approval, fetched_manifest_id.as_deref()).await?;
-    }
-
-    Ok(())
+    Ok(approval)
 }
 
-async fn post_approval_to_api(
-    args: &Args,
-    approval: &Approval,
-    fetched_manifest_id: Option<&str>,
-) -> anyhow::Result<()> {
-    // Use fetched manifest_id (from --deploy-id) or fall back to --manifest-id arg
-    let manifest_id = fetched_manifest_id
+fn resolve_manifest_id(args: &Args, fetched_manifest_id: Option<&str>) -> anyhow::Result<String> {
+    fetched_manifest_id
         .map(|s| s.to_string())
         .or_else(|| args.manifest_id.clone())
         .ok_or_else(|| {
@@ -139,57 +267,38 @@ async fn post_approval_to_api(
                 "--manifest-id is required to post approval to API (or use --deploy-id). \
                  Use --skip-post to only generate the approval locally."
             )
-        })?;
+        })
+}
 
-    let operator_id = match &args.operator_id {
-        Some(id) => id.clone(),
-        None => {
-            let config = Config::load().await?;
-            let saved_ids = config.get_last_operator_ids().ok_or_else(|| {
-                anyhow!(
-                    "--operator-id is required to post approval to API. \
-                     No saved operator IDs found. \
-                     Use --skip-post to only generate the approval locally."
-                )
-            })?;
+async fn load_saved_operator_ids() -> anyhow::Result<Vec<String>> {
+    let config = Config::load().await?;
+    Ok(config.get_last_operator_ids().unwrap_or_default())
+}
 
-            match saved_ids.len() {
-                0 => bail!("No operator IDs available"),
-                1 => saved_ids[0].clone(),
-                _ if prompts::is_interactive() => {
-                    prompts::select("Select approving operator", saved_ids.clone())?
-                }
-                // Non-interactive with multiple saved IDs: pick the first entry.
-                // Users who want a specific operator should pass --operator-id.
-                _ => saved_ids[0].clone(),
-            }
-        }
-    };
-
+async fn post_approval_to_api(
+    plan: PostApprovalPlan<'_, '_>,
+    approval: &Approval,
+) -> anyhow::Result<()> {
     println!();
     println!("Posting approval to Turnkey...");
 
-    // Build authenticated client
     let auth = crate::client::build_client().await?;
 
-    // Convert local approval to API format
     let tvc_approval = TvcManifestApproval {
-        operator_id: operator_id.clone(),
+        operator_id: plan.operator_id.into(),
         signature: hex::encode(&approval.signature),
     };
 
     let intent = CreateTvcManifestApprovalsIntent {
-        manifest_id: manifest_id.clone(),
+        manifest_id: plan.manifest_id.into(),
         approvals: vec![tvc_approval],
     };
 
-    // Get timestamp
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system time before unix epoch")?
         .as_millis();
 
-    // Post the approval
     let result = auth
         .client
         .create_tvc_manifest_approvals(auth.org_id, timestamp_ms, intent)
@@ -200,8 +309,8 @@ async fn post_approval_to_api(
     println!("Approval posted successfully!");
     println!();
     println!("Approval IDs: {:?}", result.result.approval_ids);
-    println!("Manifest ID: {manifest_id}");
-    println!("Operator ID: {operator_id}");
+    println!("Manifest ID: {}", plan.manifest_id);
+    println!("Operator ID: {}", plan.operator_id);
 
     Ok(())
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -1,18 +1,18 @@
 //! Deploy create command - creates a deployment from a config file or CLI flags.
 
 use crate::client::build_client;
-use crate::config::deploy::DeployConfig;
+use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
 use crate::prompts;
-use crate::prompts::is_interactive;
 use crate::pull_secret::encrypt_pivot_pull_secret;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::try_join;
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
 
-pub(crate) const LONG_ABOUT: &str = "\
+pub(crate) const LONG_ABOUT: &str = r#"
 Create a new TVC deployment.
 
 Use --config-file, flags, env vars, or a mix of them. Command-line flags
@@ -38,32 +38,61 @@ Special rules:
 
 Interactive vs non-interactive:
   By default, missing required values are filled by interactive prompts when
-  stdin is a TTY. Set TVC_NON_INTERACTIVE=1 to disable all prompts, like in CI; the command then
-  bails with a precise list of missing fields instead of waiting on input.
+  stdin is a TTY. Use --non-interactive or set TVC_NON_INTERACTIVE=true to
+  disable all prompts, like in CI; the command then bails with a precise list
+  of missing fields instead of waiting on input.
 
 Examples:
   tvc deploy create --config-file deploy.json
 
   # OR
 
-  TVC_ORG_ID=... \\
-  TVC_API_KEY_PUBLIC=... \\
-  TVC_API_KEY_PRIVATE=... \\
-  TVC_APP_ID=... \\
-  TVC_QOS_VERSION=... \\
-  TVC_PIVOT_PATH=... \\
-  TVC_PIVOT_IMAGE_URL=... \\
-  TVC_EXPECTED_PIVOT_DIGEST=... \\
-    tvc deploy create";
+  TVC_ORG_ID=... \
+  TVC_API_KEY_PUBLIC=... \
+  TVC_API_KEY_PRIVATE=... \
+  TVC_APP_ID=... \
+  TVC_QOS_VERSION=... \
+  TVC_PIVOT_PATH=... \
+  TVC_PIVOT_IMAGE_URL=... \
+  TVC_EXPECTED_PIVOT_DIGEST=... \
+    tvc deploy create"#;
 
 /// Create a new TVC deployment from a config file or CLI flags.
 #[derive(Debug, ClapArgs)]
+#[cfg_attr(test, derive(Default))]
 #[command(about, long_about = None)]
 pub struct Args {
     /// Path to the deployment configuration file (JSON).
     /// Optional when all required fields are provided via flags or env.
     #[arg(short = 'c', long, value_name = "PATH", env = "TVC_DEPLOY_CONFIG")]
     pub config_file: Option<PathBuf>,
+
+    /// Path to an unencrypted pivot container pull secret file.
+    ///
+    /// The content will be encrypted based on the active org's API environment and
+    /// override `pivotContainerEncryptedPullSecret` from the config file.
+    #[arg(long, value_name = "PATH", env = "TVC_PIVOT_PULL_SECRET")]
+    pub pivot_pull_secret: Option<PathBuf>,
+
+    #[command(flatten)]
+    overrides: Overrides,
+}
+
+#[derive(Debug, ClapArgs)]
+#[cfg_attr(test, derive(Default))]
+struct Overrides {
+    /// Deploy in debug mode, which forwards secure enclave logs to the host and
+    /// zeroes attestation PCRs. This defeats the purpose of a secure enclave,
+    /// so it should only be used to debug non-prod applications and view application
+    /// logs.
+    ///
+    /// # WARNING
+    ///
+    /// Only valid for apps created with `--dangerous-enable-debug-mode-deployments`.
+    /// Debug-mode deployments permanently mark the app's quorum key as insecure;
+    /// to return to a secure posture, create a new app with a fresh quorum key.
+    #[arg(long, env = "TVC_DANGEROUS_DEPLOY_DEBUG_MODE")]
+    pub dangerous_deploy_debug_mode: bool,
 
     /// Override the appId field.
     #[arg(long, env = "TVC_APP_ID")]
@@ -101,26 +130,192 @@ pub struct Args {
     /// Override the publicIngressPort field.
     #[arg(long, env = "TVC_PUBLIC_INGRESS_PORT")]
     pub public_ingress_port: Option<u16>,
+}
 
-    /// Path to an unencrypted pivot container pull secret file.
-    ///
-    /// The content will be encrypted based on the active org's API environment and
-    /// override `pivotContainerEncryptedPullSecret` from the config file.
-    #[arg(long, value_name = "PATH", env = "TVC_PIVOT_PULL_SECRET")]
-    pub pivot_pull_secret: Option<PathBuf>,
+struct ResolvedDeployInputs {
+    config_path: Option<PathBuf>,
+    config: DeployConfig,
+    pivot_pull_secret: Option<String>,
+}
 
-    /// Deploy in debug mode, which forwards secure enclave logs to the host and
-    /// zeroes attestation PCRs. This defeats the purpose of a secure enclave,
-    /// so it should only be used to debug non-prod applications and view application
-    /// logs.
-    ///
-    /// # WARNING
-    ///
-    /// Only valid for apps created with `--dangerous-enable-debug-mode-deployments`.
-    /// Debug-mode deployments permanently mark the app's quorum key as insecure;
-    /// to return to a secure posture, create a new app with a fresh quorum key.
-    #[arg(long, env = "TVC_DANGEROUS_DEPLOY_DEBUG_MODE")]
-    pub dangerous_deploy_debug_mode: bool,
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
+    let inputs = if is_non_interactive {
+        build_inputs_non_interactive(args).await?
+    } else {
+        build_inputs_interactive(args).await?
+    };
+
+    run_with_resolved_inputs(inputs).await
+}
+
+async fn build_inputs_interactive(args: Args) -> Result<ResolvedDeployInputs> {
+    let Args {
+        config_file: config_path,
+        pivot_pull_secret,
+        overrides,
+    } = args;
+    let (mut config, file_loaded) = read_config_file_bytes(config_path.as_deref())
+        .await?
+        .map(|(path, contents)| {
+            serde_json::from_str(&contents)
+                .with_context(|| format!("failed to parse config file: {}", path.display()))
+        })
+        .transpose()?
+        .map(|config| (config, true))
+        .unwrap_or_else(|| (flag_only_template(), false));
+
+    apply_overrides(&mut config, &overrides);
+
+    let mut config_updated = false;
+    loop {
+        match config.validate() {
+            Ok(()) => break,
+            Err(errors) if errors.has_non_placeholder_error() => {
+                return Err(invalid_deploy_config_error(errors));
+            }
+            _ => {
+                config_updated = true;
+                let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
+                config.fill_interactively(saved_app_id.as_deref())?;
+            }
+        }
+    }
+
+    if config_updated {
+        if let Some(path) = &config_path {
+            offer_to_save_config(path, &config, file_loaded)?;
+        }
+    }
+    let pivot_pull_secret = read_pivot_pull_secret(pivot_pull_secret.as_deref()).await?;
+
+    Ok(ResolvedDeployInputs {
+        config_path,
+        config,
+        pivot_pull_secret,
+    })
+}
+
+async fn build_inputs_non_interactive(args: Args) -> Result<ResolvedDeployInputs> {
+    let Args {
+        config_file: config_path,
+        pivot_pull_secret,
+        overrides,
+    } = args;
+
+    let (file, pivot_pull_secret) = try_join!(
+        read_config_file_bytes(config_path.as_deref()),
+        read_pivot_pull_secret(pivot_pull_secret.as_deref())
+    )?;
+
+    let mut config = match file {
+        Some((path, bytes)) => serde_json::from_str(&bytes)
+            .with_context(|| format!("failed to parse config file: {}", path.display()))?,
+        _ => flag_only_template(),
+    };
+
+    apply_overrides(&mut config, &overrides);
+
+    if let Err(errors) = config.validate() {
+        return Err(invalid_deploy_config_error(errors));
+    }
+
+    Ok(ResolvedDeployInputs {
+        config_path,
+        config,
+        pivot_pull_secret,
+    })
+}
+
+async fn read_config_file_bytes(path: Option<&Path>) -> Result<Option<(&Path, String)>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+
+    tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read config file: {}", path.display()))
+        .map(|contents| (path, contents))
+        .map(Into::into)
+}
+
+async fn read_pivot_pull_secret(path: Option<&Path>) -> Result<Option<String>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+
+    let pull_secret = tokio::fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read pivot pull secret file: {}", path.display()))?;
+
+    if pull_secret.trim().is_empty() {
+        bail!(
+            "pivot pull secret file is empty after trimming whitespace: {}",
+            path.display()
+        );
+    }
+
+    Ok(pull_secret.into())
+}
+
+fn flag_only_template() -> DeployConfig {
+    let mut template = DeployConfig::template(None);
+    // Strip the template's "<REMOVE_ME...>" hint so flag-only mode doesn't ship
+    // it to the API for public images.
+    template.pivot_container_encrypted_pull_secret = None;
+    template
+}
+
+fn apply_overrides(config: &mut DeployConfig, overrides: &Overrides) {
+    if let Some(v) = &overrides.app_id {
+        config.app_id = v.clone();
+    }
+    if let Some(v) = &overrides.qos_version {
+        config.qos_version = v.clone();
+    }
+    if let Some(v) = &overrides.pivot_image_url {
+        config.pivot_container_image_url = v.clone();
+    }
+    if let Some(v) = &overrides.expected_pivot_digest {
+        config.expected_pivot_digest = v.clone();
+    }
+    if let Some(v) = &overrides.pivot_path {
+        config.pivot_path = v.clone();
+    }
+    if !overrides.pivot_args.is_empty() {
+        config.pivot_args = overrides.pivot_args.clone();
+    }
+    // One-way: only ever flips false -> true.
+    if overrides.dangerous_deploy_debug_mode {
+        config.dangerous_deploy_debug_mode = true;
+    }
+    if let Some(v) = overrides.health_check_port {
+        config.health_check_port = v;
+    }
+    if let Some(v) = overrides.public_ingress_port {
+        config.public_ingress_port = v;
+    }
+}
+
+fn invalid_deploy_config_error(errors: DeployConfigValidationErrors) -> anyhow::Error {
+    anyhow!("invalid deploy config: {}", errors)
+}
+
+/// Ask the user whether to write the updated config back to disk.
+/// `file_loaded` distinguishes "saving over an existing file" from
+/// "creating a new file at this path" in the prompt wording.
+fn offer_to_save_config(path: &Path, config: &DeployConfig, file_loaded: bool) -> Result<()> {
+    let prompt = if file_loaded {
+        format!("Save filled config to {}?", path.display())
+    } else {
+        format!("Write a new config file at {}?", path.display())
+    };
+    if prompts::confirm(&prompt, true)? {
+        let json = serde_json::to_string_pretty(config).context("failed to serialize config")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write config file: {}", path.display()))?;
+        println!("Wrote {}", path.display());
+    }
+    Ok(())
 }
 
 fn build_validate_image_request(
@@ -164,157 +359,15 @@ fn pin_image_url(image_url: &str, resolved_digest: &str) -> String {
     }
 }
 
-fn apply_overrides(config: &mut DeployConfig, args: &Args) {
-    if let Some(v) = &args.app_id {
-        config.app_id = v.clone();
-    }
-    if let Some(v) = &args.qos_version {
-        config.qos_version = v.clone();
-    }
-    if let Some(v) = &args.pivot_image_url {
-        config.pivot_container_image_url = v.clone();
-    }
-    if let Some(v) = &args.expected_pivot_digest {
-        config.expected_pivot_digest = v.clone();
-    }
-    if let Some(v) = &args.pivot_path {
-        config.pivot_path = v.clone();
-    }
-    if !args.pivot_args.is_empty() {
-        config.pivot_args = args.pivot_args.clone();
-    }
-    if args.dangerous_deploy_debug_mode {
-        config.dangerous_deploy_debug_mode = args.dangerous_deploy_debug_mode;
-    }
-    if let Some(v) = args.health_check_port {
-        config.health_check_port = v;
-    }
-    if let Some(v) = args.public_ingress_port {
-        config.public_ingress_port = v;
-    }
-}
-
-/// Read a config from the given path, returning the parsed [`DeployConfig`] and
-/// a flag indicating whether the file existed (interactive flow may treat
-/// missing files as "start from template" when --config-file was provided).
-fn read_config_file(path: &Path) -> Result<Option<DeployConfig>> {
-    match std::fs::read_to_string(path) {
-        Ok(content) => {
-            let config: DeployConfig = serde_json::from_str(&content)
-                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
-            Ok(Some(config))
-        }
-        Err(_) if prompts::is_interactive() => Ok(None),
-        Err(e) => Err(anyhow!(e))
-            .with_context(|| format!("failed to read config file: {}", path.display())),
-    }
-}
-
-async fn resolve_deploy_config(args: &Args) -> Result<DeployConfig> {
-    let (mut config, file_loaded) = match &args.config_file {
-        Some(path) => match read_config_file(path)? {
-            Some(c) => (c, true),
-            None => (DeployConfig::template(None), false),
-        },
-        None => {
-            let mut t = DeployConfig::template(None);
-            // Strip the template's "<REMOVE_ME...>" hint so flag-only mode
-            // doesn't ship it to the API for public images.
-            t.pivot_container_encrypted_pull_secret = None;
-            (t, false)
-        }
-    };
-
-    apply_overrides(&mut config, args);
-
-    let config_updated = resolve_placeholders(&mut config, args).await?;
-    if config_updated {
-        if let Some(path) = &args.config_file {
-            offer_to_save_config(path, &config, file_loaded)?;
-        }
-    }
-    Ok(config)
-}
-
-/// Address any remaining placeholders in `config`. Returns `true` iff the
-/// resolution required walking interactive prompts
-async fn resolve_placeholders(config: &mut DeployConfig, args: &Args) -> Result<bool> {
-    if !config.has_placeholders() {
-        return Ok(false);
-    }
-    if !is_interactive() {
-        let missing = config.missing_required_fields();
-        if !missing.is_empty() {
-            let suggestion = if args.config_file.is_some() {
-                "Edit the config file or override via flag/TVC_* env."
-            } else {
-                "Provide via flag, TVC_* env, or --config-file."
-            };
-            bail!(
-                "missing required values: {}. {suggestion}",
-                missing.join(", ")
-            );
-        }
-
-        if config.pull_secret_is_placeholder() {
-            bail!(
-                "pivotContainerEncryptedPullSecret is placeholder. Set the field to null in the config file (public image), or pass --pivot-pull-secret <PATH> (private image)."
-            )
-        }
-        return Ok(false);
-    }
-
-    let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
-    config.fill_interactively(saved_app_id.as_deref())?;
-
-    Ok(true)
-}
-
-/// Ask the user whether to write the updated config back to disk.
-/// `file_loaded` distinguishes "saving over an existing file" from
-/// "creating a new file at this path" in the prompt wording.
-fn offer_to_save_config(path: &Path, config: &DeployConfig, file_loaded: bool) -> Result<()> {
-    if !is_interactive() {
-        return Ok(());
-    }
-    let prompt = if file_loaded {
-        format!("Save filled config to {}?", path.display())
-    } else {
-        format!("Write a new config file at {}?", path.display())
-    };
-    if prompts::confirm(&prompt, true)? {
-        let json = serde_json::to_string_pretty(config).context("failed to serialize config")?;
-        std::fs::write(path, json)
-            .with_context(|| format!("failed to write config file: {}", path.display()))?;
-        println!("Wrote {}", path.display());
-    }
-    Ok(())
-}
-
-/// Run the deploy create command.
-pub async fn run(args: Args) -> Result<()> {
-    let deploy_config = resolve_deploy_config(&args).await?;
+async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
+    let deploy_config = inputs.config;
 
     println!("Creating deployment for app '{}'...", deploy_config.app_id);
 
-    // Build authenticated client
     let auth = build_client().await?;
 
-    let pivot_container_encrypted_pull_secret = match args.pivot_pull_secret.as_ref() {
-        Some(path) => {
-            let pull_secret = std::fs::read_to_string(path).with_context(|| {
-                format!("failed to read pivot pull secret file: {}", path.display())
-            })?;
-
-            if pull_secret.trim().is_empty() {
-                bail!(
-                    "pivot pull secret file is empty after trimming whitespace: {}",
-                    path.display()
-                );
-            }
-
-            Some(encrypt_pivot_pull_secret(&pull_secret, &auth.api_base_url)?)
-        }
+    let pivot_container_encrypted_pull_secret = match inputs.pivot_pull_secret.as_ref() {
+        Some(pull_secret) => Some(encrypt_pivot_pull_secret(pull_secret, &auth.api_base_url)?),
         None => deploy_config.pivot_container_encrypted_pull_secret.clone(),
     };
 
@@ -345,13 +398,11 @@ pub async fn run(args: Args) -> Result<()> {
         pivot_container_encrypted_pull_secret,
     );
 
-    // Get timestamp
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system time before unix epoch")?
         .as_millis();
 
-    // Create the deployment
     let result = auth
         .client
         .create_tvc_deployment(auth.org_id, timestamp_ms, intent)
@@ -363,7 +414,7 @@ pub async fn run(args: Args) -> Result<()> {
     println!();
     println!("Deployment ID: {}", result.result.deployment_id);
     println!("App ID: {}", deploy_config.app_id);
-    if let Some(path) = &args.config_file {
+    if let Some(path) = &inputs.config_path {
         println!("Config: {}", path.display());
     }
     println!();
@@ -398,30 +449,19 @@ mod tests {
         assert_eq!(pinned, "ghcr.io/team/app@sha256:abc123");
     }
 
-    fn empty_args() -> Args {
-        Args {
-            config_file: None,
-            app_id: None,
-            qos_version: None,
-            pivot_image_url: None,
-            expected_pivot_digest: None,
-            pivot_path: None,
-            pivot_args: vec![],
-            health_check_port: None,
-            public_ingress_port: None,
-            pivot_pull_secret: None,
-            dangerous_deploy_debug_mode: false,
-        }
-    }
-
     fn all_required_flags() -> Args {
-        Args {
+        let overrides = Overrides {
             app_id: Some("flag-app-id".into()),
             qos_version: Some("flag-qos".into()),
             pivot_image_url: Some("flag-image".into()),
             expected_pivot_digest: Some("flag-digest".into()),
             pivot_path: Some("flag-path".into()),
-            ..empty_args()
+            ..Default::default()
+        };
+
+        Args {
+            overrides,
+            ..Default::default()
         }
     }
 
@@ -447,24 +487,40 @@ mod tests {
         f
     }
 
-    // Resolution tests run inside the tokio runtime since resolve_deploy_config
-    // now reaches into Config::load(). They're wired to call .block_on() via
-    // a small helper.
+    /// Mirror the non-interactive resolution pipeline (read bytes → parse →
+    /// apply overrides → validate) so the existing flag/env/config-file
+    /// composition tests still have a single helper to call.
     fn run_resolve(args: &Args) -> Result<DeployConfig> {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap()
-            .block_on(resolve_deploy_config(args))
+            .block_on(async {
+                let mut config = match read_config_file_bytes(args.config_file.as_deref()).await? {
+                    Some((path, bytes)) => serde_json::from_str(&bytes).with_context(|| {
+                        format!("failed to parse config file: {}", path.display())
+                    })?,
+                    None => flag_only_template(),
+                };
+                apply_overrides(&mut config, &args.overrides);
+                if let Err(errors) = config.validate() {
+                    return Err(invalid_deploy_config_error(errors));
+                }
+                anyhow::Ok(config)
+            })
     }
 
     #[test]
     fn flag_overrides_file_value() {
         let file = write_config(&file_config());
+        let overrides = Overrides {
+            app_id: Some("flag-app-id".into()),
+            ..Default::default()
+        };
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
-            app_id: Some("flag-app-id".into()),
-            ..empty_args()
+            overrides,
+            ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.app_id, "flag-app-id");
@@ -478,7 +534,7 @@ mod tests {
         let file = write_config(&file_config());
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
-            ..empty_args()
+            ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.app_id, "file-app-id");
@@ -505,12 +561,27 @@ mod tests {
     }
 
     #[test]
+    fn no_file_no_required_flags_bails_naming_each_field() {
+        let err = run_resolve(&Default::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("app_id"), "{msg}");
+        assert!(msg.contains("qos_version"), "{msg}");
+        assert!(msg.contains("pivot_container_image_url"), "{msg}");
+        assert!(msg.contains("pivot_path"), "{msg}");
+        assert!(msg.contains("expected_pivot_digest"), "{msg}");
+    }
+
+    #[test]
     fn pivot_args_flag_replaces_file_list() {
         let file = write_config(&file_config()); // file has ["a", "b"]
+        let overrides = Overrides {
+            pivot_args: vec!["c".into()],
+            ..Default::default()
+        };
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
-            pivot_args: vec!["c".into()],
-            ..empty_args()
+            overrides,
+            ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.pivot_args, vec!["c"]);
@@ -521,10 +592,14 @@ mod tests {
     #[test]
     fn dangerous_debug_mode_flag_enables_debug_mode() {
         let file = write_config(&file_config()); // file has dangerous_deploy_debug_mode = false
+        let overrides = Overrides {
+            dangerous_deploy_debug_mode: true,
+            ..Default::default()
+        };
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
-            dangerous_deploy_debug_mode: true,
-            ..empty_args()
+            overrides,
+            ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
         assert!(resolved.dangerous_deploy_debug_mode);
@@ -538,13 +613,43 @@ mod tests {
         let mut cfg = file_config();
         cfg.dangerous_deploy_debug_mode = true;
         let file = write_config(&cfg);
+        let overrides = Overrides {
+            dangerous_deploy_debug_mode: false,
+            ..Default::default()
+        };
         let args = Args {
             config_file: Some(file.path().to_path_buf()),
-            dangerous_deploy_debug_mode: false,
-            ..empty_args()
+            overrides,
+            ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
         assert!(resolved.dangerous_deploy_debug_mode);
+    }
+
+    /// All required fields are filled but the pull-secret sentinel is still
+    /// present. In non-interactive mode we can't prompt the user about it, so
+    /// the resolve bails rather than silently mutating the config or shipping
+    /// the sentinel to the API.
+    #[test]
+    fn pull_secret_placeholder_bails_when_non_interactive() {
+        let mut cfg = file_config();
+        cfg.pivot_container_encrypted_pull_secret =
+            Some("<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>".to_string());
+        let file = write_config(&cfg);
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let err = run_resolve(&args).unwrap_err().to_string();
+        assert!(
+            err.contains("pivotContainerEncryptedPullSecret"),
+            "error should name the offending field: {err}"
+        );
+        assert!(
+            err.contains("--pivot-pull-secret"),
+            "error should point the user at the resolution flag: {err}"
+        );
     }
 
     /// The intent builder wraps the resolved config's dangerous_deploy_debug_mode
@@ -555,5 +660,111 @@ mod tests {
         cfg.dangerous_deploy_debug_mode = true;
         let intent = build_create_intent(&cfg, "image-url".to_string(), None);
         assert_eq!(intent.debug_mode, Some(true));
+    }
+
+    /// Exercises every override flag via clap parsing so flag renames or
+    /// removals fail this test. The other override tests construct `Args` by
+    /// field name and would silently pass.
+    #[test]
+    fn every_override_flag_changes_template_value() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            args: Args,
+        }
+
+        let pull_secret_path = "/tmp/test-pull-secret";
+        let args = TestCli::try_parse_from([
+            "tvc-deploy-create",
+            "--app-id",
+            "test-app",
+            "--qos-version",
+            "test-qos",
+            "--pivot-image-url",
+            "test-image",
+            "--expected-pivot-digest",
+            "sha256:test",
+            "--pivot-path",
+            "/usr/bin/pivot",
+            "--pivot-args",
+            "arg1,arg2",
+            "--health-check-port",
+            "8080",
+            "--public-ingress-port",
+            "9090",
+            "--pivot-pull-secret",
+            pull_secret_path,
+            "--dangerous-deploy-debug-mode",
+        ])
+        .unwrap()
+        .args;
+
+        let template = flag_only_template();
+        let mut resolved = flag_only_template();
+        apply_overrides(&mut resolved, &args.overrides);
+
+        // Each override moved off its template default ...
+        assert_ne!(resolved.app_id, template.app_id);
+        assert_ne!(resolved.qos_version, template.qos_version);
+        assert_ne!(
+            resolved.pivot_container_image_url,
+            template.pivot_container_image_url
+        );
+        assert_ne!(
+            resolved.expected_pivot_digest,
+            template.expected_pivot_digest
+        );
+        assert_ne!(resolved.pivot_path, template.pivot_path);
+        assert_ne!(resolved.pivot_args, template.pivot_args);
+        assert_ne!(resolved.health_check_port, template.health_check_port);
+        assert_ne!(resolved.public_ingress_port, template.public_ingress_port);
+        assert_ne!(
+            resolved.dangerous_deploy_debug_mode,
+            template.dangerous_deploy_debug_mode
+        );
+
+        // ... to the value passed on the CLI.
+        assert_eq!(resolved.app_id, "test-app");
+        assert_eq!(resolved.qos_version, "test-qos");
+        assert_eq!(resolved.pivot_container_image_url, "test-image");
+        assert_eq!(resolved.expected_pivot_digest, "sha256:test");
+        assert_eq!(resolved.pivot_path, "/usr/bin/pivot");
+        assert_eq!(resolved.pivot_args, vec!["arg1", "arg2"]);
+        assert_eq!(resolved.health_check_port, 8080);
+        assert_eq!(resolved.public_ingress_port, 9090);
+        assert!(resolved.dangerous_deploy_debug_mode);
+
+        // pivot_pull_secret isn't part of apply_overrides; verify clap captured the path.
+        assert_eq!(
+            args.pivot_pull_secret.as_deref(),
+            Some(Path::new(pull_secret_path))
+        );
+    }
+
+    #[test]
+    fn non_interactive_overrides_can_complete_placeholder_file_without_prompting_to_save() {
+        let mut cfg = DeployConfig::template(None);
+        cfg.pivot_container_encrypted_pull_secret = None;
+        let file = write_config(&cfg);
+        let args = Args {
+            config_file: Some(file.path().to_path_buf()),
+            ..all_required_flags()
+        };
+
+        let resolved = run_resolve(&args).unwrap();
+        assert_eq!(resolved.app_id, "flag-app-id");
+        assert_eq!(resolved.qos_version, "flag-qos");
+        assert_eq!(resolved.pivot_container_image_url, "flag-image");
+        assert_eq!(resolved.pivot_path, "flag-path");
+        assert_eq!(resolved.expected_pivot_digest, "flag-digest");
+
+        let persisted: DeployConfig =
+            serde_json::from_str(&std::fs::read_to_string(file.path()).unwrap()).unwrap();
+        assert!(
+            persisted.has_placeholders(),
+            "non-interactive resolution must not offer to save or mutate config files"
+        );
     }
 }

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -2,7 +2,7 @@
 
 use crate::config::deploy::DeployConfig;
 use crate::config::turnkey;
-use crate::prompts;
+use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
 use anyhow::{Context, Result, bail};
 use chrono::Local;
 use clap::Args as ClapArgs;
@@ -23,14 +23,18 @@ pub struct Args {
 }
 
 /// Run the deploy init command.
-pub async fn run(args: Args) -> Result<()> {
-    if args.interactive && prompts::non_interactive_forced() {
-        bail!(
-            "--interactive conflicts with {}=1",
-            prompts::NON_INTERACTIVE_ENV
-        );
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
+    if args.interactive {
+        if is_non_interactive {
+            bail_interactive_conflicts_with_non_interactive()?;
+        } else {
+            ensure_stdin_is_tty()?;
+        }
     }
+    execute(args).await
+}
 
+async fn execute(args: Args) -> Result<()> {
     // Generate output filename with timestamp if not provided
     let output = args.output.unwrap_or_else(|| {
         let timestamp = Local::now().format("%Y-%m-%d-%H%M%S");
@@ -43,8 +47,10 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     // Try to get the last created app ID
-    let config = turnkey::Config::load().await?;
-    let last_app_id = config.get_last_app_id();
+    let last_app_id = turnkey::Config::load()
+        .await
+        .ok()
+        .and_then(|config| config.get_last_app_id());
 
     // Generate template (optionally walking prompts to fill it in)
     let mut config = DeployConfig::template(last_app_id.as_deref());

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -3,7 +3,7 @@
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, OrgConfig, StoredApiKey, StoredQosOperatorKey,
 };
-use crate::prompts;
+use crate::prompts::{self, error_required_in_non_interactive};
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
@@ -25,109 +25,136 @@ pub struct Args {
     pub api_base_url: Option<String>,
 }
 
-/// Run the login command.
-pub async fn run(args: Args) -> anyhow::Result<()> {
+enum OrgPlan {
+    Existing(String),
+    New { id: String, alias: String },
+}
+
+enum ApiKeyPolicy {
+    AllowGenerate,
+    RequireExisting,
+}
+
+struct LoginPlan {
+    org: OrgPlan,
+    api_base_url_override: Option<String>,
+    api_key_policy: ApiKeyPolicy,
+}
+
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
     debug!(
+        non_interactive = is_non_interactive,
         org_arg_present = args.org.is_some(),
         api_base_url_override_present = args.api_base_url.is_some(),
         "running login command"
     );
 
-    // Load existing config
-    let mut config = Config::load().await?;
+    let config = Config::load().await?;
 
-    // Select or create org
-    let (alias, org_config) = select_or_create_org(
-        &mut config,
-        args.org.as_deref(),
-        args.api_base_url.as_deref(),
-    )
-    .await?;
+    let plan = if is_non_interactive {
+        build_login_plan_non_interactive(args)?
+    } else {
+        build_login_plan_interactive(args, &config)?
+    };
+
+    execute_login(config, plan).await
+}
+
+fn build_login_plan_interactive(args: Args, config: &Config) -> Result<LoginPlan> {
+    let org = match args.org {
+        Some(query) => OrgPlan::Existing(query),
+        None => prompt_for_org_plan(config)?,
+    };
+    Ok(LoginPlan {
+        org,
+        api_base_url_override: args.api_base_url,
+        api_key_policy: ApiKeyPolicy::AllowGenerate,
+    })
+}
+
+fn build_login_plan_non_interactive(args: Args) -> Result<LoginPlan> {
+    let Some(org_query) = args.org else {
+        return Err(error_required_in_non_interactive("--org"));
+    };
+
+    Ok(LoginPlan {
+        org: OrgPlan::Existing(org_query),
+        api_base_url_override: args.api_base_url,
+        api_key_policy: ApiKeyPolicy::RequireExisting,
+    })
+}
+
+async fn execute_login(mut config: Config, plan: LoginPlan) -> Result<()> {
+    let (alias, org_config) = match plan.org {
+        OrgPlan::Existing(query) => {
+            let alias = match find_org(&config, &query) {
+                Some((alias, _)) => alias.clone(),
+                None => bail!(
+                    "Organization '{query}' not found. \
+                     Run `tvc login` without --org to set up a new organization."
+                ),
+            };
+            update_api_base_url_from_override(
+                &mut config,
+                &alias,
+                plan.api_base_url_override.as_deref(),
+            );
+            let org_config = config.orgs.get(&alias).unwrap().clone();
+            (alias, org_config)
+        }
+        OrgPlan::New { id, alias } => {
+            let api_base_url = new_org_api_base_url(plan.api_base_url_override.as_deref());
+            generate_org(&mut config, id, alias, api_base_url)?
+        }
+    };
 
     println!("Selected org: {} ({})", alias, org_config.id);
 
-    // Save config with the new/updated org
     config.set_active_org(&alias)?;
     config.save().await?;
 
-    // Get or generate API key
-    let api_key = get_or_generate_api_key(&org_config).await?;
+    let api_key = match StoredApiKey::load(&org_config).await? {
+        Some(api_key) => {
+            debug!("using existing API key");
+            println!("Using existing API key.");
+            api_key
+        }
+        None => match plan.api_key_policy {
+            ApiKeyPolicy::AllowGenerate => {
+                let api_key = generate_api_key(&org_config).await?;
+                wait_for_dashboard_registration()?;
+                api_key
+            }
+            ApiKeyPolicy::RequireExisting => bail!(
+                "API key is required in non-interactive mode for org '{}'. \
+                 Run `tvc login` interactively to generate and register one first.",
+                org_config.id
+            ),
+        },
+    };
 
-    // Verify credentials with whoami
     println!();
     println!("Verifying credentials...");
 
     let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url).await?;
+    let operator_key = find_or_generate_operator_key(&org_config).await?;
 
-    // Get or generate operator key
-    let operator_key = get_or_generate_operator_key(&org_config).await?;
-
-    println!();
-    println!("Successfully logged in!");
-    println!();
-    println!(
-        "Organization: {} ({})",
-        whoami.organization_name, whoami.organization_id
-    );
-    println!("User: {} ({})", whoami.username, whoami.user_id);
-    println!("Active Org: {alias}");
-    println!("API Key: {}", api_key.public_key);
-    println!("Operator Key: {}", operator_key.public_key);
-    println!();
-    println!(
-        "Config: {}",
-        crate::config::turnkey::config_file_path()?.display()
-    );
-    println!("API Key: {}", org_config.api_key_path.display());
-    println!("Operator Key: {}", org_config.operator_key_path.display());
-
-    Ok(())
+    print_success(&alias, &org_config, &api_key, &operator_key, &whoami)
 }
 
-/// Select an existing org or create a new one.
-/// Returns the alias and a clone of the org config.
-async fn select_or_create_org(
-    config: &mut Config,
-    org_arg: Option<&str>,
-    api_base_url_override: Option<&str>,
-) -> Result<(String, OrgConfig)> {
+fn prompt_for_org_plan(config: &Config) -> Result<OrgPlan> {
     debug!(
-        org_arg_present = org_arg.is_some(),
-        api_base_url_override_present = api_base_url_override.is_some(),
         configured_org_count = config.orgs.len(),
         active_org = ?config.active_org,
-        "selecting organization"
+        "prompting for organization plan"
     );
 
-    // If --org provided, try to find it by alias or ID
-    if let Some(org) = org_arg {
-        if let Some((alias, _)) = find_org(config, org) {
-            let alias = alias.clone();
-            debug!(org_alias = %alias, "selected existing organization from argument");
-            update_api_base_url_from_override(config, &alias, api_base_url_override);
-            let org_config = config.orgs.get(&alias).unwrap().clone();
-            return Ok((alias, org_config));
-        }
-        debug!("organization argument did not match configured organizations");
-        bail!(
-            "Organization '{org}' not found. Run `tvc login` without --org to set up a new organization."
-        );
-    }
-
-    // No --org provided — we'd need to prompt. Honor explicit opt-out.
-    prompts::bail_if_non_interactive("--org")?;
-
-    // No --org provided, check existing orgs
-    let org_count = config.orgs.len();
-
-    if org_count == 0 {
-        // No orgs configured - prompt for new org
+    if config.orgs.is_empty() {
         debug!("no organizations configured; prompting for new organization");
         println!("No organization configured.");
-        return prompt_for_new_org(config, api_base_url_override).await;
+        return prompt_for_new_org_inputs();
     }
 
-    // Show existing orgs in a `Select` list
     let mut options: Vec<OrgChoice> = config
         .orgs
         .iter()
@@ -146,16 +173,26 @@ async fn select_or_create_org(
     options.push(OrgChoice::New);
 
     match prompts::select("Select organization", options)? {
-        OrgChoice::Existing { alias, .. } => {
-            update_api_base_url_from_override(config, &alias, api_base_url_override);
-            let org_config = config.orgs.get(&alias).unwrap().clone();
-            Ok((alias, org_config))
-        }
-        OrgChoice::New => prompt_for_new_org(config, api_base_url_override).await,
+        OrgChoice::Existing { alias, .. } => Ok(OrgPlan::Existing(alias)),
+        OrgChoice::New => prompt_for_new_org_inputs(),
     }
 }
 
-/// Choices rendered by the org-selection `Select` widget.
+fn prompt_for_new_org_inputs() -> Result<OrgPlan> {
+    println!("You can find your Organization ID at: https://app.turnkey.com/dashboard/welcome");
+    println!();
+
+    let id = prompts::text("Organization ID", None)?;
+    if id.is_empty() {
+        bail!("Organization ID is required");
+    }
+
+    let alias = prompts::text("Organization alias", Some("default"))?;
+    debug!(org_alias = %alias, "user entered new organization inputs");
+
+    Ok(OrgPlan::New { id, alias })
+}
+
 enum OrgChoice {
     Existing { display: String, alias: String },
     New,
@@ -170,28 +207,28 @@ impl std::fmt::Display for OrgChoice {
     }
 }
 
-/// Prompt the user to enter a new organization ID and alias.
-async fn prompt_for_new_org(
-    config: &mut Config,
-    api_base_url_override: Option<&str>,
-) -> Result<(String, OrgConfig)> {
-    debug!("prompting for new organization");
-
-    println!("You can find your Organization ID at: https://app.turnkey.com/dashboard/welcome");
-    println!();
-
-    let org_id = prompts::text("Organization ID", None)?;
-    if org_id.is_empty() {
-        bail!("Organization ID is required");
+fn find_org<'a>(config: &'a Config, org: &str) -> Option<(&'a String, &'a OrgConfig)> {
+    if let Some((alias, org_config)) = config.orgs.get_key_value(org) {
+        return Some((alias, org_config));
     }
 
-    let alias = prompts::text("Organization alias", Some("default"))?;
-    debug!(org_alias = %alias, "user selected organization");
+    for (alias, org_config) in &config.orgs {
+        if org_config.id == org {
+            return Some((alias, org_config));
+        }
+    }
 
-    let api_base_url = new_org_api_base_url(api_base_url_override);
-    debug!(org_alias = %alias, %api_base_url, "adding prompted organization");
+    None
+}
 
-    config.add_org(&alias, org_id, api_base_url)?;
+fn generate_org(
+    config: &mut Config,
+    id: String,
+    alias: String,
+    api_base_url: String,
+) -> Result<(String, OrgConfig)> {
+    debug!(org_alias = %alias, %api_base_url, "adding organization");
+    config.add_org(&alias, id, api_base_url)?;
     let org_config = config.orgs.get(&alias).unwrap().clone();
     Ok((alias, org_config))
 }
@@ -215,20 +252,7 @@ fn update_api_base_url_from_override(
     }
 }
 
-/// Get an existing API key or generate a new one.
-/// If an API key exists, it's returned directly.
-/// If not, a new key is generated, saved, and the user is prompted to add it to the dashboard.
-async fn get_or_generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
-    debug!(api_key_path = %org_config.api_key_path.display(), "resolving API key");
-
-    // Check if API key already exists
-    if let Some(api_key) = StoredApiKey::load(org_config).await? {
-        debug!("using existing API key");
-        println!("Using existing API key.");
-        return Ok(api_key);
-    }
-
-    // Generate new API key
+async fn generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
     debug!("generating new API key");
     println!();
     println!("Generating API key...");
@@ -243,10 +267,8 @@ async fn get_or_generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey>
         curve: KeyCurve::P256,
     };
 
-    // Save the key
     api_key.save(org_config).await?;
 
-    // Display instructions
     println!();
     println!("API Key Generated!");
     println!();
@@ -258,23 +280,27 @@ async fn get_or_generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey>
     println!("  3. Paste the public key > Name it \"TVC CLI\" > Continue > Approve");
     println!();
 
-    wait_for_enter("Press Enter when done...")?;
-
     Ok(api_key)
 }
 
-/// Get an existing operator key or generate a new one.
-async fn get_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQosOperatorKey> {
+fn wait_for_dashboard_registration() -> Result<()> {
+    print!("Press Enter when done...");
+    std::io::stdout().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().lock().read_line(&mut input)?;
+    Ok(())
+}
+
+async fn find_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQosOperatorKey> {
     debug!(operator_key_path = %org_config.operator_key_path.display(), "resolving operator key");
 
-    // Check if operator key already exists
     if let Some(operator_key) = StoredQosOperatorKey::load(org_config).await? {
         debug!("using existing operator key");
         println!("Using existing operator key.");
         return Ok(operator_key);
     }
 
-    // Generate new operator key
     debug!("generating new operator key");
     println!();
     println!("Generating operator key...");
@@ -289,7 +315,6 @@ async fn get_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQo
         private_key,
     };
 
-    // Save the key
     operator_key.save(org_config).await?;
 
     println!();
@@ -303,41 +328,6 @@ async fn get_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQo
     Ok(operator_key)
 }
 
-/// Find an org by alias or by org ID.
-fn find_org<'a>(config: &'a Config, org: &str) -> Option<(&'a String, &'a OrgConfig)> {
-    // First try by alias
-    if let Some((alias, org_config)) = config.orgs.get_key_value(org) {
-        return Some((alias, org_config));
-    }
-
-    // Then try by org ID
-    for (alias, org_config) in &config.orgs {
-        if org_config.id == org {
-            return Some((alias, org_config));
-        }
-    }
-
-    None
-}
-
-/// Wait for the user to press Enter. Skips the blocking read when
-/// `TVC_NON_INTERACTIVE` is set so non-interactive callers don't stall after
-/// the dashboard-registration instructions.
-fn wait_for_enter(message: &str) -> Result<()> {
-    print!("{message}");
-    std::io::stdout().flush()?;
-
-    if prompts::non_interactive_forced() {
-        println!();
-        return Ok(());
-    }
-
-    let mut input = String::new();
-    std::io::stdin().lock().read_line(&mut input)?;
-    Ok(())
-}
-
-/// Result of a successful whoami verification.
 pub struct WhoamiResult {
     pub organization_name: String,
     pub organization_id: String,
@@ -345,8 +335,6 @@ pub struct WhoamiResult {
     pub user_id: String,
 }
 
-/// Verify credentials by calling the whoami endpoint.
-/// Returns Ok(WhoamiResult) if credentials are valid, Err otherwise.
 async fn verify_credentials(
     api_key: &StoredApiKey,
     org_id: &str,
@@ -354,18 +342,15 @@ async fn verify_credentials(
 ) -> Result<WhoamiResult> {
     debug!(%api_base_url, "verifying credentials with whoami");
 
-    // Build the API key stamper from stored keys
     let stamper = TurnkeyP256ApiKey::from_strings(&api_key.private_key, Some(&api_key.public_key))
         .context("failed to load API key")?;
 
-    // Build the client
     let client = turnkey_client::TurnkeyClient::builder()
         .api_key(stamper)
         .base_url(api_base_url)
         .build()
         .context("failed to build Turnkey client")?;
 
-    // Call whoami
     let request = GetWhoamiRequest {
         organization_id: org_id.to_string(),
     };
@@ -383,6 +368,35 @@ async fn verify_credentials(
         username: response.username,
         user_id: response.user_id,
     })
+}
+
+fn print_success(
+    alias: &str,
+    org_config: &OrgConfig,
+    api_key: &StoredApiKey,
+    operator_key: &StoredQosOperatorKey,
+    whoami: &WhoamiResult,
+) -> Result<()> {
+    println!();
+    println!("Successfully logged in!");
+    println!();
+    println!(
+        "Organization: {} ({})",
+        whoami.organization_name, whoami.organization_id
+    );
+    println!("User: {} ({})", whoami.username, whoami.user_id);
+    println!("Active Org: {alias}");
+    println!("API Key: {}", api_key.public_key);
+    println!("Operator Key: {}", operator_key.public_key);
+    println!();
+    println!(
+        "Config: {}",
+        crate::config::turnkey::config_file_path()?.display()
+    );
+    println!("API Key: {}", org_config.api_key_path.display());
+    println!("Operator Key: {}", org_config.operator_key_path.display());
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -1,8 +1,11 @@
 //! App configuration file format for `tvc app create`.
 
+use std::fmt::Display;
+
 use crate::prompts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
 
@@ -155,32 +158,57 @@ impl AppConfig {
             })
     }
 
-    pub fn validate(&self) -> anyhow::Result<()> {
-        if self.has_placeholders() {
-            anyhow::bail!("config contains placeholder values (<FILL_IN_...)");
+    pub fn validate(&self) -> Result<(), AppConfigValidationErrors> {
+        let mut errors = Vec::new();
+
+        if self.name.starts_with("<FILL_IN") {
+            errors.push(AppConfigValidationError::Placeholder {
+                field: "name",
+                placeholder: self.name.clone(),
+            });
         }
 
-        if self.manifest_set_id.is_some() && self.manifest_set_params.is_some() {
-            anyhow::bail!("Cannot specify both manifestSetId and manifestSetParams");
+        if let Some(params) = &self.manifest_set_params {
+            collect_operator_set_placeholder_errors("manifestSetParams", params, &mut errors);
         }
-        if self.manifest_set_id.is_none() && self.manifest_set_params.is_none() {
-            anyhow::bail!("Must specify either manifestSetId or manifestSetParams");
-        }
-        if self.share_set_id.is_some() && self.share_set_params.is_some() {
-            anyhow::bail!("Cannot specify both shareSetId and shareSetParams");
-        }
-        // It is fine if both share set id and params are none since we support a default dev share set
 
         if let Some(params) = &self.share_set_params {
+            collect_operator_set_placeholder_errors("shareSetParams", params, &mut errors);
+        }
+        // TODO: use types to make this smarter
+        if self.manifest_set_id.is_some() && self.manifest_set_params.is_some() {
+            errors.push(AppConfigValidationError::ConflictingFields {
+                first: "manifestSetId",
+                second: "manifestSetParams",
+            });
+        }
+
+        if self.manifest_set_id.is_none() && self.manifest_set_params.is_none() {
+            errors.push(AppConfigValidationError::MissingOneOf {
+                first: "manifestSetId",
+                second: "manifestSetParams",
+            });
+        }
+
+        if self.share_set_id.is_some() && self.share_set_params.is_some() {
+            errors.push(AppConfigValidationError::ConflictingFields {
+                first: "shareSetId",
+                second: "shareSetParams",
+            });
+        }
+
+        // It is fine if both share set id and params are none since we support a default dev share set
+        if let Some(params) = &self.share_set_params {
             if params.threshold < MIN_SHARE_SET_THRESHOLD {
-                anyhow::bail!(
-                    "shareSetParams.threshold must be >= {MIN_SHARE_SET_THRESHOLD}, got {}",
-                    params.threshold
-                );
+                errors.push(AppConfigValidationError::ThresholdTooLow {
+                    field: "shareSetParams.threshold",
+                    minimum: MIN_SHARE_SET_THRESHOLD,
+                    actual: params.threshold,
+                });
             }
         }
 
-        Ok(())
+        AppConfigValidationErrors::ok_or_errors(errors)
     }
 
     pub fn effective_share_set_params(&self) -> Option<OperatorSetParams> {
@@ -193,6 +221,104 @@ impl AppConfig {
                     .unwrap_or_else(Self::share_set_params),
             )
         }
+    }
+}
+
+fn collect_operator_set_placeholder_errors(
+    prefix: &'static str,
+    params: &OperatorSetParams,
+    errors: &mut Vec<AppConfigValidationError>,
+) {
+    if params.name.starts_with("<FILL_IN") {
+        errors.push(AppConfigValidationError::Placeholder {
+            field: if prefix == "manifestSetParams" {
+                "manifestSetParams.name"
+            } else {
+                "shareSetParams.name"
+            },
+            placeholder: params.name.clone(),
+        });
+    }
+
+    for (index, operator) in params.new_operators.iter().enumerate() {
+        if operator.public_key.starts_with("<FILL_IN") {
+            errors.push(AppConfigValidationError::OperatorPublicKeyPlaceholder {
+                set: prefix,
+                index,
+                placeholder: operator.public_key.clone(),
+            });
+        }
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum AppConfigValidationError {
+    #[error("{field} contains placeholder value {placeholder}")]
+    Placeholder {
+        field: &'static str,
+        placeholder: String,
+    },
+    #[error("{set}.newOperators[{index}].publicKey contains placeholder value {placeholder}")]
+    OperatorPublicKeyPlaceholder {
+        set: &'static str,
+        index: usize,
+        placeholder: String,
+    },
+    #[error("Cannot specify both {first} and {second}")]
+    ConflictingFields {
+        first: &'static str,
+        second: &'static str,
+    },
+    #[error("Must specify either {first} or {second}")]
+    MissingOneOf {
+        first: &'static str,
+        second: &'static str,
+    },
+    #[error("{field} must be >= {minimum}, got {actual}")]
+    ThresholdTooLow {
+        field: &'static str,
+        minimum: u32,
+        actual: u32,
+    },
+}
+
+#[derive(Debug)]
+pub struct AppConfigValidationErrors(Vec<AppConfigValidationError>);
+
+impl AppConfigValidationErrors {
+    // a bit of a hack, removes need for empty checks
+    fn ok_or_errors(errors: Vec<AppConfigValidationError>) -> Result<(), Self> {
+        if errors.is_empty() {
+            return Ok(());
+        }
+
+        Err(Self(errors))
+    }
+
+    pub fn has_non_placeholder_error(&self) -> bool {
+        self.0.iter().any(|e| !e.is_placeholder())
+    }
+}
+
+impl AppConfigValidationError {
+    pub fn is_placeholder(&self) -> bool {
+        matches!(
+            self,
+            Self::Placeholder { .. } | Self::OperatorPublicKeyPlaceholder { .. }
+        )
+    }
+}
+
+impl Display for AppConfigValidationErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = self
+            .0
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        Display::fmt(&s, f)
     }
 }
 

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -1,8 +1,11 @@
 //! Deployment configuration file format for `tvc deploy create`.
 
+use std::fmt::Display;
+
 use crate::prompts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
 
 /// Sentinel written by `tvc deploy init` to remind the user to either remove
@@ -122,6 +125,100 @@ impl DeployConfig {
 
     pub fn pull_secret_is_placeholder(&self) -> bool {
         self.pivot_container_encrypted_pull_secret.as_deref() == Some(PULL_SECRET_PLACEHOLDER)
+    }
+
+    pub fn validate(&self) -> Result<(), DeployConfigValidationErrors> {
+        let mut errors = Vec::new();
+        if self.app_id.starts_with("<FILL_IN") {
+            errors.push(DeployConfigValidationError::Placeholder {
+                field: "app_id",
+                placeholder: self.app_id.clone(),
+            });
+        }
+        if self.qos_version.starts_with("<FILL_IN") {
+            errors.push(DeployConfigValidationError::Placeholder {
+                field: "qos_version",
+                placeholder: self.qos_version.clone(),
+            });
+        }
+        if self.pivot_container_image_url.starts_with("<FILL_IN") {
+            errors.push(DeployConfigValidationError::Placeholder {
+                field: "pivot_container_image_url",
+                placeholder: self.pivot_container_image_url.clone(),
+            });
+        }
+        if self.pivot_path.starts_with("<FILL_IN") {
+            errors.push(DeployConfigValidationError::Placeholder {
+                field: "pivot_path",
+                placeholder: self.pivot_path.clone(),
+            });
+        }
+        if self.expected_pivot_digest.starts_with("<FILL_IN") {
+            errors.push(DeployConfigValidationError::Placeholder {
+                field: "expected_pivot_digest",
+                placeholder: self.expected_pivot_digest.clone(),
+            });
+        }
+        if self.pull_secret_is_placeholder() {
+            errors.push(DeployConfigValidationError::PullSecretPlaceholder {
+                placeholder: PULL_SECRET_PLACEHOLDER.to_string(),
+            });
+        }
+
+        DeployConfigValidationErrors::ok_or_errors(errors)
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum DeployConfigValidationError {
+    #[error("{field} contains placeholder value {placeholder}")]
+    Placeholder {
+        field: &'static str,
+        placeholder: String,
+    },
+    #[error(
+        "pivotContainerEncryptedPullSecret contains placeholder value {placeholder}; pass \
+         --pivot-pull-secret <PATH> or remove pivotContainerEncryptedPullSecret for public images"
+    )]
+    PullSecretPlaceholder { placeholder: String },
+}
+
+impl DeployConfigValidationError {
+    pub fn is_placeholder(&self) -> bool {
+        matches!(
+            self,
+            Self::Placeholder { .. } | Self::PullSecretPlaceholder { .. }
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct DeployConfigValidationErrors(Vec<DeployConfigValidationError>);
+
+impl DeployConfigValidationErrors {
+    fn ok_or_errors(errors: Vec<DeployConfigValidationError>) -> Result<(), Self> {
+        if errors.is_empty() {
+            return Ok(());
+        }
+
+        Err(Self(errors))
+    }
+
+    pub fn has_non_placeholder_error(&self) -> bool {
+        self.0.iter().any(|e| !e.is_placeholder())
+    }
+}
+
+impl Display for DeployConfigValidationErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = self
+            .0
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        Display::fmt(&s, f)
     }
 }
 

--- a/tvc/src/prompts.rs
+++ b/tvc/src/prompts.rs
@@ -1,49 +1,40 @@
 //! Interactive prompts for the TVC CLI.
 //!
 //! Thin wrappers over [`inquire`]. Every primitive requires a real TTY; callers
-//! that expect to drive prompts from CI or scripts must use the corresponding
-//! flag, set `TVC_NON_INTERACTIVE=1`, or both.
-//!
-//! Non-interactive awareness:
-//!
-//! - [`is_interactive`] — true only when stdin is a TTY **and**
-//!   `TVC_NON_INTERACTIVE` is unset.
-//! - [`bail_if_non_interactive`] — errors with a clear message naming the
-//!   flag the caller should set instead. Used at the top of any function
-//!   that's about to prompt.
+//! that expect to drive prompts from CI or scripts must use --non-interactive,
+//! set TVC_NON_INTERACTIVE=true, or both.
 
 use anyhow::{Result, bail};
 use inquire::{Confirm, Password, Select, Text};
 use std::fmt::Display;
 use std::io::IsTerminal;
 
-/// Env var that forces non-interactive mode.
+/// Env var that disables interactive prompts when parsed as true.
 pub const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
 
-/// True when we are in a full interactive session: stdin is a TTY and
-/// `TVC_NON_INTERACTIVE` is unset.
-pub fn is_interactive() -> bool {
-    if non_interactive_forced() {
-        return false;
-    }
+pub fn stdin_can_prompt() -> bool {
     std::io::stdin().is_terminal()
 }
 
-/// True when the user has explicitly set `TVC_NON_INTERACTIVE`.
-pub fn non_interactive_forced() -> bool {
-    std::env::var_os(NON_INTERACTIVE_ENV).is_some()
+pub fn error_required_in_non_interactive(flag_hint: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "{flag_hint} is required in non-interactive mode \
+     (set {flag_hint} or run in a TTY without --non-interactive \
+     / {NON_INTERACTIVE_ENV}=true)"
+    )
 }
 
-/// Error with a clear message when we cannot prompt — either the env var is
-/// set, or stdin is not a TTY.
-///
-/// `flag_hint` is the flag the user should set instead (e.g. `"--org"`).
-pub fn bail_if_non_interactive(flag_hint: &str) -> Result<()> {
-    if !is_interactive() {
-        bail!(
-            "{flag_hint} is required in non-interactive mode \
-             (set {flag_hint} or run in a TTY without {NON_INTERACTIVE_ENV})"
-        );
+pub fn bail_required_in_non_interactive(flag_hint: &str) -> Result<()> {
+    bail!(error_required_in_non_interactive(flag_hint));
+}
+
+pub fn bail_interactive_conflicts_with_non_interactive() -> Result<()> {
+    bail!("--interactive conflicts with --non-interactive or {NON_INTERACTIVE_ENV}=true");
+}
+
+pub fn ensure_stdin_is_tty() -> Result<()> {
+    if !stdin_can_prompt() {
+        bail!("--interactive requires a TTY");
     }
     Ok(())
 }

--- a/tvc/tests/config_validation.rs
+++ b/tvc/tests/config_validation.rs
@@ -1,0 +1,82 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use serde_json::json;
+use std::fs;
+use tempfile::NamedTempFile;
+use tvc::config::deploy::DeployConfig;
+
+const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+
+fn write_json(value: &serde_json::Value) -> NamedTempFile {
+    let file = NamedTempFile::new().unwrap();
+    fs::write(file.path(), serde_json::to_string_pretty(value).unwrap()).unwrap();
+    file
+}
+
+#[test]
+fn deploy_create_non_interactive_reports_all_placeholder_errors() {
+    let config = NamedTempFile::new().unwrap();
+    fs::write(
+        config.path(),
+        serde_json::to_string_pretty(&DeployConfig::template(None)).unwrap(),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("deploy")
+        .arg("create")
+        .arg("--config-file")
+        .arg(config.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("app_id"))
+        .stderr(predicate::str::contains("qos_version"))
+        .stderr(predicate::str::contains("pivot_container_image_url"))
+        .stderr(predicate::str::contains("pivot_path"))
+        .stderr(predicate::str::contains("expected_pivot_digest"))
+        .stderr(predicate::str::contains(
+            "pivotContainerEncryptedPullSecret",
+        ));
+}
+
+#[test]
+fn app_create_non_interactive_reports_placeholder_and_structural_errors() {
+    let config = write_json(&json!({
+        "name": "<FILL_IN_APP_NAME>",
+        "quorumPublicKey": "test-quorum-public-key",
+        "manifestSetId": "manifest-set-id",
+        "manifestSetParams": {
+            "name": "<FILL_IN_MANIFEST_SET_NAME>",
+            "threshold": 1,
+            "newOperators": [{
+                "name": "operator-1",
+                "publicKey": "<FILL_IN_OPERATOR_PUBLIC_KEY>"
+            }]
+        },
+        "shareSetId": "share-set-id",
+        "shareSetParams": {
+            "name": "share-set",
+            "threshold": 1,
+            "newOperators": []
+        }
+    }));
+
+    cargo_bin_cmd!("tvc")
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("app")
+        .arg("create")
+        .arg("--config-file")
+        .arg(config.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("name"))
+        .stderr(predicate::str::contains("manifestSetParams.name"))
+        .stderr(predicate::str::contains(
+            "manifestSetParams.newOperators[0].publicKey",
+        ))
+        .stderr(predicate::str::contains("manifestSetId"))
+        .stderr(predicate::str::contains("shareSetId"))
+        .stderr(predicate::str::contains("shareSetParams"))
+        .stderr(predicate::str::contains("shareSetParams.threshold"));
+}

--- a/tvc/tests/deploy_create_help.rs
+++ b/tvc/tests/deploy_create_help.rs
@@ -17,6 +17,9 @@ fn deploy_create_help_documents_config_and_override_precedence() {
         ))
         .stdout(predicate::str::contains(
             "--pivot-args replaces the config file's list entirely",
+        ))
+        .stdout(predicate::str::contains(
+            "Use --non-interactive or set TVC_NON_INTERACTIVE=true",
         ));
 }
 
@@ -58,4 +61,26 @@ fn top_level_help_documents_auth_precedence() {
         .stdout(predicate::str::contains("TVC_ORG_ID"))
         .stdout(predicate::str::contains("TVC_API_KEY_PUBLIC"))
         .stdout(predicate::str::contains("TVC_API_KEY_PRIVATE"));
+}
+
+#[test]
+fn top_level_help_documents_non_interactive_flag() {
+    cargo_bin_cmd!("tvc")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--non-interactive"))
+        .stdout(predicate::str::contains("TVC_NON_INTERACTIVE"));
+}
+
+#[test]
+fn deploy_create_help_documents_non_interactive_global_flag() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--non-interactive"))
+        .stdout(predicate::str::contains("TVC_NON_INTERACTIVE"));
 }

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 
 /// When `--org <alias>` points to an alias that is not present in the local
 /// config, we fail fast without entering any interactive flow. Exercises the
-/// early-return branch in `select_or_create_org`.
+/// `OrgPlan::Existing` branch in `execute_login`.
 #[test]
 fn login_errors_when_provided_org_not_found() {
     let temp = TempDir::new().unwrap();

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -8,10 +8,69 @@
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use std::collections::HashMap;
+use std::fs;
 use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use tvc::config::turnkey::{Config, KeyCurve, OrgConfig, StoredApiKey};
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+const LOCAL_API_BASE_URL: &str = "http://127.0.0.1:1";
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+fn write_config(
+    home: &TempDir,
+    api_key_path: std::path::PathBuf,
+    operator_key_path: std::path::PathBuf,
+    last_operator_ids: Vec<String>,
+) {
+    let turnkey_dir = home.path().join(".config").join("turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path,
+                operator_key_path,
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::from([("test".to_string(), last_operator_ids)]),
+    };
+
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        toml::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_api_key(path: &std::path::Path) {
+    let (public_key, private_key) = generated_api_key();
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&StoredApiKey {
+            public_key,
+            private_key,
+            curve: KeyCurve::P256,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+}
 
 #[test]
 fn login_without_org_errors_when_non_interactive_forced() {
@@ -27,6 +86,52 @@ fn login_without_org_errors_when_non_interactive_forced() {
             "--org is required in non-interactive mode",
         ))
         .stderr(predicate::str::contains(NON_INTERACTIVE_ENV));
+}
+
+#[test]
+fn login_without_org_errors_with_non_interactive_flag() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("--non-interactive")
+        .arg("login")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--org is required in non-interactive mode",
+        ))
+        .stderr(predicate::str::contains("--non-interactive"));
+}
+
+#[test]
+fn login_non_interactive_requires_existing_api_key_before_generating_one() {
+    let temp = TempDir::new().unwrap();
+    let org_dir = temp
+        .path()
+        .join(".config")
+        .join("turnkey")
+        .join("orgs")
+        .join("test");
+    let api_key_path = org_dir.join("api_key.json");
+    let operator_key_path = org_dir.join("operator.json");
+    write_config(&temp, api_key_path.clone(), operator_key_path, vec![]);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .arg("--org")
+        .arg("test")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("API key"))
+        .stderr(predicate::str::contains("non-interactive"));
+
+    assert!(
+        !api_key_path.exists(),
+        "non-interactive login must not generate an API key"
+    );
 }
 
 #[test]
@@ -65,8 +170,58 @@ fn deploy_init_interactive_conflicts_with_non_interactive_env() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--interactive conflicts with TVC_NON_INTERACTIVE",
+            "--interactive conflicts with --non-interactive or TVC_NON_INTERACTIVE",
         ));
+}
+
+#[test]
+fn deploy_init_interactive_conflicts_with_non_interactive_flag() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .current_dir(temp.path())
+        .arg("deploy")
+        .arg("init")
+        .arg("--interactive")
+        .arg("--non-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--interactive conflicts with --non-interactive or TVC_NON_INTERACTIVE",
+        ));
+}
+
+#[test]
+fn non_interactive_env_zero_does_not_force_non_interactive_mode() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "0")
+        .current_dir(temp.path())
+        .arg("deploy")
+        .arg("init")
+        .arg("--interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--interactive requires a TTY"))
+        .stderr(predicate::str::contains("conflicts").not());
+}
+
+#[test]
+fn invalid_non_interactive_env_value_errors_during_cli_parse() {
+    let temp = TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "definitely")
+        .arg("login")
+        .arg("--org")
+        .arg("default")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("value was not a boolean"));
 }
 
 #[test]
@@ -83,14 +238,14 @@ fn app_init_interactive_conflicts_with_non_interactive_env() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--interactive conflicts with TVC_NON_INTERACTIVE",
+            "--interactive conflicts with --non-interactive or TVC_NON_INTERACTIVE",
         ));
 }
 
-/// `deploy create` with no config file and no required flags can't prompt for
-/// the missing values, so it bails naming every flag the user still has to set.
+/// `deploy create` with no config file and no required fields can't prompt for
+/// the missing values, so it bails naming every field the user still has to set.
 #[test]
-fn deploy_create_without_required_flags_bails_naming_each_flag() {
+fn deploy_create_without_required_fields_bails_naming_each_field() {
     let temp = TempDir::new().unwrap();
 
     cargo_bin_cmd!("tvc")
@@ -100,11 +255,11 @@ fn deploy_create_without_required_flags_bails_naming_each_flag() {
         .arg("create")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--app-id"))
-        .stderr(predicate::str::contains("--qos-version"))
-        .stderr(predicate::str::contains("--pivot-image-url"))
-        .stderr(predicate::str::contains("--pivot-path"))
-        .stderr(predicate::str::contains("--expected-pivot-digest"));
+        .stderr(predicate::str::contains("app_id"))
+        .stderr(predicate::str::contains("qos_version"))
+        .stderr(predicate::str::contains("pivot_container_image_url"))
+        .stderr(predicate::str::contains("pivot_path"))
+        .stderr(predicate::str::contains("expected_pivot_digest"));
 }
 
 /// All required fields are filled from the config file, but the pull-secret
@@ -169,4 +324,61 @@ fn approve_dangerous_skip_interactive_bypasses_prompts_when_non_interactive_forc
         .arg("--skip-post")
         .assert()
         .success();
+}
+
+#[test]
+fn approve_non_interactive_requires_operator_id_when_saved_ids_are_ambiguous() {
+    let temp = TempDir::new().unwrap();
+    let org_dir = temp
+        .path()
+        .join(".config")
+        .join("turnkey")
+        .join("orgs")
+        .join("test");
+    let api_key_path = org_dir.join("api_key.json");
+    let operator_key_path = org_dir.join("operator.json");
+    write_config(
+        &temp,
+        api_key_path.clone(),
+        operator_key_path,
+        vec!["operator-1".to_string(), "operator-2".to_string()],
+    );
+    write_api_key(&api_key_path);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--dangerous-skip-interactive")
+        .arg("--manifest-id")
+        .arg("manifest-id")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--operator-id"))
+        .stderr(predicate::str::contains("multiple"));
+}
+
+#[test]
+fn deploy_init_template_does_not_require_readable_existing_config() {
+    let temp = TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config").join("turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+    fs::write(turnkey_dir.join("tvc.config.toml"), "not valid toml").unwrap();
+
+    let output = temp.path().join("deploy.json");
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("init")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+
+    assert!(output.exists(), "deploy init should write the template");
 }


### PR DESCRIPTION
Linear: TVC-66

Summary:
- Add a global `--non-interactive` flag backed by `TVC_NON_INTERACTIVE`, using
  clap boolean parsing so falsey values do not force non-interactive mode.
- Thread a single `is_non_interactive: bool` into each prompt-capable command's
  `run(args, is_non_interactive)` entry point, which dispatches internally to
  mode-specific input builders feeding a shared mode-agnostic executor. Prompt
  helpers remain TTY UI primitives.
- Make non-interactive config/login paths fail fast without prompting or
  offering to save filled config, and document the behavior in help output.
- Replace `Vec<ValidationError>` + `is_empty()` checks with typed
  `DeployConfigValidationErrors` / `AppConfigValidationErrors` wrappers that
  expose `has_non_placeholder_error()` for the interactive prompt loop.
- Split `Args` overrides into `Overrides` substructs for `deploy create` and
  `app create` (clap `#[command(flatten)]`), so override fields are scoped
  separately from path/secret inputs.

Tests:
- `cargo fmt -p tvc -- --check`
- `cargo test -p tvc` (full suite; key files: `non_interactive.rs`,
  `config_validation.rs`, `deploy_create_help.rs`)

@tkhq/dependency-reviewers, I added `thiserror` as a dependency to `tvc`. That's
the only change, it was already in the dependency tree.