### PR TITLE
chore(tvc): sync protos and fix tests

### DIFF
--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -4003,7 +4003,7 @@ impl<S: Stamp> TurnkeyClient<S> {
     }
     /// Get balances
     ///
-    /// Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access.
+    /// Get balances of supported assets for an address on the specified network. Only non-zero balances are returned.
     pub async fn get_wallet_address_balances(
         &self,
         request: coordinator::GetWalletAddressBalancesRequest,
@@ -4016,7 +4016,7 @@ impl<S: Stamp> TurnkeyClient<S> {
     }
     /// List supported assets
     ///
-    /// List supported assets for the specified network. This feature is in beta - please contact support for access.
+    /// List supported assets for the specified network.
     pub async fn list_supported_assets(
         &self,
         request: coordinator::ListSupportedAssetsRequest,

--- a/client/src/generated/external.data.v1.rs
+++ b/client/src/generated/external.data.v1.rs
@@ -371,6 +371,8 @@ pub struct BootProof {
     pub owner: ::prost::alloc::string::String,
     #[serde(default)]
     pub created_at: ::core::option::Option<Timestamp>,
+    #[serde(default)]
+    pub qos_manifest_version: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -531,6 +533,8 @@ pub struct TvcApp {
     #[serde(default)]
     pub live_deployment_id: ::core::option::Option<::prost::alloc::string::String>,
     pub public_domain: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub enable_debug_mode_deployments: bool,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -2171,6 +2171,8 @@ pub struct CreateTvcAppIntent {
     pub share_set_params: ::core::option::Option<TvcOperatorSetParams>,
     #[serde(default)]
     pub enable_egress: ::core::option::Option<bool>,
+    #[serde(default)]
+    pub enable_debug_mode_deployments: ::core::option::Option<bool>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -506,6 +506,7 @@ mod tests {
             enclave_app: "signer".to_string(),
             owner: "tkhq".to_string(),
             created_at: Some(Timestamp{seconds: "1758057949".to_string(), nanos: "436158000".to_string()}),
+            qos_manifest_version: None,
         }
     }
 
@@ -519,6 +520,7 @@ mod tests {
             enclave_app: "signer".to_string(),
             owner: "tkhq".to_string(),
             created_at: Some(Timestamp{seconds: "1758057841".to_string(), nanos: "448145000".to_string()}),
+            qos_manifest_version: None,
         }
     }
 

--- a/proto/external/data/v1/proofs.proto
+++ b/proto/external/data/v1/proofs.proto
@@ -21,11 +21,11 @@ message BootProof {
   ];
   string qos_manifest_b64 = 3 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The borsch serialized base64 encoded Manifest."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The base64 encoded QOS manifest. Encoding depends on qos_manifest_version."}
   ];
   string qos_manifest_envelope_b64 = 4 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The borsch serialized base64 encoded Manifest Envelope."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The base64 encoded QOS manifest envelope. Encoding depends on qos_manifest_version."}
   ];
   string deployment_label = 5 [
     (google.api.field_behavior) = REQUIRED,
@@ -40,6 +40,7 @@ message BootProof {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Owner of the app i.e. 'tkhq'"}
   ];
   Timestamp created_at = 8 [(google.api.field_behavior) = REQUIRED];
+  optional string qos_manifest_version = 9 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "QOS manifest schema version."}];
 }
 
 message AppProof {

--- a/proto/external/data/v1/tvc.proto
+++ b/proto/external/data/v1/tvc.proto
@@ -45,6 +45,10 @@ message TvcApp {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The public domain for ingress to this TVC App (in the format \"app-<ID>.turnkey.cloud\")."}
   ];
+  bool enable_debug_mode_deployments = 12 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Whether this app permits debug-mode deployments. Set at app creation via CreateTvcAppIntent.enable_debug_mode_deployments and never updated thereafter. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. The app's quorum key is therefore considered permanently insecure once enabled — a new app with a fresh quorum key must be created to return to a secure posture."}
+  ];
 }
 
 message TvcDeployment {

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -4153,6 +4153,10 @@ message CreateTvcAppIntent {
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Enables network egress for this TVC app. Default if not provided: false."}
   ];
+  optional bool enable_debug_mode_deployments = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "When true, this app may create deployments in debug-mode. Debug-mode deployments expose logs and emit zero'd attestation PCRs, so remote attestation cannot succeed. Cannot be changed after app creation. Setting this true means the app's quorum key is considered permanently insecure, and a new app with a fresh quorum key must be created. Default if not provided: false."}
+  ];
 }
 
 message TvcOperatorSetParams {

--- a/proto/services/coordinator/public/v1/public_api.proto
+++ b/proto/services/coordinator/public/v1/public_api.proto
@@ -1905,7 +1905,7 @@ service PublicApiService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned. This feature is in beta - please contact support for access."
+      description: "Get balances of supported assets for an address on the specified network. Only non-zero balances are returned."
       summary: "Get balances"
       tags: "Wallets"
     };
@@ -1917,7 +1917,7 @@ service PublicApiService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      description: "List supported assets for the specified network. This feature is in beta - please contact support for access."
+      description: "List supported assets for the specified network."
       summary: "List supported assets"
       tags: "Wallets"
     };
@@ -2940,6 +2940,8 @@ message GetWalletAddressBalancesRequest {
         "eip155:84532",
         "eip155:137",
         "eip155:80002",
+        "eip155:42161",
+        "eip155:421614",
         "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
         "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
       ]
@@ -2981,6 +2983,8 @@ message ListSupportedAssetsRequest {
         "eip155:84532",
         "eip155:137",
         "eip155:80002",
+        "eip155:42161",
+        "eip155:421614",
         "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
         "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
       ]

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -140,6 +140,7 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
         share_set_id: app_config.share_set_id.clone(),
         share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
         enable_egress: app_config.external_connectivity,
+        enable_debug_mode_deployments: None,
     }
 }
 


### PR DESCRIPTION
was working on #132 and sync'd protos (via `make sync/rust-sdk` in `mono`), and noticed that the latest protos broke some TVC tests. Splitting out the protos fix into this PR for clarity 