### PR TITLE
Am/feat/list apps

### DIFF
--- a/tvc/CHANGELOG.md
+++ b/tvc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `tvc app list` command to list all TVC applications for an organization, with optional filtering by name.
+
 ## [0.7.0](https://github.com/tkhq/rust-sdk/compare/tvc-v0.6.2...tvc-v0.7.0) - 2026-05-19
 
 ### Added

--- a/tvc/CHANGELOG.md
+++ b/tvc/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-
-- Added `tvc app list` command to list all TVC applications for an organization, with optional filtering by name.
-
 ## [0.7.0](https://github.com/tkhq/rust-sdk/compare/tvc-v0.6.2...tvc-v0.7.0) - 2026-05-19
 
 ### Added

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -28,9 +28,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
 
     let mut apps = response.tvc_apps;
 
-    if let Some(ref name_filter) = args.name {
-        apps.retain(|app| app.name.contains(name_filter.as_str()));
-    }
+    filter_by_name(&mut apps, args.name.as_deref());
 
     if apps.is_empty() {
         println!("No apps found.");
@@ -44,6 +42,12 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn filter_by_name(apps: &mut Vec<TvcApp>, name: Option<&str>) {
+    if let Some(filter) = name {
+        apps.retain(|app| app.name.contains(filter));
+    }
+}
+
 fn render_app(app: &TvcApp) {
     println!("Name: {}", app.name);
     println!("ID: {}", app.id);
@@ -54,4 +58,80 @@ fn render_app(app: &TvcApp) {
         println!("Public Domain: {}", app.public_domain);
     }
     println!("{}", "─".repeat(40));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_app(name: &str) -> TvcApp {
+        TvcApp {
+            id: "test-id".to_string(),
+            organization_id: "test-org".to_string(),
+            name: name.to_string(),
+            quorum_public_key: "test-key".to_string(),
+            manifest_set: None,
+            share_set: None,
+            enable_egress: false,
+            created_at: None,
+            updated_at: None,
+            live_deployment_id: None,
+            public_domain: String::new(),
+        }
+    }
+
+    #[test]
+    fn filter_by_name_no_filter_returns_all() {
+        let mut apps = vec![make_app("alpha"), make_app("beta")];
+        filter_by_name(&mut apps, None);
+        assert_eq!(apps.len(), 2);
+    }
+
+    #[test]
+    fn filter_by_name_exact_match_returns_one() {
+        let mut apps = vec![make_app("alpha"), make_app("beta")];
+        filter_by_name(&mut apps, Some("alpha"));
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].name, "alpha");
+    }
+
+    #[test]
+    fn filter_by_name_partial_match_returns_matching() {
+        let mut apps = vec![make_app("my-app-prod"), make_app("my-app-staging"), make_app("other")];
+        filter_by_name(&mut apps, Some("my-app"));
+        assert_eq!(apps.len(), 2);
+    }
+
+    #[test]
+    fn filter_by_name_no_match_returns_empty() {
+        let mut apps = vec![make_app("alpha"), make_app("beta")];
+        filter_by_name(&mut apps, Some("gamma"));
+        assert!(apps.is_empty());
+    }
+
+    #[test]
+    fn matched_app_has_all_rendered_fields() {
+        let mut app = make_app("my-app");
+        app.id = "app-uuid-123".to_string();
+        app.quorum_public_key = "04abcdef".to_string();
+        app.live_deployment_id = Some("deploy-uuid-456".to_string());
+        app.public_domain = "my-app.example.com".to_string();
+
+        let mut apps = vec![app];
+        filter_by_name(&mut apps, Some("my-app"));
+
+        assert_eq!(apps.len(), 1);
+        let app = &apps[0];
+        assert_eq!(app.name, "my-app");
+        assert_eq!(app.id, "app-uuid-123");
+        assert_eq!(app.quorum_public_key, "04abcdef");
+        assert_eq!(app.live_deployment_id.as_deref().unwrap_or("(none)"), "deploy-uuid-456");
+        assert_eq!(app.public_domain, "my-app.example.com");
+    }
+
+    #[test]
+    fn app_with_no_live_deployment_renders_none() {
+        let app = make_app("my-app");
+        assert_eq!(app.live_deployment_id.as_deref().unwrap_or("(none)"), "(none)");
+    }
 }

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -1,6 +1,8 @@
 //! App list command.
 
+use anyhow::Context;
 use clap::Args as ClapArgs;
+use turnkey_client::generated::GetTvcAppsRequest;
 
 /// List apps.
 #[derive(Debug, ClapArgs)]
@@ -13,6 +15,38 @@ pub struct Args {
 
 /// Run the app list command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    println!("Listing apps with filter: {:?}", args.name);
-    todo!("app list not yet implemented")
+    let auth = crate::client::build_client().await?;
+
+    let response = auth
+        .client
+        .get_tvc_apps(GetTvcAppsRequest {
+            organization_id: auth.org_id.clone(),
+        })
+        .await
+        .context("failed to list TVC apps")?;
+
+    let mut apps = response.tvc_apps;
+
+    if let Some(ref name_filter) = args.name {
+        apps.retain(|app| app.name.contains(name_filter.as_str()));
+    }
+
+    if apps.is_empty() {
+        println!("No apps found.");
+        return Ok(());
+    }
+
+    for app in &apps {
+        println!("Name:              {}", app.name);
+        println!("ID:                {}", app.id);
+        println!("Quorum Public Key: {}", app.quorum_public_key);
+        let live = app.live_deployment_id.as_deref().unwrap_or("(none)");
+        println!("Live Deployment:   {live}");
+        if !app.public_domain.is_empty() {
+            println!("Public Domain:     {}", app.public_domain);
+        }
+        println!();
+    }
+
+    Ok(())
 }

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
+use turnkey_client::generated::external::data::v1::TvcApp;
 use turnkey_client::generated::GetTvcAppsRequest;
 
 /// List apps.
@@ -37,16 +38,20 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     }
 
     for app in &apps {
-        println!("Name:              {}", app.name);
-        println!("ID:                {}", app.id);
-        println!("Quorum Public Key: {}", app.quorum_public_key);
-        let live = app.live_deployment_id.as_deref().unwrap_or("(none)");
-        println!("Live Deployment:   {live}");
-        if !app.public_domain.is_empty() {
-            println!("Public Domain:     {}", app.public_domain);
-        }
-        println!();
+        render_app(app);
     }
 
     Ok(())
+}
+
+fn render_app(app: &TvcApp) {
+    println!("Name: {}", app.name);
+    println!("ID: {}", app.id);
+    println!("Quorum Public Key: {}", app.quorum_public_key);
+    let live = app.live_deployment_id.as_deref().unwrap_or("(none)");
+    println!("Live Deployment: {live}");
+    if !app.public_domain.is_empty() {
+        println!("Public Domain: {}", app.public_domain);
+    }
+    println!("{}", "─".repeat(40));
 }

--- a/tvc/tests/app_list.rs
+++ b/tvc/tests/app_list.rs
@@ -1,0 +1,48 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn app_cmd() -> (TempDir, assert_cmd::Command) {
+    let temp = TempDir::new().unwrap();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear().env("HOME", temp.path()).arg("app");
+    (temp, cmd)
+}
+
+fn app_list_cmd() -> (TempDir, assert_cmd::Command) {
+    let (temp, mut cmd) = app_cmd();
+    cmd.arg("list");
+    (temp, cmd)
+}
+
+#[test]
+fn app_help_lists_list() {
+    let (_temp, mut cmd) = app_cmd();
+
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"));
+}
+
+#[test]
+fn app_list_help_lists_expected_flags() {
+    let (_temp, mut cmd) = app_list_cmd();
+
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name <NAME>"));
+}
+
+#[test]
+fn app_list_name_filter_accepted() {
+    let (_temp, mut cmd) = app_list_cmd();
+
+    // Fails on auth (no credentials), not on arg parsing.
+    cmd.arg("--name")
+        .arg("my-app")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--name").not());
+}


### PR DESCRIPTION
Implements `tvc app list`:
  - Lists all TVC apps for the org, with optional `--name` filter
  - Adds integration tests in `tests/app_list.rs` and unit tests in `list.rs`
  - Updates `CHANGELOG.md`
 
Closes [ENG-3119](https://linear.app/turnkey/issue/ENG-3119/cli-tvc-app-list)