### PR TITLE
feat: breaking rename external connectivity in config to enable egress to match api

### DIFF
--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -146,7 +146,7 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
             .map(to_tvc_operator_set_params),
         share_set_id: app_config.share_set_id.clone(),
         share_set_params: share_set_params.as_ref().map(to_tvc_operator_set_params),
-        enable_egress: app_config.external_connectivity,
+        enable_egress: app_config.enable_egress,
         enable_debug_mode_deployments: app_config.dangerous_enable_debug_mode_deployments.into(),
     }
 }
@@ -184,7 +184,7 @@ mod tests {
         AppConfig {
             name: "test-app".to_string(),
             quorum_public_key: KNOWN_QUORUM_KEY.to_string(),
-            external_connectivity: Some(false),
+            enable_egress: Some(false),
             manifest_set_id: None,
             manifest_set_params: Some(OperatorSetParams {
                 name: "manifest-set".to_string(),

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -13,7 +13,7 @@ pub struct AppConfig {
     pub name: String,
     pub quorum_public_key: String,
     #[serde(default)]
-    pub external_connectivity: Option<bool>,
+    pub enable_egress: Option<bool>,
     #[serde(default)]
     pub manifest_set_id: Option<String>,
     #[serde(default)]
@@ -63,7 +63,7 @@ impl AppConfig {
         Self {
             name: "<FILL_IN_APP_NAME>".to_string(),
             quorum_public_key: KNOWN_QUORUM_KEY.to_string(),
-            external_connectivity: Some(false),
+            enable_egress: Some(false),
             manifest_set_id: None,
             manifest_set_params: Some(OperatorSetParams {
                 name: "<FILL_IN_MANIFEST_SET_NAME>".to_string(),
@@ -216,6 +216,15 @@ mod tests {
 
         config.validate().unwrap();
         assert_eq!(config.effective_share_set_params().unwrap().threshold, 2);
+    }
+
+    #[test]
+    fn config_deserializes_enable_egress() {
+        let mut json = valid_config_json();
+        json["enableEgress"] = json!(true);
+        let config: AppConfig = serde_json::from_value(json).unwrap();
+
+        assert_eq!(config.enable_egress, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
Rename config field name to better align with api field name