### PR TITLE
ci: pin CI toolchain to 1.88 to match rust-toolchain.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.88"
           components: clippy,rustfmt
       - name: install protoc
         uses: arduino/setup-protoc@v3

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,13 @@ strip-doc:
 
 .PHONY: check-generate
 check-generate:
-	make generate
+	$(MAKE) generate
 	git diff --exit-code
+	@if [ -n "$$(git ls-files --others --exclude-standard client/src/generated)" ]; then \
+		echo "Untracked generated files found:"; \
+		git ls-files --others --exclude-standard client/src/generated; \
+		exit 1; \
+	fi
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ strip-doc:
 .PHONY: check-generate
 check-generate:
 	make generate
-	git diff --exit-code client/src/generated/client.rs
+	git diff --exit-code
 
 .PHONY: fmt
 fmt:

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -4,9 +4,9 @@ use crate::config::turnkey::{Config, StoredApiKey};
 use anyhow::{Context, Result, anyhow, bail};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use turnkey_client::generated::external::data::v1::TvcApp;
-use turnkey_client::generated::GetTvcAppRequest;
 use turnkey_client::TurnkeyClient;
+use turnkey_client::generated::GetTvcAppRequest;
+use turnkey_client::generated::external::data::v1::TvcApp;
 
 /// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
 /// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.

--- a/tvc/src/commands/display.rs
+++ b/tvc/src/commands/display.rs
@@ -1,11 +1,7 @@
 //! Shared display helpers for CLI output.
 
 pub fn yes_no(value: bool) -> &'static str {
-    if value {
-        "yes"
-    } else {
-        "no"
-    }
+    if value { "yes" } else { "no" }
 }
 
 pub fn format_egress_enabled(enable_egress: bool) -> String {


### PR DESCRIPTION
This PR makes CI catch Rust formatting drift more reliably.

Changes:
1. Pins CI Rust toolchain to `1.88` to match `rust-toolchain.toml`, so CI runs the same toolchain used locally.
2. Changes `check-generate` to run `git diff --exit-code` over the whole tracked tree after `$(MAKE) generate`, so any tracked file modified by generation or formatting fails the check.
3. Adds an untracked-file guard for `client/src/generated`, so newly generated files cannot be missed just because they are not tracked yet.
4. Includes `tvc` rustfmt fixes so the new full-tree diff guard passes on this branch.

Root cause: `make check-generate` runs before `make lint`; `make generate` includes `cargo fmt --`, so CI could reformat handwritten files before the fmt check ran. The old diff guard only checked `client/src/generated/client.rs`, so formatting drift in `tvc` was invisible. It also ignored untracked generated files.

This was first exposed by #166, whose CI failed in `make lint` after `make check-generate` had already passed. The underlying `tvc` formatting drift came from PR #158 egress visibility changes, but #158 itself went green on `main` because CI did not catch the drift at the time.