### PR TITLE
style: fix pre-existing cargo fmt violations

### DIFF
--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -4,9 +4,9 @@ use crate::config::turnkey::{Config, StoredApiKey};
 use anyhow::{Context, Result, anyhow, bail};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use turnkey_client::generated::external::data::v1::TvcApp;
-use turnkey_client::generated::GetTvcAppRequest;
 use turnkey_client::TurnkeyClient;
+use turnkey_client::generated::GetTvcAppRequest;
+use turnkey_client::generated::external::data::v1::TvcApp;
 
 /// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
 /// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.

--- a/tvc/src/commands/display.rs
+++ b/tvc/src/commands/display.rs
@@ -1,11 +1,7 @@
 //! Shared display helpers for CLI output.
 
 pub fn yes_no(value: bool) -> &'static str {
-    if value {
-        "yes"
-    } else {
-        "no"
-    }
+    if value { "yes" } else { "no" }
 }
 
 pub fn format_egress_enabled(enable_egress: bool) -> String {


### PR DESCRIPTION
## Summary

The checked-in code on `main` does **not** satisfy `cargo fmt -- --check` when run under the repo's **pinned toolchain** (`1.88`, per `rust-toolchain.toml`) — i.e. what `make lint` uses locally. This PR applies the formatting that pinned-1.88 rustfmt wants.

> **Why does `main`'s CI show green, then?** Because CI does not currently use the pinned toolchain — it lints under `stable`. See #168 for the toolchain-mismatch fix and the full root-cause writeup. This PR fixes the formatting itself so it's clean under both toolchains.

**Formatting changes ONLY — no logic changes.**

## Files reformatted

- `tvc/src/client.rs` — import ordering: `use turnkey_client::generated::GetTvcAppRequest;` now sorts before `use turnkey_client::generated::external::data::v1::TvcApp;`
- `tvc/src/commands/display.rs` — `yes_no` collapsed to the edition-2024 short-if style: `if value { "yes" } else { "no" }`

## Verification

- Reproduced on `main` (`5b6c776`): `cargo fmt -- --check` exits **1** under pinned 1.88 (`rustfmt 1.8.0-stable`, `cargo 1.88.0`), flagging the two files above.
- After this PR's changes, `cargo fmt -- --check` exits `0` under pinned 1.88.
- `git diff main --stat` shows only these two files (3 insertions, 7 deletions) — pure whitespace/import-ordering/short-if churn.
- No generated files under `client/src/generated/` were touched.

This is fmt-only and intentionally does not touch the clippy lint / AGENTS.md work from PR #166 or the CI-pin in #168. See #168 for which commit introduced the drift and the toolchain root cause.
