### PR TITLE
ENG-3890: Explain TVC deployment ports

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -153,7 +153,10 @@ enum DeployCommands {
     /// Get the status of a deployment.
     Status(commands::deploy::status::Args),
     /// Create a new deployment from a config file.
-    #[command(long_about = commands::deploy::create::LONG_ABOUT)]
+    #[command(
+        long_about = commands::deploy::create::LONG_ABOUT,
+        after_help = commands::deploy::PORT_GUIDANCE
+    )]
     Create(commands::deploy::create::Args),
     /// Generate a template deployment configuration file.
     Init(commands::deploy::init::Args),

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -1,5 +1,6 @@
 //! Deploy create command - creates a deployment from a config file or CLI flags.
 
+use super::format_port_summary;
 use crate::client::build_client;
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
@@ -123,11 +124,16 @@ struct Overrides {
     )]
     pub pivot_args: Vec<String>,
 
-    /// Override the healthCheckPort field.
+    /// Container port TVC probes to decide whether the deployment is healthy.
+    ///
+    /// Use the same value as --public-ingress-port unless your binary exposes
+    /// health checks on a separate listener.
     #[arg(long, env = "TVC_HEALTH_CHECK_PORT")]
     pub health_check_port: Option<u16>,
 
-    /// Override the publicIngressPort field.
+    /// Container port that receives public app traffic.
+    ///
+    /// This is usually the port your server listens on for external requests.
     #[arg(long, env = "TVC_PUBLIC_INGRESS_PORT")]
     pub public_ingress_port: Option<u16>,
 }
@@ -363,6 +369,8 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
     let deploy_config = inputs.config;
 
     println!("Creating deployment for app '{}'...", deploy_config.app_id);
+    println!("{}", format_port_summary(&deploy_config));
+    println!();
 
     let auth = build_client().await?;
 

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -1,5 +1,6 @@
 //! Deploy init command - generates a template config file.
 
+use super::PORT_GUIDANCE;
 use crate::config::deploy::DeployConfig;
 use crate::config::turnkey;
 use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
@@ -74,6 +75,8 @@ async fn execute(args: Args) -> Result<()> {
         println!("Edit the file to fill in your values, then run:");
         println!("  tvc deploy create --config-file {}", output.display());
     }
+    println!();
+    println!("{PORT_GUIDANCE}");
 
     Ok(())
 }

--- a/tvc/src/commands/deploy/mod.rs
+++ b/tvc/src/commands/deploy/mod.rs
@@ -1,5 +1,7 @@
 //! Deploy commands.
 
+use crate::config::deploy::DeployConfig;
+
 pub mod approve;
 pub mod create;
 pub mod delete;
@@ -9,3 +11,68 @@ pub mod post_share;
 pub mod provisioning_details;
 pub mod restore;
 pub mod status;
+
+pub(crate) const PORT_GUIDANCE: &str = r#"Port guidance:
+  publicIngressPort is the port inside your container that receives public app
+  traffic.
+  healthCheckPort is the port TVC probes to decide whether the deployment is
+  healthy.
+  Use the same port for both unless your binary exposes health checks on a
+  separate listener. Generated configs default both to 3000."#;
+
+pub(crate) fn format_port_summary(config: &DeployConfig) -> String {
+    let public_port = config.public_ingress_port;
+    let health_port = config.health_check_port;
+
+    if public_port == health_port {
+        return format!(
+            r#"Ports:
+  Public ingress and health checks both use container port {public_port}.
+  This is the common case when one listener serves app traffic and health checks."#
+        );
+    }
+
+    format!(
+        r#"Ports:
+  Public ingress uses container port {public_port}.
+  Health checks use container port {health_port}.
+  Separate ports are for binaries that expose health checks on a separate listener."#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_summary_explains_shared_port() {
+        let config = DeployConfig::template(None);
+
+        let summary = format_port_summary(&config);
+
+        assert!(
+            summary.contains("both use container port 3000"),
+            "{summary}"
+        );
+        assert!(summary.contains("common case"), "{summary}");
+    }
+
+    #[test]
+    fn port_summary_explains_split_ports() {
+        let mut config = DeployConfig::template(None);
+        config.public_ingress_port = 8080;
+        config.health_check_port = 9090;
+
+        let summary = format_port_summary(&config);
+
+        assert!(
+            summary.contains("Public ingress uses container port 8080"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("Health checks use container port 9090"),
+            "{summary}"
+        );
+        assert!(summary.contains("separate listener"), "{summary}");
+    }
+}

--- a/tvc/tests/deploy_create_help.rs
+++ b/tvc/tests/deploy_create_help.rs
@@ -40,6 +40,24 @@ fn deploy_create_help_documents_env_only_usage() {
 }
 
 #[test]
+fn deploy_create_help_explains_deployment_ports() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Port guidance:"))
+        .stdout(predicate::str::contains(
+            "publicIngressPort is the port inside your container",
+        ))
+        .stdout(predicate::str::contains(
+            "healthCheckPort is the port TVC probes",
+        ))
+        .stdout(predicate::str::contains("Use the same port for both"));
+}
+
+#[test]
 fn deploy_create_help_leaves_auth_details_to_global_docs() {
     cargo_bin_cmd!("tvc")
         .arg("deploy")

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -378,7 +378,11 @@ fn deploy_init_template_does_not_require_readable_existing_config() {
         .arg("--output")
         .arg(&output)
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("Port guidance:"))
+        .stdout(predicate::str::contains(
+            "Use the same port for both unless your binary exposes health checks",
+        ));
 
     assert!(output.exists(), "deploy init should write the template");
 }


### PR DESCRIPTION
Linear: ENG-3890

Summary:
- Add shared guidance for how to choose publicIngressPort and healthCheckPort in the TVC deploy flow.
- Show the resolved port setup before creating a deployment, including whether health checks share the public ingress listener or use a separate listener.
- Improve port flag help text and cover the new guidance in help/init output tests.

New output:
```bash
➜  rust-sdk git:(richard/eng-3890-explain-ports-when-creating-a-new-deployment) ✗ tvc deploy init
Created deployment config template: deploy-2026-06-11-094428.json

Edit the file to fill in your values, then run:
  tvc deploy create --config-file deploy-2026-06-11-094428.json

Port guidance:
  publicIngressPort is the port inside your container that receives public app
  traffic.
  healthCheckPort is the port TVC probes to decide whether the deployment is
  healthy.
  Use the same port for both unless your binary exposes health checks on a
  separate listener. Generated configs default both to 3000.
  ```