### PR TITLE
tvc: default deploys to QOS 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,19 @@ checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
- "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+dependencies = [
+ "num-traits",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
  "subtle",
  "zeroize",
 ]
@@ -925,7 +937,7 @@ dependencies = [
  "digest",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
- "serdect",
+ "serdect 0.2.0",
  "signature",
  "spki 0.7.3",
 ]
@@ -974,7 +986,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "tap",
  "zeroize",
@@ -982,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve-tools"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48843edfbd0a370b3dd14cdbb4e446e9a8855311e6b2b57bf9a1fd1367bc317"
+checksum = "1de2b6fae800f08032a6ea32995b52925b1d451bff9d445c8ab2932323277faf"
 dependencies = [
  "elliptic-curve 0.13.8",
  "heapless",
@@ -1522,6 +1534,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2352,7 +2373,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder 0.13.6",
- "serdect",
+ "serdect 0.2.0",
  "sha2",
 ]
 
@@ -2566,7 +2587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
- "serdect",
+ "serdect 0.2.0",
 ]
 
 [[package]]
@@ -2716,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "qos_core"
-version = "0.6.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893f63fac0ccdb1dd5f66da2d2b463b8c5c23763a61f440c2c3cdc4e6a481323"
+checksum = "ec597d5969af94dd140ee619b08821fe4d283496ea118607b4c54f27a783276f"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
@@ -2727,6 +2748,7 @@ dependencies = [
  "nix 0.30.1",
  "qos_crypto",
  "qos_hex",
+ "qos_json",
  "qos_nsm",
  "qos_p256",
  "serde",
@@ -2734,40 +2756,56 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-vsock",
+ "zeroize",
 ]
 
 [[package]]
 name = "qos_crypto"
-version = "0.6.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c49415fb28a9dc7388e53fed1494189fdf9d917f956905288966d856a4a884"
+checksum = "b8ea38f26e3207858d019d23d160acc1c00e20e480222c6b4b762a2dccf4bafc"
 dependencies = [
  "rand 0.9.2",
  "sha2",
  "thiserror 2.0.12",
  "vsss-rs",
+ "zeroize",
 ]
 
 [[package]]
 name = "qos_hex"
-version = "0.6.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a19810c8e0561e92b11bf4fbf1ae880a7251826b8aa711533c8e773c5e7ca1"
+checksum = "f96802bf51c27037d1b077db08a1d73215bfe6cffea023f932488d2dcb4e72d9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "qos_nsm"
-version = "0.6.1"
+name = "qos_json"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d91112b30ca87b38b0e54e2a88a3395b47e755d35dc88abe9d41a1bd3576be2"
+checksum = "d9f28c63cfb0108ea1f99584fd66aa91de239d8df6aef9de7ab7a0a28b8f7045"
+dependencies = [
+ "qos_hex",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "qos_nsm"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082030a1c12e080eb6efb818e838648b6981c9abfa459780fe3892aa61cdd35d"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "p384 0.13.1",
  "qos_hex",
+ "qos_json",
+ "serde",
  "serde_bytes",
  "sha2",
  "webpki",
@@ -2776,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "qos_p256"
-version = "0.6.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9af0113f0e9996a4f9d4446cbed70cd1682119d87536572f425fe752f2205e"
+checksum = "c77913a25f56570a4ea1e19acccda7063a5aa250f026d93e63a09c64c75a3222"
 dependencies = [
  "aes-gcm",
  "borsh",
@@ -2786,6 +2824,7 @@ dependencies = [
  "hmac",
  "p256 0.13.2",
  "qos_hex",
+ "serde",
  "sha2",
  "zeroize",
 ]
@@ -3246,7 +3285,7 @@ dependencies = [
  "der 0.7.9",
  "generic-array 0.14.7",
  "pkcs8 0.10.2",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -3438,6 +3477,16 @@ name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct 0.2.0",
  "serde",
@@ -4171,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -4262,15 +4311,16 @@ dependencies = [
 
 [[package]]
 name = "vsss-rs"
-version = "5.1.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec4ebcc5594130c31b49594d55c0583fe80621f252f570b222ca4845cafd3cf"
+checksum = "6ec751bdcc8bda099e269b24cc6b4ad14f9ce8b0490c1599174070e792ecd70c"
 dependencies = [
- "crypto-bigint 0.5.5",
+ "crypto-bigint 0.6.1",
  "elliptic-curve 0.13.8",
  "elliptic-curve-tools",
  "generic-array 1.3.3",
  "hex",
+ "hybrid-array",
  "num",
  "rand_core 0.6.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ resolver = "2"
 
 [workspace.dependencies]
 # QuorumOS
-qos_core = { version = "0.6.1", default-features = false }
-qos_crypto = { version = "0.6.1", default-features = false }
-qos_nsm = { version = "0.6.1", default-features = false }
-qos_p256 = { version = "0.6.1", default-features = false }
+qos_core = { version = "0.10.2", default-features = false }
+qos_crypto = { version = "0.10.2", default-features = false }
+qos_nsm = { version = "0.10.2", default-features = false }
+qos_p256 = { version = "0.10.2", default-features = false }
 
 # Encoding and serialization
 base64 = { version = "0.22.0", default-features = false, features = ["std"] }

--- a/api_key_stamper/src/lib.rs
+++ b/api_key_stamper/src/lib.rs
@@ -111,14 +111,11 @@ impl TurnkeyP256ApiKey {
         let private_key_bytes = hex::decode(private_key.as_ref())
             .map_err(|e| StamperError::HexDecode(e.to_string()))?;
 
-        let public_key_bytes = if public_key.is_some() {
-            Some(
-                hex::decode(public_key.unwrap().as_ref())
-                    .map_err(|e| StamperError::HexDecode(e.to_string()))?,
-            )
-        } else {
-            None
-        };
+        let public_key_bytes = public_key
+            .map(|public_key| {
+                hex::decode(public_key.as_ref()).map_err(|e| StamperError::HexDecode(e.to_string()))
+            })
+            .transpose()?;
 
         Self::from_bytes(private_key_bytes, public_key_bytes)
     }

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -2229,8 +2229,6 @@ pub struct CreateTvcDeploymentIntent {
     pub health_check_port: u32,
     #[serde(default)]
     pub public_ingress_port: u32,
-    #[serde(default)]
-    pub egress_allowlist: ::core::option::Option<TvcEgressAllowlist>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -4101,18 +4099,6 @@ pub struct SparkStaticDepositDerivation {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SparkHtlcPreimageDerivation {}
-#[derive(Debug)]
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Clone, PartialEq)]
-pub struct TvcEgressAllowlist {
-    #[serde(default)]
-    pub urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[serde(default)]
-    pub hostnames: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[serde(default)]
-    pub ips: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
 /// Type of Activity, such as Add User, or Sign Transaction.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -2229,6 +2229,8 @@ pub struct CreateTvcDeploymentIntent {
     pub health_check_port: u32,
     #[serde(default)]
     pub public_ingress_port: u32,
+    #[serde(default)]
+    pub egress_allowlist: ::core::option::Option<TvcEgressAllowlist>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -4099,6 +4101,18 @@ pub struct SparkStaticDepositDerivation {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, Copy, PartialEq)]
 pub struct SparkHtlcPreimageDerivation {}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct TvcEgressAllowlist {
+    #[serde(default)]
+    pub urls: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[serde(default)]
+    pub hostnames: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[serde(default)]
+    pub ips: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Type of Activity, such as Add User, or Sign Transaction.
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -380,22 +380,22 @@ impl<S: Stamp> TurnkeyClient<S> {
             .await?;
 
         let status = res.status();
-        let content_type = res
-            .headers()
-            .get(CONTENT_TYPE)
-            .ok_or(TurnkeyClientError::MissingContentTypeHeader)?
-            .to_str()
-            .map_err(|e| TurnkeyClientError::HeaderToStrError(e.to_string()))?
-            .parse::<mime::Mime>()
-            .map_err(|e| TurnkeyClientError::HeaderFromStrError(e.to_string()))?;
+        let content_type = res.headers().get(CONTENT_TYPE).cloned();
         let text = res.text().await?;
 
         if !status.is_success() {
             return Err(TurnkeyClientError::UnexpectedHttpStatus(
                 status.as_u16(),
-                text,
+                http_error_body(status, text),
             ));
         }
+
+        let content_type = content_type
+            .ok_or(TurnkeyClientError::MissingContentTypeHeader)?
+            .to_str()
+            .map_err(|e| TurnkeyClientError::HeaderToStrError(e.to_string()))?
+            .parse::<mime::Mime>()
+            .map_err(|e| TurnkeyClientError::HeaderFromStrError(e.to_string()))?;
 
         if content_type != mime::APPLICATION_JSON {
             return Err(TurnkeyClientError::UnexpectedMimeType(
@@ -408,6 +408,24 @@ impl<S: Stamp> TurnkeyClient<S> {
 
         Ok(response)
     }
+}
+
+fn http_error_body(status: reqwest::StatusCode, body: String) -> String {
+    if status.is_server_error() {
+        return json_error_message(&body).unwrap_or(body);
+    }
+
+    body
+}
+
+fn json_error_message(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let message = value.get("message")?.as_str()?.trim();
+    if message.is_empty() {
+        return None;
+    }
+
+    Some(message.to_string())
 }
 
 #[cfg(test)]
@@ -525,6 +543,34 @@ mod test {
             TurnkeyClientError::UnexpectedHttpStatus(status, body) => {
                 assert_eq!(status, 500);
                 assert_eq!(body, "internal server error");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_server_error_with_json_body_exposes_message() {
+        let (client, server) = setup_client_and_server().await;
+
+        let response = ResponseTemplate::new(504).set_body_json(serde_json::json!({
+            "code": 13,
+            "message": "timed out while validating TVC image",
+            "details": [],
+            "turnkeyErrorCode": "",
+        }));
+        Mock::given(method("POST"))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+
+        let result = client
+            .process_activity(simple_activity_intent(), "/sign_raw_payload".to_string())
+            .await;
+
+        match result.unwrap_err() {
+            TurnkeyClientError::UnexpectedHttpStatus(status, body) => {
+                assert_eq!(status, 504);
+                assert_eq!(body, "timed out while validating TVC image");
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/enclave_encrypt/src/server.rs
+++ b/enclave_encrypt/src/server.rs
@@ -132,7 +132,7 @@ impl EnclaveEncryptServer {
             .user_id
             .as_ref()
             .ok_or(EnclaveEncryptError::InvalidUser)?
-            .to_string();
+            .clone();
         let data = ServerTargetData {
             target_public: self.target_public.to_bytes().to_vec().try_into()?,
             organization_id: self.organization_id.clone(),

--- a/proofs/src/syntactic_validation.rs
+++ b/proofs/src/syntactic_validation.rs
@@ -91,10 +91,10 @@ pub(super) fn nonce(n: &Option<ByteBuf>) -> Result<(), AttestError> {
 }
 
 fn bytes_512(val: &Option<ByteBuf>) -> Result<(), AttestError> {
-    if let Some(val) = val {
-        if val.len() > 512 {
-            return Err(AttestError::InvalidBytes);
-        }
+    if let Some(val) = val
+        && val.len() > 512
+    {
+        return Err(AttestError::InvalidBytes);
     }
 
     Ok(())

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -4248,10 +4248,6 @@ message CreateTvcDeploymentIntent {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Port to use for public ingress."}
   ];
-  TvcEgressAllowlist egress_allowlist = 17 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional egress allowlist metadata to include in the QOS manifest for TVC apps with egress enabled. This metadata is not enforced by QOS."}
-  ];
 }
 
 message CreateTvcManifestApprovalsIntent {
@@ -6596,18 +6592,3 @@ message SparkStaticDepositDerivation {
 }
 
 message SparkHtlcPreimageDerivation {}
-
-message TvcEgressAllowlist {
-  repeated string urls = 1 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "URL entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
-  ];
-  repeated string hostnames = 2 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Hostname entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
-  ];
-  repeated string ips = 3 [
-    (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "IP entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
-  ];
-}

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -4248,6 +4248,10 @@ message CreateTvcDeploymentIntent {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Port to use for public ingress."}
   ];
+  TvcEgressAllowlist egress_allowlist = 17 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional egress allowlist metadata to include in the QOS manifest for TVC apps with egress enabled. This metadata is not enforced by QOS."}
+  ];
 }
 
 message CreateTvcManifestApprovalsIntent {
@@ -6592,3 +6596,18 @@ message SparkStaticDepositDerivation {
 }
 
 message SparkHtlcPreimageDerivation {}
+
+message TvcEgressAllowlist {
+  repeated string urls = 1 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "URL entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
+  ];
+  repeated string hostnames = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Hostname entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
+  ];
+  repeated string ips = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "IP entries to include in the TVC deployment manifest egress allowlist metadata. This metadata is not enforced by QOS."}
+  ];
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.94"
 components = [ "rustfmt", "cargo", "clippy" ]
 profile = "minimal"

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -4,9 +4,9 @@ use crate::config::turnkey::{Config, StoredApiKey};
 use anyhow::{Context, Result, anyhow, bail};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use turnkey_client::generated::external::data::v1::TvcApp;
-use turnkey_client::generated::GetTvcAppRequest;
 use turnkey_client::TurnkeyClient;
+use turnkey_client::generated::GetTvcAppRequest;
+use turnkey_client::generated::external::data::v1::TvcApp;
 
 /// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
 /// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -101,6 +101,28 @@ struct ResolvedApproveInputs {
     post_target: Option<PostTarget>,
 }
 
+struct LoadedManifest {
+    manifest: VersionedManifest,
+    egress_allowlist: Option<EgressAllowlistReview>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EgressAllowlistReview {
+    #[serde(default)]
+    urls: Vec<String>,
+    #[serde(default)]
+    hostnames: Vec<String>,
+    #[serde(default)]
+    ips: Vec<String>,
+}
+
+impl EgressAllowlistReview {
+    fn is_empty(&self) -> bool {
+        self.urls.is_empty() && self.hostnames.is_empty() && self.ips.is_empty()
+    }
+}
+
 pub async fn run(args: Args, is_non_interactive: bool) -> anyhow::Result<()> {
     let inputs = if is_non_interactive {
         build_inputs_non_interactive(args).await?
@@ -120,10 +142,10 @@ async fn build_inputs_interactive(args: Args) -> anyhow::Result<ResolvedApproveI
         bail_required_in_non_interactive("--dangerous-skip-interactive")?;
     }
 
-    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
+    let (loaded_manifest, fetched_manifest_id) = load_manifest(&args).await?;
 
     if do_prompt_user {
-        interactive_approve(&manifest)?;
+        interactive_approve(&loaded_manifest)?;
     }
 
     let post_target = if !args.dry_run && !args.skip_post {
@@ -160,7 +182,7 @@ async fn build_inputs_interactive(args: Args) -> anyhow::Result<ResolvedApproveI
     };
 
     Ok(ResolvedApproveInputs {
-        manifest,
+        manifest: loaded_manifest.manifest,
         operator_seed: args.operator_seed,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
@@ -173,7 +195,7 @@ async fn build_inputs_non_interactive(args: Args) -> anyhow::Result<ResolvedAppr
         bail_required_in_non_interactive("--dangerous-skip-interactive")?;
     }
 
-    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
+    let (loaded_manifest, fetched_manifest_id) = load_manifest(&args).await?;
 
     let post_target = if !args.dry_run && !args.skip_post {
         let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
@@ -204,7 +226,7 @@ async fn build_inputs_non_interactive(args: Args) -> anyhow::Result<ResolvedAppr
     };
 
     Ok(ResolvedApproveInputs {
-        manifest,
+        manifest: loaded_manifest.manifest,
         operator_seed: args.operator_seed,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
@@ -237,7 +259,7 @@ async fn run_with_resolved_inputs(inputs: ResolvedApproveInputs) -> anyhow::Resu
     Ok(())
 }
 
-async fn load_manifest(args: &Args) -> anyhow::Result<(VersionedManifest, Option<String>)> {
+async fn load_manifest(args: &Args) -> anyhow::Result<(LoadedManifest, Option<String>)> {
     match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
         (_, Some(deploy_id)) => {
@@ -406,7 +428,9 @@ async fn generate_approval(
 }
 
 /// Walk the user through each section of the manifest for approval.
-fn interactive_approve(manifest: &VersionedManifest) -> anyhow::Result<()> {
+fn interactive_approve(loaded_manifest: &LoadedManifest) -> anyhow::Result<()> {
+    let manifest = &loaded_manifest.manifest;
+
     println!("\n========================================");
     println!("         MANIFEST APPROVAL");
     println!("========================================\n");
@@ -414,6 +438,9 @@ fn interactive_approve(manifest: &VersionedManifest) -> anyhow::Result<()> {
     review_namespace(manifest.namespace())?;
     review_enclave(manifest.enclave())?;
     review_pivot(manifest)?;
+    if let Some(allowlist) = &loaded_manifest.egress_allowlist {
+        review_egress_allowlist(allowlist)?;
+    }
     review_manifest_set(manifest.manifest_set())?;
     review_share_set(manifest.share_set())?;
 
@@ -481,6 +508,34 @@ fn review_pivot(manifest: &VersionedManifest) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve pivot binary?", "approval")
 }
 
+fn render_entries(label: &str, entries: &[String], out: &mut String) {
+    if entries.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(out, "  {label}:");
+    for entry in entries {
+        let _ = writeln!(out, "    {entry}");
+    }
+}
+
+fn render_egress_allowlist(allowlist: &EgressAllowlistReview) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "EGRESS ALLOWLIST");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let _ = writeln!(s, "  Metadata only; not enforced by QOS.");
+    render_entries("URLs", &allowlist.urls, &mut s);
+    render_entries("Hostnames", &allowlist.hostnames, &mut s);
+    render_entries("IPs", &allowlist.ips, &mut s);
+    let _ = writeln!(s);
+    s
+}
+
+fn review_egress_allowlist(allowlist: &EgressAllowlistReview) -> anyhow::Result<()> {
+    print!("{}", render_egress_allowlist(allowlist));
+    prompts::confirm_or_bail("Approve egress allowlist metadata?", "approval")
+}
+
 fn render_quorum_members(members: &[QuorumMember]) -> String {
     let mut s = String::new();
     for member in members.iter() {
@@ -521,18 +576,39 @@ fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve share set?", "approval")
 }
 
-async fn read_manifest_from_path(path: &Path) -> anyhow::Result<VersionedManifest> {
+fn parse_egress_allowlist(manifest_bytes: &[u8]) -> anyhow::Result<Option<EgressAllowlistReview>> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(manifest_bytes) else {
+        return Ok(None);
+    };
+
+    let Some(raw_allowlist) = value.get("egressAllowlist") else {
+        return Ok(None);
+    };
+
+    let allowlist: EgressAllowlistReview = serde_json::from_value(raw_allowlist.clone())
+        .context("failed to parse egressAllowlist metadata")?;
+    if allowlist.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(allowlist))
+}
+
+async fn read_manifest_from_path(path: &Path) -> anyhow::Result<LoadedManifest> {
     let content = read_file_to_string(path).await?;
     let manifest = VersionedManifest::try_from_slice_compat(content.as_bytes())
         .with_context(|| format!("failed to parse manifest JSON from: {}", path.display()))?;
-    Ok(manifest)
+    let egress_allowlist = parse_egress_allowlist(content.as_bytes())?;
+
+    Ok(LoadedManifest {
+        manifest,
+        egress_allowlist,
+    })
 }
 
 /// Fetch manifest from Turnkey using GetTvcDeployment API.
 /// Returns the manifest and its Turnkey manifest_id.
-async fn fetch_manifest_from_deploy(
-    deploy_id: &str,
-) -> anyhow::Result<(VersionedManifest, String)> {
+async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(LoadedManifest, String)> {
     println!("Fetching deployment {deploy_id}...");
 
     let auth = crate::client::build_client().await?;
@@ -558,10 +634,17 @@ async fn fetch_manifest_from_deploy(
 
     let manifest = VersionedManifest::try_from_slice_compat(&tvc_manifest.manifest)
         .context("failed to parse manifest from deployment")?;
+    let egress_allowlist = parse_egress_allowlist(&tvc_manifest.manifest)?;
 
     println!("✓ Manifest loaded (manifest_id: {})", tvc_manifest.id);
 
-    Ok((manifest, tvc_manifest.id))
+    Ok((
+        LoadedManifest {
+            manifest,
+            egress_allowlist,
+        },
+        tvc_manifest.id,
+    ))
 }
 
 #[cfg(test)]
@@ -619,6 +702,43 @@ mod tests {
         assert!(matches!(manifest, VersionedManifest::V2(_)));
         assert_eq!(manifest.manifest_set().threshold, 1);
         assert!(render_pivot(&manifest).contains("--flag"));
+    }
+
+    #[test]
+    fn parses_egress_allowlist_from_raw_manifest_json() {
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "egressAllowlist": {
+                "urls": ["https://api.example.com/v1"],
+                "hostnames": ["api.example.com"],
+                "ips": ["203.0.113.10"]
+            }
+        }))
+        .unwrap();
+
+        let allowlist = parse_egress_allowlist(&manifest_bytes)
+            .unwrap()
+            .expect("allowlist should parse");
+
+        assert_eq!(allowlist.urls, ["https://api.example.com/v1"]);
+        assert_eq!(allowlist.hostnames, ["api.example.com"]);
+        assert_eq!(allowlist.ips, ["203.0.113.10"]);
+    }
+
+    #[test]
+    fn render_egress_allowlist_includes_each_entry() {
+        let allowlist = EgressAllowlistReview {
+            urls: vec!["https://api.example.com/v1".into()],
+            hostnames: vec!["api.example.com".into()],
+            ips: vec!["203.0.113.10".into()],
+        };
+
+        let rendered = render_egress_allowlist(&allowlist);
+
+        assert!(rendered.contains("EGRESS ALLOWLIST"));
+        assert!(rendered.contains("not enforced"));
+        assert!(rendered.contains("https://api.example.com/v1"));
+        assert!(rendered.contains("api.example.com"));
+        assert!(rendered.contains("203.0.113.10"));
     }
 
     fn test_operator(id: &str) -> TvcOperator {

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -7,10 +7,9 @@ use crate::prompts::{bail_required_in_non_interactive, stdin_can_prompt};
 use crate::util::{read_file_to_string, write_file};
 use anyhow::{Context, anyhow, bail};
 use clap::{ArgGroup, Args as ClapArgs};
-use qos_core::protocol::QosHash;
 use qos_core::protocol::services::boot::Approval;
 use qos_core::protocol::services::boot::{
-    Manifest, ManifestSet, Namespace, NitroConfig, PivotConfig, QuorumMember, ShareSet,
+    ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
 };
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -95,7 +94,7 @@ struct PostTarget {
 }
 
 struct ResolvedApproveInputs {
-    manifest: Manifest,
+    manifest: VersionedManifest,
     operator_seed: Option<PathBuf>,
     approval_out: Option<PathBuf>,
     dry_run: bool,
@@ -238,7 +237,7 @@ async fn run_with_resolved_inputs(inputs: ResolvedApproveInputs) -> anyhow::Resu
     Ok(())
 }
 
-async fn load_manifest(args: &Args) -> anyhow::Result<(Manifest, Option<String>)> {
+async fn load_manifest(args: &Args) -> anyhow::Result<(VersionedManifest, Option<String>)> {
     match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
         (_, Some(deploy_id)) => {
@@ -252,7 +251,7 @@ async fn load_manifest(args: &Args) -> anyhow::Result<(Manifest, Option<String>)
 async fn sign_and_output(
     operator_seed: Option<&Path>,
     approval_out: Option<&Path>,
-    manifest: &Manifest,
+    manifest: &VersionedManifest,
 ) -> anyhow::Result<Approval> {
     let pair: Box<dyn crate::pair::Pair> = Box::new(load_operator_pair(operator_seed).await?);
 
@@ -385,11 +384,11 @@ fn manifest_approval_quorum_reached(deployment: &TvcDeployment) -> bool {
 
 async fn generate_approval(
     pair: Box<dyn crate::pair::Pair>,
-    manifest: &Manifest,
+    manifest: &VersionedManifest,
 ) -> anyhow::Result<Approval> {
     let public_key = pair.public_key();
     let member = manifest
-        .manifest_set
+        .manifest_set()
         .members
         .iter()
         .find(|m| m.pub_key == public_key)
@@ -401,22 +400,22 @@ async fn generate_approval(
             )
         })?;
 
-    let signature = pair.sign(manifest.qos_hash().to_vec()).await?;
+    let signature = pair.sign(manifest.manifest_hash().to_vec()).await?;
 
     Ok(Approval { signature, member })
 }
 
 /// Walk the user through each section of the manifest for approval.
-fn interactive_approve(manifest: &Manifest) -> anyhow::Result<()> {
+fn interactive_approve(manifest: &VersionedManifest) -> anyhow::Result<()> {
     println!("\n========================================");
     println!("         MANIFEST APPROVAL");
     println!("========================================\n");
 
-    review_namespace(&manifest.namespace)?;
-    review_enclave(&manifest.enclave)?;
-    review_pivot(&manifest.pivot)?;
-    review_manifest_set(&manifest.manifest_set)?;
-    review_share_set(&manifest.share_set)?;
+    review_namespace(manifest.namespace())?;
+    review_enclave(manifest.enclave())?;
+    review_pivot(manifest)?;
+    review_manifest_set(manifest.manifest_set())?;
+    review_share_set(manifest.share_set())?;
 
     println!("\n========================================");
     println!("    ALL SECTIONS APPROVED");
@@ -459,22 +458,26 @@ fn review_enclave(enclave: &NitroConfig) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve enclave configuration?", "approval")
 }
 
-fn render_pivot(pivot: &PivotConfig) -> String {
+fn render_pivot(manifest: &VersionedManifest) -> String {
     let mut s = String::new();
     let _ = writeln!(s, "PIVOT BINARY");
     let _ = writeln!(s, "─────────────────────────────────────");
-    let _ = writeln!(s, "  Pivot Binary Hash: {}", hex::encode(pivot.hash));
-    if pivot.args.is_empty() {
+    let _ = writeln!(
+        s,
+        "  Pivot Binary Hash: {}",
+        hex::encode(manifest.pivot_hash())
+    );
+    if manifest.args().is_empty() {
         let _ = writeln!(s, "  CLI Args: (none)");
     } else {
-        let _ = writeln!(s, "  CLI Args:\n   {}", pivot.args.join("\n   "));
+        let _ = writeln!(s, "  CLI Args:\n   {}", manifest.args().join("\n   "));
     }
     let _ = writeln!(s);
     s
 }
 
-fn review_pivot(pivot: &PivotConfig) -> anyhow::Result<()> {
-    print!("{}", render_pivot(pivot));
+fn review_pivot(manifest: &VersionedManifest) -> anyhow::Result<()> {
+    print!("{}", render_pivot(manifest));
     prompts::confirm_or_bail("Approve pivot binary?", "approval")
 }
 
@@ -518,16 +521,18 @@ fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve share set?", "approval")
 }
 
-async fn read_manifest_from_path(path: &Path) -> anyhow::Result<Manifest> {
+async fn read_manifest_from_path(path: &Path) -> anyhow::Result<VersionedManifest> {
     let content = read_file_to_string(path).await?;
-    let manifest: Manifest = serde_json::from_str(&content)
+    let manifest = VersionedManifest::try_from_slice_compat(content.as_bytes())
         .with_context(|| format!("failed to parse manifest JSON from: {}", path.display()))?;
     Ok(manifest)
 }
 
 /// Fetch manifest from Turnkey using GetTvcDeployment API.
 /// Returns the manifest and its Turnkey manifest_id.
-async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(Manifest, String)> {
+async fn fetch_manifest_from_deploy(
+    deploy_id: &str,
+) -> anyhow::Result<(VersionedManifest, String)> {
     println!("Fetching deployment {deploy_id}...");
 
     let auth = crate::client::build_client().await?;
@@ -551,7 +556,7 @@ async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(Manifest
         .manifest
         .ok_or_else(|| anyhow!("manifest not found in deployment"))?;
 
-    let manifest: Manifest = serde_json::from_slice(&tvc_manifest.manifest)
+    let manifest = VersionedManifest::try_from_slice_compat(&tvc_manifest.manifest)
         .context("failed to parse manifest from deployment")?;
 
     println!("✓ Manifest loaded (manifest_id: {})", tvc_manifest.id);
@@ -566,9 +571,54 @@ mod tests {
         TvcOperator, TvcOperatorApproval, TvcOperatorSet,
     };
 
-    fn fixture_manifest() -> Manifest {
-        serde_json::from_str(include_str!("../../../fixtures/manifest.json"))
+    fn fixture_manifest() -> VersionedManifest {
+        VersionedManifest::try_from_slice_compat(include_bytes!("../../../fixtures/manifest.json"))
             .expect("fixture manifest should parse")
+    }
+
+    #[test]
+    fn parses_v2_manifest() {
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "version": "v2",
+            "namespace": {
+                "name": "turnkey-prod",
+                "nonce": 1,
+                "quorumKey": "04a1"
+            },
+            "pivot": {
+                "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                "restart": "Never",
+                "bridgeConfig": [],
+                "debugMode": false,
+                "args": ["--flag"]
+            },
+            "manifestSet": {
+                "threshold": 1,
+                "members": [{
+                    "alias": "operator-alice",
+                    "pubKey": "04aabb"
+                }]
+            },
+            "shareSet": {
+                "threshold": 0,
+                "members": []
+            },
+            "enclave": {
+                "pcr0": "00",
+                "pcr1": "11",
+                "pcr2": "22",
+                "pcr3": "33",
+                "awsRootCertificate": "44",
+                "qosCommit": "test-commit"
+            }
+        }))
+        .unwrap();
+
+        let manifest = VersionedManifest::try_from_slice_compat(&manifest_bytes).unwrap();
+
+        assert!(matches!(manifest, VersionedManifest::V2(_)));
+        assert_eq!(manifest.manifest_set().threshold, 1);
+        assert!(render_pivot(&manifest).contains("--flag"));
     }
 
     fn test_operator(id: &str) -> TvcOperator {
@@ -632,7 +682,7 @@ mod tests {
     #[test]
     fn render_namespace_includes_name_nonce_and_quorum_key() {
         let manifest = fixture_manifest();
-        let rendered = render_namespace(&manifest.namespace);
+        let rendered = render_namespace(manifest.namespace());
         assert!(rendered.contains("NAMESPACE"));
         assert!(rendered.contains("turnkey-prod"));
         assert!(rendered.contains("Nonce:"));
@@ -642,7 +692,7 @@ mod tests {
     #[test]
     fn render_enclave_includes_all_four_pcrs() {
         let manifest = fixture_manifest();
-        let rendered = render_enclave(&manifest.enclave);
+        let rendered = render_enclave(manifest.enclave());
         assert!(rendered.contains("ENCLAVE (AWS Nitro)"));
         assert!(rendered.contains("PCR0"));
         assert!(rendered.contains("PCR1"));
@@ -653,7 +703,7 @@ mod tests {
     #[test]
     fn render_pivot_includes_header_and_args() {
         let manifest = fixture_manifest();
-        let rendered = render_pivot(&manifest.pivot);
+        let rendered = render_pivot(&manifest);
         assert!(rendered.contains("PIVOT BINARY"));
         assert!(rendered.contains("Pivot Binary Hash:"));
         assert!(rendered.contains("--flag"));
@@ -663,7 +713,7 @@ mod tests {
     #[test]
     fn render_manifest_set_includes_threshold_and_each_member() {
         let manifest = fixture_manifest();
-        let rendered = render_manifest_set(&manifest.manifest_set);
+        let rendered = render_manifest_set(manifest.manifest_set());
         assert!(rendered.contains("MANIFEST SET"));
         assert!(rendered.contains("Threshold: 2 of 3"));
         assert!(rendered.contains("operator-alice"));

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, anyhow, bail};
 use clap::{ArgGroup, Args as ClapArgs};
 use qos_core::protocol::services::boot::Approval;
 use qos_core::protocol::services::boot::{
-    ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
+    BridgeConfig, ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
 };
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -414,6 +414,7 @@ fn interactive_approve(manifest: &VersionedManifest) -> anyhow::Result<()> {
     review_namespace(manifest.namespace())?;
     review_enclave(manifest.enclave())?;
     review_pivot(manifest)?;
+    review_bridge_config(manifest)?;
     review_manifest_set(manifest.manifest_set())?;
     review_share_set(manifest.share_set())?;
 
@@ -479,6 +480,39 @@ fn render_pivot(manifest: &VersionedManifest) -> String {
 fn review_pivot(manifest: &VersionedManifest) -> anyhow::Result<()> {
     print!("{}", render_pivot(manifest));
     prompts::confirm_or_bail("Approve pivot binary?", "approval")
+}
+
+fn render_bridge_config(manifest: &VersionedManifest) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "BRIDGE CONFIG");
+    let _ = writeln!(s, "─────────────────────────────────────");
+    let bridge_config = manifest.bridge_config();
+    if bridge_config.is_empty() {
+        let _ = writeln!(s, "  Entries: (none)");
+    } else {
+        for (index, bridge) in bridge_config.iter().enumerate() {
+            let _ = writeln!(s, "  Entry {}:", index + 1);
+            match bridge {
+                BridgeConfig::Server { port, host } => {
+                    let _ = writeln!(s, "    Type: server");
+                    let _ = writeln!(s, "    Port: {port}");
+                    let _ = writeln!(s, "    Host: {host}");
+                }
+                BridgeConfig::Client { port, host } => {
+                    let _ = writeln!(s, "    Type: client");
+                    let _ = writeln!(s, "    Port: {port}");
+                    let _ = writeln!(s, "    Host: {}", host.as_deref().unwrap_or("null"));
+                }
+            }
+        }
+    }
+    let _ = writeln!(s);
+    s
+}
+
+fn review_bridge_config(manifest: &VersionedManifest) -> anyhow::Result<()> {
+    print!("{}", render_bridge_config(manifest));
+    prompts::confirm_or_bail("Approve bridge configuration?", "approval")
 }
 
 fn render_quorum_members(members: &[QuorumMember]) -> String {
@@ -574,6 +608,46 @@ mod tests {
     fn fixture_manifest() -> VersionedManifest {
         VersionedManifest::try_from_slice_compat(include_bytes!("../../../fixtures/manifest.json"))
             .expect("fixture manifest should parse")
+    }
+
+    fn manifest_with_bridge_config(bridge_config: serde_json::Value) -> VersionedManifest {
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "version": "v2",
+            "namespace": {
+                "name": "turnkey-prod",
+                "nonce": 1,
+                "quorumKey": "04a1"
+            },
+            "pivot": {
+                "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                "restart": "Never",
+                "bridgeConfig": bridge_config,
+                "debugMode": false,
+                "args": []
+            },
+            "manifestSet": {
+                "threshold": 1,
+                "members": [{
+                    "alias": "operator-alice",
+                    "pubKey": "04aabb"
+                }]
+            },
+            "shareSet": {
+                "threshold": 0,
+                "members": []
+            },
+            "enclave": {
+                "pcr0": "00",
+                "pcr1": "11",
+                "pcr2": "22",
+                "pcr3": "33",
+                "awsRootCertificate": "44",
+                "qosCommit": "test-commit"
+            }
+        }))
+        .unwrap();
+
+        VersionedManifest::try_from_slice_compat(&manifest_bytes).unwrap()
     }
 
     #[test]
@@ -708,6 +782,48 @@ mod tests {
         assert!(rendered.contains("Pivot Binary Hash:"));
         assert!(rendered.contains("--flag"));
         assert!(rendered.contains("positional"));
+    }
+
+    #[test]
+    fn render_bridge_config_reports_no_entries() {
+        let manifest = manifest_with_bridge_config(serde_json::json!([]));
+
+        let rendered = render_bridge_config(&manifest);
+
+        assert!(rendered.contains("BRIDGE CONFIG"));
+        assert!(rendered.contains("(none)"));
+    }
+
+    #[test]
+    fn render_bridge_config_includes_server_entries() {
+        let manifest = fixture_manifest();
+
+        let rendered = render_bridge_config(&manifest);
+
+        assert!(rendered.contains("BRIDGE CONFIG"));
+        assert!(rendered.contains("Entry 1:"));
+        assert!(rendered.contains("Type: server"));
+        assert!(rendered.contains("Port: 3000"));
+        assert!(rendered.contains("Host: 0.0.0.0"));
+    }
+
+    #[test]
+    fn render_bridge_config_includes_client_entries_with_null_host() {
+        let manifest = manifest_with_bridge_config(serde_json::json!([
+            {
+                "type": "client",
+                "port": 0,
+                "host": null
+            }
+        ]));
+
+        let rendered = render_bridge_config(&manifest);
+
+        assert!(rendered.contains("BRIDGE CONFIG"));
+        assert!(rendered.contains("Entry 1:"));
+        assert!(rendered.contains("Type: client"));
+        assert!(rendered.contains("Port: 0"));
+        assert!(rendered.contains("Host: null"));
     }
 
     #[test]

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -101,28 +101,6 @@ struct ResolvedApproveInputs {
     post_target: Option<PostTarget>,
 }
 
-struct LoadedManifest {
-    manifest: VersionedManifest,
-    egress_allowlist: Option<EgressAllowlistReview>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct EgressAllowlistReview {
-    #[serde(default)]
-    urls: Vec<String>,
-    #[serde(default)]
-    hostnames: Vec<String>,
-    #[serde(default)]
-    ips: Vec<String>,
-}
-
-impl EgressAllowlistReview {
-    fn is_empty(&self) -> bool {
-        self.urls.is_empty() && self.hostnames.is_empty() && self.ips.is_empty()
-    }
-}
-
 pub async fn run(args: Args, is_non_interactive: bool) -> anyhow::Result<()> {
     let inputs = if is_non_interactive {
         build_inputs_non_interactive(args).await?
@@ -142,10 +120,10 @@ async fn build_inputs_interactive(args: Args) -> anyhow::Result<ResolvedApproveI
         bail_required_in_non_interactive("--dangerous-skip-interactive")?;
     }
 
-    let (loaded_manifest, fetched_manifest_id) = load_manifest(&args).await?;
+    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
 
     if do_prompt_user {
-        interactive_approve(&loaded_manifest)?;
+        interactive_approve(&manifest)?;
     }
 
     let post_target = if !args.dry_run && !args.skip_post {
@@ -182,7 +160,7 @@ async fn build_inputs_interactive(args: Args) -> anyhow::Result<ResolvedApproveI
     };
 
     Ok(ResolvedApproveInputs {
-        manifest: loaded_manifest.manifest,
+        manifest,
         operator_seed: args.operator_seed,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
@@ -195,7 +173,7 @@ async fn build_inputs_non_interactive(args: Args) -> anyhow::Result<ResolvedAppr
         bail_required_in_non_interactive("--dangerous-skip-interactive")?;
     }
 
-    let (loaded_manifest, fetched_manifest_id) = load_manifest(&args).await?;
+    let (manifest, fetched_manifest_id) = load_manifest(&args).await?;
 
     let post_target = if !args.dry_run && !args.skip_post {
         let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
@@ -226,7 +204,7 @@ async fn build_inputs_non_interactive(args: Args) -> anyhow::Result<ResolvedAppr
     };
 
     Ok(ResolvedApproveInputs {
-        manifest: loaded_manifest.manifest,
+        manifest,
         operator_seed: args.operator_seed,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
@@ -259,7 +237,7 @@ async fn run_with_resolved_inputs(inputs: ResolvedApproveInputs) -> anyhow::Resu
     Ok(())
 }
 
-async fn load_manifest(args: &Args) -> anyhow::Result<(LoadedManifest, Option<String>)> {
+async fn load_manifest(args: &Args) -> anyhow::Result<(VersionedManifest, Option<String>)> {
     match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
         (_, Some(deploy_id)) => {
@@ -428,9 +406,7 @@ async fn generate_approval(
 }
 
 /// Walk the user through each section of the manifest for approval.
-fn interactive_approve(loaded_manifest: &LoadedManifest) -> anyhow::Result<()> {
-    let manifest = &loaded_manifest.manifest;
-
+fn interactive_approve(manifest: &VersionedManifest) -> anyhow::Result<()> {
     println!("\n========================================");
     println!("         MANIFEST APPROVAL");
     println!("========================================\n");
@@ -438,9 +414,6 @@ fn interactive_approve(loaded_manifest: &LoadedManifest) -> anyhow::Result<()> {
     review_namespace(manifest.namespace())?;
     review_enclave(manifest.enclave())?;
     review_pivot(manifest)?;
-    if let Some(allowlist) = &loaded_manifest.egress_allowlist {
-        review_egress_allowlist(allowlist)?;
-    }
     review_manifest_set(manifest.manifest_set())?;
     review_share_set(manifest.share_set())?;
 
@@ -508,34 +481,6 @@ fn review_pivot(manifest: &VersionedManifest) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve pivot binary?", "approval")
 }
 
-fn render_entries(label: &str, entries: &[String], out: &mut String) {
-    if entries.is_empty() {
-        return;
-    }
-
-    let _ = writeln!(out, "  {label}:");
-    for entry in entries {
-        let _ = writeln!(out, "    {entry}");
-    }
-}
-
-fn render_egress_allowlist(allowlist: &EgressAllowlistReview) -> String {
-    let mut s = String::new();
-    let _ = writeln!(s, "EGRESS ALLOWLIST");
-    let _ = writeln!(s, "─────────────────────────────────────");
-    let _ = writeln!(s, "  Metadata only; not enforced by QOS.");
-    render_entries("URLs", &allowlist.urls, &mut s);
-    render_entries("Hostnames", &allowlist.hostnames, &mut s);
-    render_entries("IPs", &allowlist.ips, &mut s);
-    let _ = writeln!(s);
-    s
-}
-
-fn review_egress_allowlist(allowlist: &EgressAllowlistReview) -> anyhow::Result<()> {
-    print!("{}", render_egress_allowlist(allowlist));
-    prompts::confirm_or_bail("Approve egress allowlist metadata?", "approval")
-}
-
 fn render_quorum_members(members: &[QuorumMember]) -> String {
     let mut s = String::new();
     for member in members.iter() {
@@ -576,39 +521,18 @@ fn review_share_set(set: &ShareSet) -> anyhow::Result<()> {
     prompts::confirm_or_bail("Approve share set?", "approval")
 }
 
-fn parse_egress_allowlist(manifest_bytes: &[u8]) -> anyhow::Result<Option<EgressAllowlistReview>> {
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(manifest_bytes) else {
-        return Ok(None);
-    };
-
-    let Some(raw_allowlist) = value.get("egressAllowlist") else {
-        return Ok(None);
-    };
-
-    let allowlist: EgressAllowlistReview = serde_json::from_value(raw_allowlist.clone())
-        .context("failed to parse egressAllowlist metadata")?;
-    if allowlist.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(allowlist))
-}
-
-async fn read_manifest_from_path(path: &Path) -> anyhow::Result<LoadedManifest> {
+async fn read_manifest_from_path(path: &Path) -> anyhow::Result<VersionedManifest> {
     let content = read_file_to_string(path).await?;
     let manifest = VersionedManifest::try_from_slice_compat(content.as_bytes())
         .with_context(|| format!("failed to parse manifest JSON from: {}", path.display()))?;
-    let egress_allowlist = parse_egress_allowlist(content.as_bytes())?;
-
-    Ok(LoadedManifest {
-        manifest,
-        egress_allowlist,
-    })
+    Ok(manifest)
 }
 
 /// Fetch manifest from Turnkey using GetTvcDeployment API.
 /// Returns the manifest and its Turnkey manifest_id.
-async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(LoadedManifest, String)> {
+async fn fetch_manifest_from_deploy(
+    deploy_id: &str,
+) -> anyhow::Result<(VersionedManifest, String)> {
     println!("Fetching deployment {deploy_id}...");
 
     let auth = crate::client::build_client().await?;
@@ -634,17 +558,10 @@ async fn fetch_manifest_from_deploy(deploy_id: &str) -> anyhow::Result<(LoadedMa
 
     let manifest = VersionedManifest::try_from_slice_compat(&tvc_manifest.manifest)
         .context("failed to parse manifest from deployment")?;
-    let egress_allowlist = parse_egress_allowlist(&tvc_manifest.manifest)?;
 
     println!("✓ Manifest loaded (manifest_id: {})", tvc_manifest.id);
 
-    Ok((
-        LoadedManifest {
-            manifest,
-            egress_allowlist,
-        },
-        tvc_manifest.id,
-    ))
+    Ok((manifest, tvc_manifest.id))
 }
 
 #[cfg(test)]
@@ -702,43 +619,6 @@ mod tests {
         assert!(matches!(manifest, VersionedManifest::V2(_)));
         assert_eq!(manifest.manifest_set().threshold, 1);
         assert!(render_pivot(&manifest).contains("--flag"));
-    }
-
-    #[test]
-    fn parses_egress_allowlist_from_raw_manifest_json() {
-        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
-            "egressAllowlist": {
-                "urls": ["https://api.example.com/v1"],
-                "hostnames": ["api.example.com"],
-                "ips": ["203.0.113.10"]
-            }
-        }))
-        .unwrap();
-
-        let allowlist = parse_egress_allowlist(&manifest_bytes)
-            .unwrap()
-            .expect("allowlist should parse");
-
-        assert_eq!(allowlist.urls, ["https://api.example.com/v1"]);
-        assert_eq!(allowlist.hostnames, ["api.example.com"]);
-        assert_eq!(allowlist.ips, ["203.0.113.10"]);
-    }
-
-    #[test]
-    fn render_egress_allowlist_includes_each_entry() {
-        let allowlist = EgressAllowlistReview {
-            urls: vec!["https://api.example.com/v1".into()],
-            hostnames: vec!["api.example.com".into()],
-            ips: vec!["203.0.113.10".into()],
-        };
-
-        let rendered = render_egress_allowlist(&allowlist);
-
-        assert!(rendered.contains("EGRESS ALLOWLIST"));
-        assert!(rendered.contains("not enforced"));
-        assert!(rendered.contains("https://api.example.com/v1"));
-        assert!(rendered.contains("api.example.com"));
-        assert!(rendered.contains("203.0.113.10"));
     }
 
     fn test_operator(id: &str) -> TvcOperator {

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -28,6 +28,9 @@ Required deployment fields:
 
 Optional deployment fields:
   --qos-version / TVC_QOS_VERSION (defaults to 0.10.2)
+  --egress-allowed-url / TVC_EGRESS_ALLOWED_URLS
+  --egress-allowed-hostname / TVC_EGRESS_ALLOWED_HOSTNAMES
+  --egress-allowed-ip / TVC_EGRESS_ALLOWED_IPS
 
 Special rules:
   --pivot-args replaces the config file's list entirely (does not append).
@@ -137,6 +140,39 @@ struct Overrides {
     /// This is usually the port your server listens on for external requests.
     #[arg(long, env = "TVC_PUBLIC_INGRESS_PORT")]
     pub public_ingress_port: Option<u16>,
+
+    /// URL metadata entries to include in the manifest egress allowlist.
+    ///
+    /// These entries are for operator review only and are not enforced by QOS.
+    #[arg(
+        long = "egress-allowed-url",
+        value_name = "URL",
+        value_delimiter = ',',
+        env = "TVC_EGRESS_ALLOWED_URLS"
+    )]
+    pub egress_allowed_urls: Vec<String>,
+
+    /// Hostname metadata entries to include in the manifest egress allowlist.
+    ///
+    /// These entries are for operator review only and are not enforced by QOS.
+    #[arg(
+        long = "egress-allowed-hostname",
+        value_name = "HOSTNAME",
+        value_delimiter = ',',
+        env = "TVC_EGRESS_ALLOWED_HOSTNAMES"
+    )]
+    pub egress_allowed_hostnames: Vec<String>,
+
+    /// IP metadata entries to include in the manifest egress allowlist.
+    ///
+    /// These entries are for operator review only and are not enforced by QOS.
+    #[arg(
+        long = "egress-allowed-ip",
+        value_name = "IP",
+        value_delimiter = ',',
+        env = "TVC_EGRESS_ALLOWED_IPS"
+    )]
+    pub egress_allowed_ips: Vec<String>,
 }
 
 struct ResolvedDeployInputs {
@@ -301,6 +337,15 @@ fn apply_overrides(config: &mut DeployConfig, overrides: &Overrides) {
     if let Some(v) = overrides.public_ingress_port {
         config.public_ingress_port = v;
     }
+    if !overrides.egress_allowed_urls.is_empty() {
+        config.egress_allowlist.urls = overrides.egress_allowed_urls.clone();
+    }
+    if !overrides.egress_allowed_hostnames.is_empty() {
+        config.egress_allowlist.hostnames = overrides.egress_allowed_hostnames.clone();
+    }
+    if !overrides.egress_allowed_ips.is_empty() {
+        config.egress_allowlist.ips = overrides.egress_allowed_ips.clone();
+    }
 }
 
 fn invalid_deploy_config_error(errors: DeployConfigValidationErrors) -> anyhow::Error {
@@ -355,6 +400,7 @@ fn build_create_intent(
         health_check_type: deploy_config.health_check_type,
         health_check_port: deploy_config.health_check_port as u32,
         public_ingress_port: deploy_config.public_ingress_port as u32,
+        egress_allowlist: deploy_config.egress_allowlist.to_intent(),
     }
 }
 
@@ -670,6 +716,31 @@ mod tests {
         assert_eq!(intent.debug_mode, Some(true));
     }
 
+    #[test]
+    fn build_intent_forwards_egress_allowlist() {
+        let mut cfg = file_config();
+        cfg.egress_allowlist.urls = vec!["https://api.example.com/v1".into()];
+        cfg.egress_allowlist.hostnames = vec!["api.example.com".into()];
+        cfg.egress_allowlist.ips = vec!["203.0.113.10".into()];
+
+        let intent = build_create_intent(&cfg, "image-url".to_string(), None);
+        let allowlist = intent
+            .egress_allowlist
+            .expect("allowlist should be present");
+
+        assert_eq!(allowlist.urls, ["https://api.example.com/v1"]);
+        assert_eq!(allowlist.hostnames, ["api.example.com"]);
+        assert_eq!(allowlist.ips, ["203.0.113.10"]);
+    }
+
+    #[test]
+    fn build_intent_omits_empty_egress_allowlist() {
+        let cfg = file_config();
+        let intent = build_create_intent(&cfg, "image-url".to_string(), None);
+
+        assert_eq!(intent.egress_allowlist, None);
+    }
+
     /// Exercises every override flag via clap parsing so flag renames or
     /// removals fail this test. The other override tests construct `Args` by
     /// field name and would silently pass.
@@ -702,6 +773,12 @@ mod tests {
             "8080",
             "--public-ingress-port",
             "9090",
+            "--egress-allowed-url",
+            "https://api.example.com/v1",
+            "--egress-allowed-hostname",
+            "api.example.com",
+            "--egress-allowed-ip",
+            "203.0.113.10",
             "--pivot-pull-secret",
             pull_secret_path,
             "--dangerous-deploy-debug-mode",
@@ -728,6 +805,7 @@ mod tests {
         assert_ne!(resolved.pivot_args, template.pivot_args);
         assert_ne!(resolved.health_check_port, template.health_check_port);
         assert_ne!(resolved.public_ingress_port, template.public_ingress_port);
+        assert_ne!(resolved.egress_allowlist, template.egress_allowlist);
         assert_ne!(
             resolved.dangerous_deploy_debug_mode,
             template.dangerous_deploy_debug_mode
@@ -742,6 +820,12 @@ mod tests {
         assert_eq!(resolved.pivot_args, vec!["arg1", "arg2"]);
         assert_eq!(resolved.health_check_port, 8080);
         assert_eq!(resolved.public_ingress_port, 9090);
+        assert_eq!(
+            resolved.egress_allowlist.urls,
+            ["https://api.example.com/v1"]
+        );
+        assert_eq!(resolved.egress_allowlist.hostnames, ["api.example.com"]);
+        assert_eq!(resolved.egress_allowlist.ips, ["203.0.113.10"]);
         assert!(resolved.dangerous_deploy_debug_mode);
 
         // pivot_pull_secret isn't part of apply_overrides; verify clap captured the path.

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -28,9 +28,6 @@ Required deployment fields:
 
 Optional deployment fields:
   --qos-version / TVC_QOS_VERSION (defaults to 0.10.2)
-  --egress-allowed-url / TVC_EGRESS_ALLOWED_URLS
-  --egress-allowed-hostname / TVC_EGRESS_ALLOWED_HOSTNAMES
-  --egress-allowed-ip / TVC_EGRESS_ALLOWED_IPS
 
 Special rules:
   --pivot-args replaces the config file's list entirely (does not append).
@@ -140,39 +137,6 @@ struct Overrides {
     /// This is usually the port your server listens on for external requests.
     #[arg(long, env = "TVC_PUBLIC_INGRESS_PORT")]
     pub public_ingress_port: Option<u16>,
-
-    /// URL metadata entries to include in the manifest egress allowlist.
-    ///
-    /// These entries are for operator review only and are not enforced by QOS.
-    #[arg(
-        long = "egress-allowed-url",
-        value_name = "URL",
-        value_delimiter = ',',
-        env = "TVC_EGRESS_ALLOWED_URLS"
-    )]
-    pub egress_allowed_urls: Vec<String>,
-
-    /// Hostname metadata entries to include in the manifest egress allowlist.
-    ///
-    /// These entries are for operator review only and are not enforced by QOS.
-    #[arg(
-        long = "egress-allowed-hostname",
-        value_name = "HOSTNAME",
-        value_delimiter = ',',
-        env = "TVC_EGRESS_ALLOWED_HOSTNAMES"
-    )]
-    pub egress_allowed_hostnames: Vec<String>,
-
-    /// IP metadata entries to include in the manifest egress allowlist.
-    ///
-    /// These entries are for operator review only and are not enforced by QOS.
-    #[arg(
-        long = "egress-allowed-ip",
-        value_name = "IP",
-        value_delimiter = ',',
-        env = "TVC_EGRESS_ALLOWED_IPS"
-    )]
-    pub egress_allowed_ips: Vec<String>,
 }
 
 struct ResolvedDeployInputs {
@@ -337,15 +301,6 @@ fn apply_overrides(config: &mut DeployConfig, overrides: &Overrides) {
     if let Some(v) = overrides.public_ingress_port {
         config.public_ingress_port = v;
     }
-    if !overrides.egress_allowed_urls.is_empty() {
-        config.egress_allowlist.urls = overrides.egress_allowed_urls.clone();
-    }
-    if !overrides.egress_allowed_hostnames.is_empty() {
-        config.egress_allowlist.hostnames = overrides.egress_allowed_hostnames.clone();
-    }
-    if !overrides.egress_allowed_ips.is_empty() {
-        config.egress_allowlist.ips = overrides.egress_allowed_ips.clone();
-    }
 }
 
 fn invalid_deploy_config_error(errors: DeployConfigValidationErrors) -> anyhow::Error {
@@ -400,7 +355,6 @@ fn build_create_intent(
         health_check_type: deploy_config.health_check_type,
         health_check_port: deploy_config.health_check_port as u32,
         public_ingress_port: deploy_config.public_ingress_port as u32,
-        egress_allowlist: deploy_config.egress_allowlist.to_intent(),
     }
 }
 
@@ -716,31 +670,6 @@ mod tests {
         assert_eq!(intent.debug_mode, Some(true));
     }
 
-    #[test]
-    fn build_intent_forwards_egress_allowlist() {
-        let mut cfg = file_config();
-        cfg.egress_allowlist.urls = vec!["https://api.example.com/v1".into()];
-        cfg.egress_allowlist.hostnames = vec!["api.example.com".into()];
-        cfg.egress_allowlist.ips = vec!["203.0.113.10".into()];
-
-        let intent = build_create_intent(&cfg, "image-url".to_string(), None);
-        let allowlist = intent
-            .egress_allowlist
-            .expect("allowlist should be present");
-
-        assert_eq!(allowlist.urls, ["https://api.example.com/v1"]);
-        assert_eq!(allowlist.hostnames, ["api.example.com"]);
-        assert_eq!(allowlist.ips, ["203.0.113.10"]);
-    }
-
-    #[test]
-    fn build_intent_omits_empty_egress_allowlist() {
-        let cfg = file_config();
-        let intent = build_create_intent(&cfg, "image-url".to_string(), None);
-
-        assert_eq!(intent.egress_allowlist, None);
-    }
-
     /// Exercises every override flag via clap parsing so flag renames or
     /// removals fail this test. The other override tests construct `Args` by
     /// field name and would silently pass.
@@ -773,12 +702,6 @@ mod tests {
             "8080",
             "--public-ingress-port",
             "9090",
-            "--egress-allowed-url",
-            "https://api.example.com/v1",
-            "--egress-allowed-hostname",
-            "api.example.com",
-            "--egress-allowed-ip",
-            "203.0.113.10",
             "--pivot-pull-secret",
             pull_secret_path,
             "--dangerous-deploy-debug-mode",
@@ -805,7 +728,6 @@ mod tests {
         assert_ne!(resolved.pivot_args, template.pivot_args);
         assert_ne!(resolved.health_check_port, template.health_check_port);
         assert_ne!(resolved.public_ingress_port, template.public_ingress_port);
-        assert_ne!(resolved.egress_allowlist, template.egress_allowlist);
         assert_ne!(
             resolved.dangerous_deploy_debug_mode,
             template.dangerous_deploy_debug_mode
@@ -820,12 +742,6 @@ mod tests {
         assert_eq!(resolved.pivot_args, vec!["arg1", "arg2"]);
         assert_eq!(resolved.health_check_port, 8080);
         assert_eq!(resolved.public_ingress_port, 9090);
-        assert_eq!(
-            resolved.egress_allowlist.urls,
-            ["https://api.example.com/v1"]
-        );
-        assert_eq!(resolved.egress_allowlist.hostnames, ["api.example.com"]);
-        assert_eq!(resolved.egress_allowlist.ips, ["203.0.113.10"]);
         assert!(resolved.dangerous_deploy_debug_mode);
 
         // pivot_pull_secret isn't part of apply_overrides; verify clap captured the path.

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -188,10 +188,8 @@ async fn build_inputs_interactive(args: Args) -> Result<ResolvedDeployInputs> {
         }
     }
 
-    if config_updated {
-        if let Some(path) = &config_path {
-            offer_to_save_config(path, &config, file_loaded)?;
-        }
+    if config_updated && let Some(path) = &config_path {
+        offer_to_save_config(path, &config, file_loaded)?;
     }
     let pivot_pull_secret = read_pivot_pull_secret(pivot_pull_secret.as_deref()).await?;
 

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -22,10 +22,12 @@ omitted, all required deployment fields must be provided by flags or env vars.
 
 Required deployment fields:
   --app-id / TVC_APP_ID
-  --qos-version / TVC_QOS_VERSION
   --pivot-image-url / TVC_PIVOT_IMAGE_URL
   --pivot-path / TVC_PIVOT_PATH
   --expected-pivot-digest / TVC_EXPECTED_PIVOT_DIGEST
+
+Optional deployment fields:
+  --qos-version / TVC_QOS_VERSION (defaults to 0.10.2)
 
 Special rules:
   --pivot-args replaces the config file's list entirely (does not append).
@@ -52,7 +54,6 @@ Examples:
   TVC_API_KEY_PUBLIC=... \
   TVC_API_KEY_PRIVATE=... \
   TVC_APP_ID=... \
-  TVC_QOS_VERSION=... \
   TVC_PIVOT_PATH=... \
   TVC_PIVOT_IMAGE_URL=... \
   TVC_EXPECTED_PIVOT_DIGEST=... \
@@ -442,6 +443,7 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::deploy::DEFAULT_QOS_VERSION;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -460,7 +462,6 @@ mod tests {
     fn all_required_flags() -> Args {
         let overrides = Overrides {
             app_id: Some("flag-app-id".into()),
-            qos_version: Some("flag-qos".into()),
             pivot_image_url: Some("flag-image".into()),
             expected_pivot_digest: Some("flag-digest".into()),
             pivot_path: Some("flag-path".into()),
@@ -555,7 +556,7 @@ mod tests {
         let resolved = run_resolve(&all_required_flags()).unwrap();
         // Required fields come from flags.
         assert_eq!(resolved.app_id, "flag-app-id");
-        assert_eq!(resolved.qos_version, "flag-qos");
+        assert_eq!(resolved.qos_version, DEFAULT_QOS_VERSION);
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");
         assert_eq!(resolved.expected_pivot_digest, "flag-digest");
@@ -573,7 +574,6 @@ mod tests {
         let err = run_resolve(&Default::default()).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("app_id"), "{msg}");
-        assert!(msg.contains("qos_version"), "{msg}");
         assert!(msg.contains("pivot_container_image_url"), "{msg}");
         assert!(msg.contains("pivot_path"), "{msg}");
         assert!(msg.contains("expected_pivot_digest"), "{msg}");
@@ -763,7 +763,7 @@ mod tests {
 
         let resolved = run_resolve(&args).unwrap();
         assert_eq!(resolved.app_id, "flag-app-id");
-        assert_eq!(resolved.qos_version, "flag-qos");
+        assert_eq!(resolved.qos_version, DEFAULT_QOS_VERSION);
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");
         assert_eq!(resolved.expected_pivot_digest, "flag-digest");

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -6,7 +6,7 @@ use crate::provisioning::{
 use crate::util::write_file;
 use anyhow::{Context, bail};
 use clap::Args as ClapArgs;
-use qos_core::protocol::services::boot::{Approval, ManifestEnvelope};
+use qos_core::protocol::services::boot::{Approval, VersionedManifestEnvelope};
 use qos_nsm::types::NsmDigest;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -87,8 +87,9 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         bail!("manifest envelope missing in provisioning details response");
     }
 
-    let manifest_envelope: ManifestEnvelope = serde_json::from_slice(&manifest_envelope_bytes)
-        .context("failed to parse manifest envelope from provisioning details")?;
+    let manifest_envelope =
+        VersionedManifestEnvelope::try_from_slice_compat(&manifest_envelope_bytes)
+            .context("failed to parse manifest envelope from provisioning details")?;
 
     let summary = build_summary_with_optional_verify(
         &attestation_document,
@@ -129,7 +130,7 @@ async fn write_provision_bundle(path: &Path, bundle: &ProvisionBundle) -> anyhow
 
 fn build_summary_with_optional_verify(
     cose_sign1_der: &[u8],
-    manifest_envelope: &ManifestEnvelope,
+    manifest_envelope: &VersionedManifestEnvelope,
     dangerous_skip_verification: bool,
     validation_time_override: Option<u64>,
 ) -> anyhow::Result<AttestationSummary> {
@@ -159,9 +160,9 @@ fn build_summary_with_optional_verify(
             .collect(),
         certificate_len: attestation_doc.certificate.len(),
         ca_bundle_cert_count: attestation_doc.cabundle.len(),
-        manifest_set_threshold: manifest_envelope.manifest.manifest_set.threshold,
-        manifest_set_approvals: approval_summaries(&manifest_envelope.manifest_set_approvals),
-        share_set_approvals: approval_summaries(&manifest_envelope.share_set_approvals),
+        manifest_set_threshold: manifest_envelope.manifest_set().threshold,
+        manifest_set_approvals: approval_summaries(manifest_envelope.manifest_set_approvals()),
+        share_set_approvals: approval_summaries(manifest_envelope.share_set_approvals()),
         module_id: attestation_doc.module_id,
         digest: attestation_doc.digest.into(),
         timestamp_ms: attestation_doc.timestamp,
@@ -235,7 +236,7 @@ fn print_approval_summary_entries(approvals: &[ApprovalSummary]) {
 mod tests {
     use super::build_summary_with_optional_verify;
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-    use qos_core::protocol::services::boot::ManifestEnvelope;
+    use qos_core::protocol::services::boot::{ManifestEnvelope, VersionedManifestEnvelope};
     use serde::Deserialize;
 
     #[derive(Debug, Deserialize)]
@@ -261,7 +262,7 @@ mod tests {
 
         let summary = build_summary_with_optional_verify(
             &attestation_document,
-            &fixture.manifest_envelope,
+            &VersionedManifestEnvelope::from(fixture.manifest_envelope.clone()),
             false,
             Some(fixture.validation_time_secs),
         )
@@ -286,6 +287,7 @@ mod tests {
             .unwrap();
         let mut manifest_envelope = fixture.manifest_envelope;
         manifest_envelope.manifest_set_approvals.clear();
+        let manifest_envelope = VersionedManifestEnvelope::from(manifest_envelope);
 
         assert!(
             build_summary_with_optional_verify(

--- a/tvc/src/commands/display.rs
+++ b/tvc/src/commands/display.rs
@@ -1,11 +1,7 @@
 //! Shared display helpers for CLI output.
 
 pub fn yes_no(value: bool) -> &'static str {
-    if value {
-        "yes"
-    } else {
-        "no"
-    }
+    if value { "yes" } else { "no" }
 }
 
 pub fn format_egress_enabled(enable_egress: bool) -> String {

--- a/tvc/src/commands/keys/generate_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_quorum_key.rs
@@ -10,7 +10,7 @@ use clap::Args as ClapArgs;
 use qos_p256::{P256Pair, P256Public};
 use std::fs;
 use std::path::PathBuf;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 #[derive(Debug, ClapArgs)]
 #[command(about, long_about = None)]
@@ -34,15 +34,7 @@ struct OperatorPublicKey {
     public: P256Public,
 }
 
-struct PlaintextShares(Vec<Vec<u8>>);
-
-impl Drop for PlaintextShares {
-    fn drop(&mut self) {
-        for share in &mut self.0 {
-            share.as_mut_slice().zeroize();
-        }
-    }
-}
+struct PlaintextShares(Vec<Zeroizing<Vec<u8>>>);
 
 /// Run the quorum key generation command.
 pub async fn run(args: Args) -> Result<()> {
@@ -113,7 +105,7 @@ fn generate_and_encrypt_shares(
     let quorum_key_public = hex::encode(quorum_pair.public_key().to_bytes());
 
     let plaintext_shares = qos_crypto::shamir::shares_generate(
-        quorum_pair.to_master_seed(),
+        &quorum_pair.to_master_seed()[..],
         shares as usize,
         threshold as usize,
     )
@@ -126,7 +118,7 @@ fn generate_and_encrypt_shares(
         .map(|(operator_public, share)| {
             let encrypted_share = operator_public
                 .public
-                .encrypt(share)
+                .encrypt(share.as_slice())
                 .map_err(|e| anyhow::anyhow!("failed to encrypt quorum key share: {e:?}"))?;
 
             Ok(EncryptedShareMetadata {
@@ -199,11 +191,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let reconstructed = qos_crypto::shamir::shares_reconstruct(&decrypted_shares[..2])
-            .unwrap()
-            .try_into()
-            .map(|seed: [u8; MASTER_SEED_LEN]| P256Pair::from_master_seed(&seed).unwrap())
-            .unwrap();
+        let reconstructed_seed =
+            qos_crypto::shamir::shares_reconstruct(&decrypted_shares[..2]).unwrap();
+        let reconstructed_seed: [u8; MASTER_SEED_LEN] =
+            reconstructed_seed.as_slice().try_into().unwrap();
+        let reconstructed_seed = Zeroizing::new(reconstructed_seed);
+        let reconstructed = P256Pair::from_master_seed(&reconstructed_seed).unwrap();
 
         assert_eq!(
             hex::encode(reconstructed.public_key().to_bytes()),

--- a/tvc/src/commands/keys/re_encrypt_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_share.rs
@@ -7,8 +7,7 @@ use crate::quorum_key_metadata::QuorumKeyMetadata;
 use crate::util::{read_json_file, write_file};
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
-use qos_core::protocol::QosHash;
-use qos_core::protocol::services::boot::{Approval, ManifestEnvelope, QuorumMember};
+use qos_core::protocol::services::boot::{Approval, QuorumMember, VersionedManifestEnvelope};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
@@ -107,8 +106,7 @@ async fn build_re_encrypted_share_output(
         .sign(
             provision_bundle
                 .manifest_envelope()
-                .manifest
-                .qos_hash()
+                .manifest_hash()
                 .to_vec(),
         )
         .await
@@ -128,11 +126,8 @@ fn ensure_quorum_key_matches_manifest(
     provision_bundle: &ProvisionBundle,
 ) -> anyhow::Result<()> {
     let metadata_quorum_key = quorum_key_metadata.quorum_key_public_bytes()?;
-    let manifest_quorum_key = &provision_bundle
-        .manifest_envelope()
-        .manifest
-        .namespace
-        .quorum_key;
+    let manifest = provision_bundle.manifest_envelope().clone().manifest();
+    let manifest_quorum_key = &manifest.namespace().quorum_key;
 
     if metadata_quorum_key.as_slice() != manifest_quorum_key.as_slice() {
         anyhow::bail!(
@@ -146,12 +141,12 @@ fn ensure_quorum_key_matches_manifest(
 }
 
 fn find_share_set_member(
-    manifest_envelope: &ManifestEnvelope,
+    manifest_envelope: &VersionedManifestEnvelope,
     operator_public_key: &[u8],
 ) -> anyhow::Result<QuorumMember> {
-    manifest_envelope
-        .manifest
-        .share_set
+    let manifest = manifest_envelope.clone().manifest();
+    manifest
+        .share_set()
         .members
         .iter()
         .find(|member| member.pub_key == operator_public_key)
@@ -187,10 +182,9 @@ mod tests {
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
     use crate::quorum_key_metadata::{EncryptedShareMetadata, QuorumKeyMetadata};
-    use qos_core::protocol::QosHash;
     use qos_core::protocol::services::boot::{
         Approval, Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig, PatchSet,
-        PivotConfig, QuorumMember, RestartPolicy, ShareSet,
+        PivotConfig, QuorumMember, RestartPolicy, ShareSet, VersionedManifestEnvelope,
     };
     use qos_p256::{P256Pair, P256Public};
     use serde_json::json;
@@ -198,7 +192,7 @@ mod tests {
     fn sample_manifest_envelope(
         quorum_key: Vec<u8>,
         share_set_members: Vec<QuorumMember>,
-    ) -> ManifestEnvelope {
+    ) -> VersionedManifestEnvelope {
         ManifestEnvelope {
             manifest: Manifest {
                 namespace: Namespace {
@@ -237,6 +231,7 @@ mod tests {
             manifest_set_approvals: vec![],
             share_set_approvals: vec![],
         }
+        .into()
     }
 
     fn bundle_with_ephemeral_key(
@@ -254,7 +249,7 @@ mod tests {
     }
 
     fn local_pair_from_pair(pair: &P256Pair) -> LocalPair {
-        let seed_hex = String::from_utf8(pair.to_master_seed_hex()).unwrap();
+        let seed_hex = String::from_utf8(pair.to_master_seed_hex().to_vec()).unwrap();
         LocalPair::from_hex_seed(&seed_hex).unwrap()
     }
 
@@ -441,14 +436,14 @@ mod tests {
         );
         let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
         let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
-        assert_eq!(decrypted_share, plaintext_share);
+        assert_eq!(decrypted_share.as_slice(), plaintext_share);
         assert_eq!(output.share_approval.member, operator_member);
 
         let approval_public_key =
             P256Public::from_bytes(&output.share_approval.member.pub_key).unwrap();
         approval_public_key
             .verify(
-                &bundle.manifest_envelope().manifest.qos_hash(),
+                &bundle.manifest_envelope().manifest_hash(),
                 &output.share_approval.signature,
             )
             .unwrap();

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -198,14 +198,14 @@ impl AppConfig {
         }
 
         // It is fine if both share set id and params are none since we support a default dev share set
-        if let Some(params) = &self.share_set_params {
-            if params.threshold < MIN_SHARE_SET_THRESHOLD {
-                errors.push(AppConfigValidationError::ThresholdTooLow {
-                    field: "shareSetParams.threshold",
-                    minimum: MIN_SHARE_SET_THRESHOLD,
-                    actual: params.threshold,
-                });
-            }
+        if let Some(params) = &self.share_set_params
+            && params.threshold < MIN_SHARE_SET_THRESHOLD
+        {
+            errors.push(AppConfigValidationError::ThresholdTooLow {
+                field: "shareSetParams.threshold",
+                minimum: MIN_SHARE_SET_THRESHOLD,
+                actual: params.threshold,
+            });
         }
 
         AppConfigValidationErrors::ok_or_errors(errors)

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -12,12 +12,18 @@ use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
 /// the field (public image) or replace it with an encrypted pull secret
 /// (private image). Treated as a placeholder by [`DeployConfig::has_placeholders`].
 const PULL_SECRET_PLACEHOLDER: &str = "<REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC>";
+pub const DEFAULT_QOS_VERSION: &str = "0.10.2";
+
+fn default_qos_version() -> String {
+    DEFAULT_QOS_VERSION.to_string()
+}
 
 /// Deployment configuration loaded from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeployConfig {
     pub app_id: String,
+    #[serde(default = "default_qos_version")]
     pub qos_version: String,
     pub pivot_container_image_url: String,
     pub pivot_path: String,
@@ -42,7 +48,7 @@ impl DeployConfig {
     pub fn template(app_id: Option<&str>) -> Self {
         Self {
             app_id: app_id.unwrap_or("<FILL_IN_APP_ID>").to_string(),
-            qos_version: "<FILL_IN_QOS_VERSION>".to_string(),
+            qos_version: default_qos_version(),
             pivot_container_image_url: "<FILL_IN_PIVOT_CONTAINER_IMAGE_URL>".to_string(),
             pivot_path: "<FILL_IN_PIVOT_PATH>".to_string(),
             pivot_args: vec![],
@@ -64,7 +70,7 @@ impl DeployConfig {
             self.app_id = prompts::required_text("App ID", saved_app_id)?;
         }
         if self.qos_version.starts_with("<FILL_IN") {
-            self.qos_version = prompts::required_text("QOS version", None)?;
+            self.qos_version = prompts::required_text("QOS version", Some(DEFAULT_QOS_VERSION))?;
         }
         if self.pivot_container_image_url.starts_with("<FILL_IN") {
             self.pivot_container_image_url =
@@ -230,6 +236,28 @@ mod tests {
     fn fresh_template_is_all_placeholders() {
         let config = DeployConfig::template(None);
         assert!(config.has_placeholders());
+    }
+
+    #[test]
+    fn fresh_template_defaults_qos_version() {
+        let config = DeployConfig::template(None);
+        assert_eq!(config.qos_version, DEFAULT_QOS_VERSION);
+    }
+
+    #[test]
+    fn missing_qos_version_deserializes_to_default() {
+        let config: DeployConfig = serde_json::from_value(serde_json::json!({
+            "appId": "app_123",
+            "pivotContainerImageUrl": "ghcr.io/x/y:v1",
+            "pivotPath": "/bin/pivot",
+            "expectedPivotDigest": "sha256:abc",
+            "healthCheckType": "TVC_HEALTH_CHECK_TYPE_HTTP",
+            "healthCheckPort": 3000,
+            "publicIngressPort": 3000
+        }))
+        .unwrap();
+
+        assert_eq!(config.qos_version, DEFAULT_QOS_VERSION);
     }
 
     #[test]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -6,6 +6,7 @@ use crate::prompts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use turnkey_client::generated::TvcEgressAllowlist;
 use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
 
 /// Sentinel written by `tvc deploy init` to remind the user to either remove
@@ -16,6 +17,36 @@ pub const DEFAULT_QOS_VERSION: &str = "0.10.2";
 
 fn default_qos_version() -> String {
     DEFAULT_QOS_VERSION.to_string()
+}
+
+/// Non-enforced egress allowlist metadata to include in the QOS manifest.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EgressAllowlist {
+    #[serde(default)]
+    pub urls: Vec<String>,
+    #[serde(default)]
+    pub hostnames: Vec<String>,
+    #[serde(default)]
+    pub ips: Vec<String>,
+}
+
+impl EgressAllowlist {
+    pub fn is_empty(&self) -> bool {
+        self.urls.is_empty() && self.hostnames.is_empty() && self.ips.is_empty()
+    }
+
+    pub fn to_intent(&self) -> Option<TvcEgressAllowlist> {
+        if self.is_empty() {
+            return None;
+        }
+
+        Some(TvcEgressAllowlist {
+            urls: self.urls.clone(),
+            hostnames: self.hostnames.clone(),
+            ips: self.ips.clone(),
+        })
+    }
 }
 
 /// Deployment configuration loaded from JSON file.
@@ -40,6 +71,8 @@ pub struct DeployConfig {
     pub health_check_type: TvcHealthCheckType,
     pub health_check_port: u16,
     pub public_ingress_port: u16,
+    #[serde(default)]
+    pub egress_allowlist: EgressAllowlist,
 }
 
 impl DeployConfig {
@@ -58,6 +91,7 @@ impl DeployConfig {
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,
             public_ingress_port: 3000,
+            egress_allowlist: EgressAllowlist::default(),
         }
     }
 
@@ -258,6 +292,29 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.qos_version, DEFAULT_QOS_VERSION);
+    }
+
+    #[test]
+    fn config_deserializes_egress_allowlist() {
+        let config: DeployConfig = serde_json::from_value(serde_json::json!({
+            "appId": "app_123",
+            "pivotContainerImageUrl": "ghcr.io/x/y:v1",
+            "pivotPath": "/bin/pivot",
+            "expectedPivotDigest": "sha256:abc",
+            "healthCheckType": "TVC_HEALTH_CHECK_TYPE_HTTP",
+            "healthCheckPort": 3000,
+            "publicIngressPort": 3000,
+            "egressAllowlist": {
+                "urls": ["https://api.example.com/v1"],
+                "hostnames": ["api.example.com"],
+                "ips": ["203.0.113.10"]
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(config.egress_allowlist.urls, ["https://api.example.com/v1"]);
+        assert_eq!(config.egress_allowlist.hostnames, ["api.example.com"]);
+        assert_eq!(config.egress_allowlist.ips, ["203.0.113.10"]);
     }
 
     #[test]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -6,7 +6,6 @@ use crate::prompts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use turnkey_client::generated::TvcEgressAllowlist;
 use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
 
 /// Sentinel written by `tvc deploy init` to remind the user to either remove
@@ -17,36 +16,6 @@ pub const DEFAULT_QOS_VERSION: &str = "0.10.2";
 
 fn default_qos_version() -> String {
     DEFAULT_QOS_VERSION.to_string()
-}
-
-/// Non-enforced egress allowlist metadata to include in the QOS manifest.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EgressAllowlist {
-    #[serde(default)]
-    pub urls: Vec<String>,
-    #[serde(default)]
-    pub hostnames: Vec<String>,
-    #[serde(default)]
-    pub ips: Vec<String>,
-}
-
-impl EgressAllowlist {
-    pub fn is_empty(&self) -> bool {
-        self.urls.is_empty() && self.hostnames.is_empty() && self.ips.is_empty()
-    }
-
-    pub fn to_intent(&self) -> Option<TvcEgressAllowlist> {
-        if self.is_empty() {
-            return None;
-        }
-
-        Some(TvcEgressAllowlist {
-            urls: self.urls.clone(),
-            hostnames: self.hostnames.clone(),
-            ips: self.ips.clone(),
-        })
-    }
 }
 
 /// Deployment configuration loaded from JSON file.
@@ -71,8 +40,6 @@ pub struct DeployConfig {
     pub health_check_type: TvcHealthCheckType,
     pub health_check_port: u16,
     pub public_ingress_port: u16,
-    #[serde(default)]
-    pub egress_allowlist: EgressAllowlist,
 }
 
 impl DeployConfig {
@@ -91,7 +58,6 @@ impl DeployConfig {
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,
             public_ingress_port: 3000,
-            egress_allowlist: EgressAllowlist::default(),
         }
     }
 
@@ -292,29 +258,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.qos_version, DEFAULT_QOS_VERSION);
-    }
-
-    #[test]
-    fn config_deserializes_egress_allowlist() {
-        let config: DeployConfig = serde_json::from_value(serde_json::json!({
-            "appId": "app_123",
-            "pivotContainerImageUrl": "ghcr.io/x/y:v1",
-            "pivotPath": "/bin/pivot",
-            "expectedPivotDigest": "sha256:abc",
-            "healthCheckType": "TVC_HEALTH_CHECK_TYPE_HTTP",
-            "healthCheckPort": 3000,
-            "publicIngressPort": 3000,
-            "egressAllowlist": {
-                "urls": ["https://api.example.com/v1"],
-                "hostnames": ["api.example.com"],
-                "ips": ["203.0.113.10"]
-            }
-        }))
-        .unwrap();
-
-        assert_eq!(config.egress_allowlist.urls, ["https://api.example.com/v1"]);
-        assert_eq!(config.egress_allowlist.hostnames, ["api.example.com"]);
-        assert_eq!(config.egress_allowlist.ips, ["203.0.113.10"]);
     }
 
     #[test]

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
+use zeroize::Zeroizing;
 
 /// Something that can do key pair operations with the QOS p256 scheme.
 pub trait Pair: Send + Sync {
@@ -42,6 +43,7 @@ impl LocalPair {
         let bytes_seed: [u8; 32] = hex::decode(hex_seed.trim())?
             .try_into()
             .map_err(|v: Vec<u8>| anyhow!("seed must be exactly 32 bytes, got {}", v.len()))?;
+        let bytes_seed = Zeroizing::new(bytes_seed);
 
         let pair = P256Pair::from_master_seed(&bytes_seed)
             .map_err(|_| anyhow!("could not create key from seed"))?;
@@ -83,6 +85,7 @@ impl Pair for LocalPair {
             tokio::task::spawn_blocking(move || {
                 pair2
                     .decrypt(&ciphertext)
+                    .map(|plaintext| plaintext.to_vec())
                     .map_err(|_| anyhow!("failed to decrypt with local signer"))
             })
             .await?

--- a/tvc/src/provisioning.rs
+++ b/tvc/src/provisioning.rs
@@ -3,8 +3,7 @@
 use anyhow::{Context, anyhow, bail};
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-use qos_core::protocol::QosHash;
-use qos_core::protocol::services::boot::ManifestEnvelope;
+use qos_core::protocol::services::boot::VersionedManifestEnvelope;
 use qos_p256::P256Public;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -13,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ProvisionBundle {
     attestation_document_cose_sign1_base64: String,
-    manifest_envelope: ManifestEnvelope,
+    manifest_envelope: VersionedManifestEnvelope,
     fetched_at_unix_ms: u64,
     deployment_id: String,
     ephemeral_public_key_hex: String,
@@ -23,13 +22,13 @@ impl ProvisionBundle {
     pub(crate) fn new(
         deployment_id: String,
         attestation_document: &[u8],
-        manifest_envelope: ManifestEnvelope,
+        manifest_envelope: impl Into<VersionedManifestEnvelope>,
         fetched_at_unix_ms: u64,
         ephemeral_public_key: &[u8],
     ) -> Self {
         Self {
             attestation_document_cose_sign1_base64: BASE64_STANDARD.encode(attestation_document),
-            manifest_envelope,
+            manifest_envelope: manifest_envelope.into(),
             fetched_at_unix_ms,
             deployment_id,
             ephemeral_public_key_hex: hex::encode(ephemeral_public_key),
@@ -44,7 +43,7 @@ impl ProvisionBundle {
         &self.ephemeral_public_key_hex
     }
 
-    pub(crate) fn manifest_envelope(&self) -> &ManifestEnvelope {
+    pub(crate) fn manifest_envelope(&self) -> &VersionedManifestEnvelope {
         &self.manifest_envelope
     }
 
@@ -93,7 +92,7 @@ impl ProvisionBundle {
 
 pub(crate) fn verify_provisioning_details(
     cose_sign1_der: &[u8],
-    manifest_envelope: &ManifestEnvelope,
+    manifest_envelope: &VersionedManifestEnvelope,
     validation_time_override: Option<u64>,
 ) -> anyhow::Result<AttestationDoc> {
     manifest_envelope
@@ -108,13 +107,15 @@ pub(crate) fn verify_provisioning_details(
     )
     .context("failed to parse and verify attestation document")?;
 
+    let manifest = manifest_envelope.clone().manifest();
+    let enclave = manifest.enclave();
     qos_nsm::nitro::verify_attestation_doc_against_user_input(
         &attestation_doc,
-        &manifest_envelope.manifest.qos_hash(),
-        &manifest_envelope.manifest.enclave.pcr0,
-        &manifest_envelope.manifest.enclave.pcr1,
-        &manifest_envelope.manifest.enclave.pcr2,
-        &manifest_envelope.manifest.enclave.pcr3,
+        &manifest_envelope.manifest_hash(),
+        &enclave.pcr0,
+        &enclave.pcr1,
+        &enclave.pcr2,
+        &enclave.pcr3,
     )
     .context("attestation document did not match manifest expectations")?;
 
@@ -154,7 +155,7 @@ fn validation_time_secs(validation_time_override: Option<u64>) -> anyhow::Result
 mod tests {
     use super::{ProvisionBundle, extract_ephemeral_public_key_bytes, verify_provisioning_details};
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-    use qos_core::protocol::services::boot::ManifestEnvelope;
+    use qos_core::protocol::services::boot::{ManifestEnvelope, VersionedManifestEnvelope};
     use qos_p256::P256Pair;
     use serde::Deserialize;
     use serde_json::json;
@@ -273,7 +274,7 @@ mod tests {
 
         verify_provisioning_details(
             &attestation_document,
-            &fixture.manifest_envelope,
+            &VersionedManifestEnvelope::from(fixture.manifest_envelope),
             Some(fixture.validation_time_secs),
         )
         .unwrap();
@@ -287,6 +288,7 @@ mod tests {
             .unwrap();
         let mut manifest_envelope = fixture.manifest_envelope;
         manifest_envelope.manifest_set_approvals.clear();
+        let manifest_envelope = VersionedManifestEnvelope::from(manifest_envelope);
 
         assert!(
             verify_provisioning_details(
@@ -341,7 +343,7 @@ mod tests {
         let expected_public_key = P256Pair::generate().unwrap().public_key();
         let bundle = ProvisionBundle {
             attestation_document_cose_sign1_base64: "not base64".to_string(),
-            manifest_envelope: sample_manifest_envelope(),
+            manifest_envelope: sample_manifest_envelope().into(),
             fetched_at_unix_ms: 1_712_345_678_901,
             deployment_id: "deploy-123".to_string(),
             ephemeral_public_key_hex: hex::encode(expected_public_key.to_bytes()),

--- a/tvc/tests/config_validation.rs
+++ b/tvc/tests/config_validation.rs
@@ -31,7 +31,6 @@ fn deploy_create_non_interactive_reports_all_placeholder_errors() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("app_id"))
-        .stderr(predicate::str::contains("qos_version"))
         .stderr(predicate::str::contains("pivot_container_image_url"))
         .stderr(predicate::str::contains("pivot_path"))
         .stderr(predicate::str::contains("expected_pivot_digest"))

--- a/tvc/tests/keys_generate_quorum_key.rs
+++ b/tvc/tests/keys_generate_quorum_key.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;
+use zeroize::Zeroizing;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -87,11 +88,12 @@ fn generate_quorum_key_writes_metadata() {
         })
         .collect::<Vec<_>>();
 
-    let reconstructed = qos_crypto::shamir::shares_reconstruct(&decrypted_shares[..2])
-        .unwrap()
-        .try_into()
-        .map(|seed: [u8; MASTER_SEED_LEN]| P256Pair::from_master_seed(&seed).unwrap())
-        .unwrap();
+    let reconstructed_seed =
+        qos_crypto::shamir::shares_reconstruct(&decrypted_shares[..2]).unwrap();
+    let reconstructed_seed: [u8; MASTER_SEED_LEN] =
+        reconstructed_seed.as_slice().try_into().unwrap();
+    let reconstructed_seed = Zeroizing::new(reconstructed_seed);
+    let reconstructed = P256Pair::from_master_seed(&reconstructed_seed).unwrap();
     assert_eq!(
         hex::encode(reconstructed.public_key().to_bytes()),
         metadata.quorum_key_public

--- a/tvc/tests/keys_re_encrypt_share.rs
+++ b/tvc/tests/keys_re_encrypt_share.rs
@@ -139,7 +139,7 @@ fn re_encrypt_share_round_trips_metadata_share() {
 
     fs::write(
         &operator_seed_path,
-        String::from_utf8(operator_pair.to_master_seed_hex()).unwrap(),
+        String::from_utf8(operator_pair.to_master_seed_hex().to_vec()).unwrap(),
     )
     .unwrap();
     fs::write(
@@ -203,7 +203,7 @@ fn re_encrypt_share_round_trips_metadata_share() {
     );
     let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
     let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
-    assert_eq!(decrypted_share, plaintext_share);
+    assert_eq!(decrypted_share.as_slice(), plaintext_share);
     assert_eq!(output.share_approval.member.pub_key, operator_public_key);
 
     let approval_public_key =

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -256,7 +256,6 @@ fn deploy_create_without_required_fields_bails_naming_each_field() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("app_id"))
-        .stderr(predicate::str::contains("qos_version"))
         .stderr(predicate::str::contains("pivot_container_image_url"))
         .stderr(predicate::str::contains("pivot_path"))
         .stderr(predicate::str::contains("expected_pivot_digest"));

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -21,7 +21,7 @@ fn spawn(args: &str) -> PtySession {
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {cmd}"))
 }
 
-/// `tvc deploy approve` walks all five section confirmations in order and
+/// `tvc deploy approve` walks all six section confirmations in order and
 /// emits the signed approval JSON when the user accepts every section.
 ///
 /// Replaces the deleted `tests/deploy_approve.rs::approve_interactive_prompts`
@@ -49,6 +49,11 @@ fn approve_walks_all_sections_with_yeses() {
 
     session.exp_string("PIVOT BINARY").unwrap();
     session.exp_string("Approve pivot binary?").unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("BRIDGE CONFIG").unwrap();
+    session.exp_string("Type: server").unwrap();
+    session.exp_string("Approve bridge configuration?").unwrap();
     session.send_line("y").unwrap();
 
     session.exp_string("MANIFEST SET").unwrap();


### PR DESCRIPTION
## Summary
- default TVC deploy configs to QOS 0.10.2 while keeping --qos-version as an override
- update QOS crates and rust-toolchain to the 0.10.2-compatible toolchain
- parse/sign versioned QOS manifests and envelopes so manifest v2 works for deploy approval, provisioning details, and share re-encryption

