### PR TITLE
feat(tvc): add deploy debug-logs command

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -9,28 +9,29 @@ CLI for building with Turnkey Verifiable Cloud.
 
 Some commands accept multiple configuration input types.
 Configuration values are resolved in this order, highest priority first:
-  1. Command-line flag (e.g. --app-id)
-  2. Environment variable (e.g. TVC_APP_ID)
-  3. Config file value (--config-file)
-  4. Built-in default
+    1. Command-line flag (e.g. --app-id)
+    2. Environment variable (e.g. TVC_APP_ID)
+    3. Config file value (--config-file)
+    4. Built-in default
 
 Special rules (exceptions to the order above):
-  --pivot-args replaces the config file's list entirely (does not append)
-  Debug-mode flags (--dangerous-deploy-debug-mode and
+    --pivot-args replaces the config file's list entirely (does not append)
+
+    Debug-mode flags (--dangerous-deploy-debug-mode and
     --dangerous-enable-debug-mode-deployments) are opt-in only: the flag
     or its env var can turn debug mode ON, but its absence never turns OFF
     a config file that enables it. To disable debug mode, set it false in
     the config file (or omit it) and do not pass the flag.
 
 Authentication:
-  Local: run `tvc login` once; commands then read ~/.config/turnkey/.
-  CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
+    Local: run `tvc login` once; commands then read ~/.config/turnkey/.
+    CI:    set TVC_ORG_ID, TVC_API_KEY_PUBLIC, and TVC_API_KEY_PRIVATE
          to authenticate without files. Env vars take precedence over local
          config files. Setting some but not all three required vars will error.
 
 Interactive behavior:
-  By default, commands may prompt when stdin is a TTY. Use --non-interactive
-  or set TVC_NON_INTERACTIVE=true to disable prompts and fail fast instead.";
+    By default, commands may prompt when stdin is a TTY. Use --non-interactive
+    or set TVC_NON_INTERACTIVE=true to disable prompts and fail fast instead.";
 
 /// CLI command parsing and dispatch.
 #[derive(Debug, Parser)]
@@ -79,6 +80,7 @@ impl Cli {
                 DeployCommands::Init(args) => {
                     commands::deploy::init::run(args, non_interactive).await
                 }
+                DeployCommands::DebugLogs(args) => commands::deploy::debug_logs::run(args).await,
                 DeployCommands::Delete(args) => commands::deploy::delete::run(args).await,
                 DeployCommands::Restore(args) => commands::deploy::restore::run(args).await,
             },
@@ -160,6 +162,9 @@ enum DeployCommands {
     Create(commands::deploy::create::Args),
     /// Generate a template deployment configuration file.
     Init(commands::deploy::init::Args),
+    /// Fetch debug logs for a deployment.
+    #[command(long_about = commands::deploy::debug_logs::LONG_ABOUT)]
+    DebugLogs(commands::deploy::debug_logs::Args),
     /// Delete a deployment by marking it for deletion.
     Delete(commands::deploy::delete::Args),
     /// Restore a deleted deployment.
@@ -176,6 +181,7 @@ impl DeployCommands {
             DeployCommands::Status(_) => "deploy status",
             DeployCommands::Create(_) => "deploy create",
             DeployCommands::Init(_) => "deploy init",
+            DeployCommands::DebugLogs(_) => "deploy debug-logs",
             DeployCommands::Delete(_) => "deploy delete",
             DeployCommands::Restore(_) => "deploy restore",
         }

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -13,7 +13,6 @@ use turnkey_client::generated::{
 
 const DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS: i64 = 2;
 const FOLLOW_OVERLAP_SECONDS: i64 = 2;
-const RECENT_LOG_LINE_CAPACITY: usize = 1000;
 
 fn follow_poll_interval_seconds_parser() -> clap::builder::RangedI64ValueParser<i64> {
     clap::value_parser!(i64).range(1..=i64::MAX - FOLLOW_OVERLAP_SECONDS)
@@ -25,6 +24,10 @@ fn non_negative_i32_parser() -> clap::builder::RangedI64ValueParser<i32> {
 
 fn non_negative_i64_parser() -> clap::builder::RangedI64ValueParser<i64> {
     clap::value_parser!(i64).range(0..)
+}
+
+fn positive_usize_parser() -> clap::builder::RangedU64ValueParser<usize> {
+    clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
 }
 
 pub(crate) const LONG_ABOUT: &str = r#"
@@ -94,6 +97,16 @@ pub struct Args {
     /// Include the platform timestamp prepended by the Kubernetes log stream.
     #[arg(long, env = "TVC_DEBUG_LOGS_INCLUDE_PLATFORM_TIMESTAMP")]
     pub include_platform_timestamp: bool,
+
+    /// Number of recently printed timestamped lines retained for follow-mode dedupe. This should
+    /// only be increased if high-volume logs still show duplicates across poll overlap windows.
+    #[arg(
+        long,
+        env = "TVC_DEBUG_LOGS_RECENT_LINE_CAPACITY",
+        default_value_t = 1000,
+        value_parser = positive_usize_parser()
+    )]
+    pub recent_line_capacity: usize,
 }
 
 /// Run the `deploy debug-logs` command.
@@ -108,6 +121,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         tail_lines: args.tail_lines,
         since_seconds: args.since_seconds,
         include_platform_timestamp: args.include_platform_timestamp,
+        recent_line_capacity: args.recent_line_capacity,
     };
 
     query_debug_logs(&auth.client, request).await
@@ -122,6 +136,7 @@ struct DebugLogQueryRequest {
     tail_lines: i32,
     since_seconds: i64,
     include_platform_timestamp: bool,
+    recent_line_capacity: usize,
 }
 
 impl From<DebugLogQueryRequest> for GetTvcDeploymentDebugLogsRequest {
@@ -149,8 +164,10 @@ async fn query_debug_logs(
     client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
     request: DebugLogQueryRequest,
 ) -> anyhow::Result<()> {
-    let mut log_printer =
-        DebugLogPrinter::new(request.include_platform_timestamp, RECENT_LOG_LINE_CAPACITY);
+    let mut log_printer = DebugLogPrinter::new(
+        request.include_platform_timestamp,
+        request.recent_line_capacity,
+    );
 
     let (current_request, followup_request) = if request.follow {
         (request.clone(), Some(request.into_followup_request()))
@@ -195,15 +212,13 @@ struct LogLineKey {
 }
 
 impl LogLineKey {
-    fn new(replica: &str, line: &LogLine) -> Option<Self> {
-        let ts = line.ts.as_ref()?;
-
-        Some(Self {
+    fn new(replica: &str, ts: Timestamp, content: String) -> Self {
+        Self {
             replica: replica.into(),
-            content: line.content.clone(),
-            seconds: ts.seconds.clone(),
-            nanos: ts.nanos.clone(),
-        })
+            content,
+            seconds: ts.seconds,
+            nanos: ts.nanos,
+        }
     }
 }
 
@@ -211,34 +226,33 @@ impl LogLineKey {
 struct RecentLogLines {
     seen: HashSet<LogLineKey>,
     order: VecDeque<LogLineKey>,
-    capacity: usize,
 }
 
 impl RecentLogLines {
     fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "recent log line capacity must be positive");
+
         Self {
-            seen: HashSet::new(),
-            order: VecDeque::new(),
-            capacity,
+            seen: HashSet::with_capacity(capacity),
+            order: VecDeque::with_capacity(capacity),
         }
     }
 
     fn insert(&mut self, key: LogLineKey) -> bool {
-        if self.capacity == 0 {
-            return true;
-        }
-
-        if !self.seen.insert(key.clone()) {
+        if self.seen.contains(&key) {
             return false;
         }
 
-        self.order.push_back(key);
-
-        while self.order.len() > self.capacity {
-            if let Some(oldest) = self.order.pop_front() {
-                self.seen.remove(&oldest);
-            }
+        if self.order.len() == self.order.capacity() {
+            let oldest = self
+                .order
+                .pop_front()
+                .expect("full recent log line cache should contain an oldest key");
+            self.seen.remove(&oldest);
         }
+
+        self.seen.insert(key.clone());
+        self.order.push_back(key);
 
         true
     }
@@ -247,15 +261,24 @@ impl RecentLogLines {
     ///
     /// NOTE: Mutating filter
     fn record_if_new(&mut self, replica: &str, line: &LogLine) -> bool {
-        match LogLineKey::new(replica, line) {
-            Some(key) => self.insert(key),
-            None => true,
-        }
+        let LogLine { content, ts } = line;
+        let Some(ts) = ts else {
+            return true;
+        };
+
+        let key = LogLineKey::new(replica, ts.clone(), content.clone());
+
+        self.insert(key)
     }
 
     #[cfg(test)]
     fn len(&self) -> usize {
         self.seen.len()
+    }
+
+    #[cfg(test)]
+    fn capacity(&self) -> usize {
+        self.order.capacity()
     }
 }
 
@@ -342,6 +365,10 @@ mod tests {
         }
     }
 
+    fn log_line_key(replica: &str, content: &str, seconds: &str, nanos: &str) -> LogLineKey {
+        LogLineKey::new(replica, timestamp(seconds, nanos), content.to_string())
+    }
+
     #[test]
     fn request_maps_to_unary_api_request() {
         let request = DebugLogQueryRequest {
@@ -352,6 +379,7 @@ mod tests {
             tail_lines: 10,
             since_seconds: 30,
             include_platform_timestamp: true,
+            recent_line_capacity: 1000,
         };
 
         let api_request: GetTvcDeploymentDebugLogsRequest = request.into();
@@ -372,6 +400,7 @@ mod tests {
             tail_lines: 100,
             since_seconds: 0,
             include_platform_timestamp: false,
+            recent_line_capacity: 1000,
         };
 
         let followup = request.clone().into_followup_request();
@@ -384,19 +413,20 @@ mod tests {
 
     #[test]
     fn log_line_key_matches_duplicate_lines() {
-        let line = log_line("hello", Some(timestamp("1710000000", "123456789")));
-
         assert_eq!(
-            LogLineKey::new("replica 1/3", &line),
-            LogLineKey::new("replica 1/3", &line)
+            log_line_key("replica 1/3", "hello", "1710000000", "123456789"),
+            log_line_key("replica 1/3", "hello", "1710000000", "123456789")
         );
     }
 
     #[test]
-    fn log_line_key_requires_timestamp() {
+    fn record_if_new_treats_missing_timestamp_as_new() {
         let line = log_line("hello", None);
+        let mut recent = RecentLogLines::new(1000);
 
-        assert_eq!(LogLineKey::new("replica 1/3", &line), None);
+        assert!(recent.record_if_new("replica 1/3", &line));
+        assert!(recent.record_if_new("replica 1/3", &line));
+        assert_eq!(recent.len(), 0);
     }
 
     #[test]
@@ -440,9 +470,9 @@ mod tests {
     }
 
     #[test]
-    fn recent_log_lines_treats_untimestamped_lines_as_new() {
+    fn recent_log_lines_treats_non_timestamped_lines_as_new() {
         let line = log_line("hello", None);
-        let mut recent = RecentLogLines::new(RECENT_LOG_LINE_CAPACITY);
+        let mut recent = RecentLogLines::new(1000);
 
         assert!(recent.record_if_new("replica 1/2", &line));
         assert!(recent.record_if_new("replica 1/2", &line));
@@ -452,11 +482,17 @@ mod tests {
     #[test]
     fn recent_log_lines_dedupes_timestamped_lines() {
         let line = log_line("hello", Some(timestamp("1710000000", "1")));
-        let mut recent = RecentLogLines::new(RECENT_LOG_LINE_CAPACITY);
+        let mut recent = RecentLogLines::new(1000);
 
         assert!(recent.record_if_new("replica 1/2", &line));
         assert!(!recent.record_if_new("replica 1/2", &line));
         assert_eq!(recent.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "recent log line capacity must be positive")]
+    fn recent_log_lines_requires_positive_capacity() {
+        RecentLogLines::new(0);
     }
 
     #[test]
@@ -474,7 +510,7 @@ mod tests {
                 entry("replica 2/2", None),
             ],
         };
-        let mut printer = DebugLogPrinter::new(false, RECENT_LOG_LINE_CAPACITY);
+        let mut printer = DebugLogPrinter::new(false, 1000);
 
         printer.print_response(&response);
 
@@ -483,21 +519,9 @@ mod tests {
 
     #[test]
     fn recent_log_lines_evicts_oldest_entries() {
-        let first = LogLineKey::new(
-            "replica 1/2",
-            &log_line("first", Some(timestamp("1710000000", "1"))),
-        )
-        .unwrap();
-        let second = LogLineKey::new(
-            "replica 1/2",
-            &log_line("second", Some(timestamp("1710000000", "2"))),
-        )
-        .unwrap();
-        let third = LogLineKey::new(
-            "replica 1/2",
-            &log_line("third", Some(timestamp("1710000000", "3"))),
-        )
-        .unwrap();
+        let first = log_line_key("replica 1/2", "first", "1710000000", "1");
+        let second = log_line_key("replica 1/2", "second", "1710000000", "2");
+        let third = log_line_key("replica 1/2", "third", "1710000000", "3");
         let mut recent = RecentLogLines::new(2);
 
         assert!(recent.insert(first.clone()));
@@ -508,5 +532,21 @@ mod tests {
         assert_eq!(recent.len(), 2);
         assert!(recent.insert(first));
         assert_eq!(recent.len(), 2);
+    }
+
+    #[test]
+    fn recent_log_lines_does_not_grow_past_initial_capacity() {
+        let first = log_line_key("replica 1/2", "first", "1710000000", "1");
+        let second = log_line_key("replica 1/2", "second", "1710000000", "2");
+        let third = log_line_key("replica 1/2", "third", "1710000000", "3");
+        let mut recent = RecentLogLines::new(2);
+        let initial_capacity = recent.capacity();
+
+        assert!(recent.insert(first));
+        assert!(recent.insert(second));
+        assert!(recent.insert(third));
+
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent.capacity(), initial_capacity);
     }
 }

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -49,6 +49,8 @@ Poll mode polls every 2 seconds by default and requests a 2-second overlap
 on each subsequent poll to avoid missing late-arriving log lines.
 By default, output omits the platform timestamp that Kubernetes prepends to each
 log line; pass `--include-platform-timestamp` to show it.
+The CLI dedupes timestamped lines with identical content across poll overlap windows
+by default; pass `--disable-dedupe` to print every returned line.
 See `tvc app create --help`, `tvc deploy create --help`, and `tvc --help`
 for more info."#;
 
@@ -98,6 +100,10 @@ pub struct Args {
     #[arg(long, env = "TVC_DEBUG_LOGS_INCLUDE_PLATFORM_TIMESTAMP")]
     pub include_platform_timestamp: bool,
 
+    /// Disable client-side dedupe across poll overlap windows.
+    #[arg(long, env = "TVC_DEBUG_LOGS_DISABLE_DEDUPE")]
+    pub disable_dedupe: bool,
+
     /// Number of recently printed timestamped lines retained for poll-mode dedupe. This should
     /// only be increased if high-volume logs still show duplicates across poll overlap windows.
     #[arg(
@@ -121,6 +127,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         tail_lines: args.tail_lines,
         since_seconds: args.since_seconds,
         include_platform_timestamp: args.include_platform_timestamp,
+        disable_dedupe: args.disable_dedupe,
         recent_line_capacity: args.recent_line_capacity,
     };
 
@@ -136,6 +143,7 @@ struct DebugLogQueryRequest {
     tail_lines: i32,
     since_seconds: i64,
     include_platform_timestamp: bool,
+    disable_dedupe: bool,
     recent_line_capacity: usize,
 }
 
@@ -167,6 +175,7 @@ async fn query_debug_logs(
     let mut log_printer = DebugLogPrinter::new(
         request.include_platform_timestamp,
         request.recent_line_capacity,
+        request.disable_dedupe,
     );
 
     let (current_request, poll_request) = if request.poll {
@@ -222,12 +231,12 @@ impl LogLineKey {
 }
 
 #[derive(Debug)]
-struct RecentLogLines {
+struct RecentLogLineDeduper {
     seen: HashSet<LogLineKey>,
     order: VecDeque<LogLineKey>,
 }
 
-impl RecentLogLines {
+impl RecentLogLineDeduper {
     fn new(capacity: usize) -> Self {
         assert!(capacity > 0, "recent log line capacity must be positive");
 
@@ -283,39 +292,49 @@ impl RecentLogLines {
 
 #[derive(Debug)]
 struct DebugLogPrinter {
-    recent_lines: RecentLogLines,
+    deduper: Option<RecentLogLineDeduper>,
     include_platform_timestamp: bool,
 }
 
 impl DebugLogPrinter {
-    fn new(include_platform_timestamp: bool, recent_line_capacity: usize) -> Self {
+    fn new(
+        include_platform_timestamp: bool,
+        recent_line_capacity: usize,
+        disable_dedupe: bool,
+    ) -> Self {
+        let deduper = if disable_dedupe {
+            None
+        } else {
+            Some(RecentLogLineDeduper::new(recent_line_capacity))
+        };
+
         Self {
-            recent_lines: RecentLogLines::new(recent_line_capacity),
+            deduper,
             include_platform_timestamp,
         }
     }
 
-    fn print_response(&mut self, response: &GetTvcDeploymentDebugLogsResponse) {
-        let recent_lines = &mut self.recent_lines;
-        let include_platform_timestamp = self.include_platform_timestamp;
+    fn should_print_line(&mut self, replica: &str, line: &LogLine) -> bool {
+        match self.deduper.as_mut() {
+            Some(deduper) => deduper.record_if_new(replica, line),
+            None => true,
+        }
+    }
 
-        // `record_if_new` updates the `recent_lines` cache while filtering duplicates.
-        response
-            .entries
-            .iter()
-            .filter_map(|entry| {
-                entry
-                    .line
-                    .as_ref()
-                    .map(|line| (entry.replica_label.as_str(), line))
-            })
-            .filter(|(replica, line)| recent_lines.record_if_new(replica, line))
-            .for_each(|(replica, line)| {
+    fn print_response(&mut self, response: &GetTvcDeploymentDebugLogsResponse) {
+        for entry in &response.entries {
+            let Some(line) = entry.line.as_ref() else {
+                continue;
+            };
+            let replica = entry.replica_label.as_str();
+
+            if self.should_print_line(replica, line) {
                 println!(
                     "{}",
-                    format_log_line(replica, line, include_platform_timestamp)
+                    format_log_line(replica, line, self.include_platform_timestamp)
                 );
-            });
+            }
+        }
     }
 }
 
@@ -378,6 +397,7 @@ mod tests {
             tail_lines: 10,
             since_seconds: 30,
             include_platform_timestamp: true,
+            disable_dedupe: false,
             recent_line_capacity: 1000,
         };
 
@@ -399,6 +419,7 @@ mod tests {
             tail_lines: 100,
             since_seconds: 0,
             include_platform_timestamp: false,
+            disable_dedupe: false,
             recent_line_capacity: 1000,
         };
 
@@ -421,11 +442,11 @@ mod tests {
     #[test]
     fn record_if_new_treats_missing_timestamp_as_new() {
         let line = log_line("hello", None);
-        let mut recent = RecentLogLines::new(1000);
+        let mut deduper = RecentLogLineDeduper::new(1000);
 
-        assert!(recent.record_if_new("replica 1/3", &line));
-        assert!(recent.record_if_new("replica 1/3", &line));
-        assert_eq!(recent.len(), 0);
+        assert!(deduper.record_if_new("replica 1/3", &line));
+        assert!(deduper.record_if_new("replica 1/3", &line));
+        assert_eq!(deduper.len(), 0);
     }
 
     #[test]
@@ -469,29 +490,29 @@ mod tests {
     }
 
     #[test]
-    fn recent_log_lines_treats_non_timestamped_lines_as_new() {
+    fn recent_log_line_deduper_treats_non_timestamped_lines_as_new() {
         let line = log_line("hello", None);
-        let mut recent = RecentLogLines::new(1000);
+        let mut deduper = RecentLogLineDeduper::new(1000);
 
-        assert!(recent.record_if_new("replica 1/2", &line));
-        assert!(recent.record_if_new("replica 1/2", &line));
-        assert_eq!(recent.len(), 0);
+        assert!(deduper.record_if_new("replica 1/2", &line));
+        assert!(deduper.record_if_new("replica 1/2", &line));
+        assert_eq!(deduper.len(), 0);
     }
 
     #[test]
-    fn recent_log_lines_dedupes_timestamped_lines() {
+    fn recent_log_line_deduper_dedupes_timestamped_lines() {
         let line = log_line("hello", Some(timestamp("1710000000", "1")));
-        let mut recent = RecentLogLines::new(1000);
+        let mut deduper = RecentLogLineDeduper::new(1000);
 
-        assert!(recent.record_if_new("replica 1/2", &line));
-        assert!(!recent.record_if_new("replica 1/2", &line));
-        assert_eq!(recent.len(), 1);
+        assert!(deduper.record_if_new("replica 1/2", &line));
+        assert!(!deduper.record_if_new("replica 1/2", &line));
+        assert_eq!(deduper.len(), 1);
     }
 
     #[test]
     #[should_panic(expected = "recent log line capacity must be positive")]
-    fn recent_log_lines_requires_positive_capacity() {
-        RecentLogLines::new(0);
+    fn recent_log_line_deduper_requires_positive_capacity() {
+        RecentLogLineDeduper::new(0);
     }
 
     #[test]
@@ -509,43 +530,53 @@ mod tests {
                 entry("replica 2/2", None),
             ],
         };
-        let mut printer = DebugLogPrinter::new(false, 1000);
+        let mut printer = DebugLogPrinter::new(false, 1000, false);
 
         printer.print_response(&response);
 
-        assert_eq!(printer.recent_lines.len(), 1);
+        assert_eq!(printer.deduper.as_ref().unwrap().len(), 1);
     }
 
     #[test]
-    fn recent_log_lines_evicts_oldest_entries() {
-        let first = log_line_key("replica 1/2", "first", "1710000000", "1");
-        let second = log_line_key("replica 1/2", "second", "1710000000", "2");
-        let third = log_line_key("replica 1/2", "third", "1710000000", "3");
-        let mut recent = RecentLogLines::new(2);
+    fn debug_log_printer_prints_duplicate_timestamped_lines_when_dedupe_is_disabled() {
+        let line = log_line("hello", Some(timestamp("1710000000", "1")));
+        let mut printer = DebugLogPrinter::new(false, 1000, true);
 
-        assert!(recent.insert(first.clone()));
-        assert!(recent.insert(second.clone()));
-        assert!(!recent.insert(first.clone()));
-        assert!(recent.insert(third));
-
-        assert_eq!(recent.len(), 2);
-        assert!(recent.insert(first));
-        assert_eq!(recent.len(), 2);
+        assert!(printer.should_print_line("replica 1/2", &line));
+        assert!(printer.should_print_line("replica 1/2", &line));
+        assert!(printer.deduper.is_none());
     }
 
     #[test]
-    fn recent_log_lines_does_not_grow_past_initial_capacity() {
+    fn recent_log_line_deduper_evicts_oldest_entries() {
         let first = log_line_key("replica 1/2", "first", "1710000000", "1");
         let second = log_line_key("replica 1/2", "second", "1710000000", "2");
         let third = log_line_key("replica 1/2", "third", "1710000000", "3");
-        let mut recent = RecentLogLines::new(2);
-        let initial_capacity = recent.capacity();
+        let mut deduper = RecentLogLineDeduper::new(2);
 
-        assert!(recent.insert(first));
-        assert!(recent.insert(second));
-        assert!(recent.insert(third));
+        assert!(deduper.insert(first.clone()));
+        assert!(deduper.insert(second.clone()));
+        assert!(!deduper.insert(first.clone()));
+        assert!(deduper.insert(third));
 
-        assert_eq!(recent.len(), 2);
-        assert_eq!(recent.capacity(), initial_capacity);
+        assert_eq!(deduper.len(), 2);
+        assert!(deduper.insert(first));
+        assert_eq!(deduper.len(), 2);
+    }
+
+    #[test]
+    fn recent_log_line_deduper_does_not_grow_past_initial_capacity() {
+        let first = log_line_key("replica 1/2", "first", "1710000000", "1");
+        let second = log_line_key("replica 1/2", "second", "1710000000", "2");
+        let third = log_line_key("replica 1/2", "third", "1710000000", "3");
+        let mut deduper = RecentLogLineDeduper::new(2);
+        let initial_capacity = deduper.capacity();
+
+        assert!(deduper.insert(first));
+        assert!(deduper.insert(second));
+        assert!(deduper.insert(third));
+
+        assert_eq!(deduper.len(), 2);
+        assert_eq!(deduper.capacity(), initial_capacity);
     }
 }

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -1,13 +1,11 @@
 //! Deploy debug-logs command.
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 use chrono::{DateTime, SecondsFormat, Utc};
 use clap::Args as ClapArgs;
 use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
 use turnkey_client::TurnkeyP256ApiKey;
-#[cfg(test)]
-use turnkey_client::generated::TvcDeploymentDebugLogEntry;
 use turnkey_client::generated::external::data::v1::{LogLine, Timestamp};
 use turnkey_client::generated::{
     GetTvcDeploymentDebugLogsRequest, GetTvcDeploymentDebugLogsResponse,
@@ -16,6 +14,18 @@ use turnkey_client::generated::{
 const DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS: i64 = 2;
 const FOLLOW_OVERLAP_SECONDS: i64 = 2;
 const RECENT_LOG_LINE_CAPACITY: usize = 1000;
+
+fn follow_poll_interval_seconds_parser() -> clap::builder::RangedI64ValueParser<i64> {
+    clap::value_parser!(i64).range(1..=i64::MAX - FOLLOW_OVERLAP_SECONDS)
+}
+
+fn non_negative_i32_parser() -> clap::builder::RangedI64ValueParser<i32> {
+    clap::value_parser!(i32).range(0..)
+}
+
+fn non_negative_i64_parser() -> clap::builder::RangedI64ValueParser<i64> {
+    clap::value_parser!(i64).range(0..)
+}
 
 pub(crate) const LONG_ABOUT: &str = r#"
 Fetch debug logs for a deployment.
@@ -55,17 +65,31 @@ pub struct Args {
     #[arg(
         long,
         env = "TVC_DEBUG_LOGS_FOLLOW_POLL_INTERVAL_SECONDS",
+        default_value_t = DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS,
+        value_parser = follow_poll_interval_seconds_parser(),
         allow_hyphen_values = true
     )]
-    pub follow_poll_interval_seconds: Option<i64>,
+    pub follow_poll_interval_seconds: i64,
 
     /// Limit raw pod log history requested per replica. Filtered output may contain (many) fewer lines.
-    #[arg(long, env = "TVC_DEBUG_LOGS_TAIL_LINES", allow_hyphen_values = true)]
-    pub tail_lines: Option<i32>,
+    #[arg(
+        long,
+        env = "TVC_DEBUG_LOGS_TAIL_LINES",
+        default_value_t = 0,
+        value_parser = non_negative_i32_parser(),
+        allow_hyphen_values = true
+    )]
+    pub tail_lines: i32,
 
     /// Return logs newer than this many seconds ago.
-    #[arg(long, env = "TVC_DEBUG_LOGS_SINCE_SECONDS", allow_hyphen_values = true)]
-    pub since_seconds: Option<i64>,
+    #[arg(
+        long,
+        env = "TVC_DEBUG_LOGS_SINCE_SECONDS",
+        default_value_t = 0,
+        value_parser = non_negative_i64_parser(),
+        allow_hyphen_values = true
+    )]
+    pub since_seconds: i64,
 
     /// Include the platform timestamp prepended by the Kubernetes log stream.
     #[arg(long, env = "TVC_DEBUG_LOGS_INCLUDE_PLATFORM_TIMESTAMP")]
@@ -74,23 +98,19 @@ pub struct Args {
 
 /// Run the `deploy debug-logs` command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    let tail_lines = tail_lines_or_default(args.tail_lines)?;
-    let since_seconds = since_seconds_or_default(args.since_seconds)?;
-    let follow_poll_interval_seconds =
-        follow_poll_interval_seconds_or_default(args.follow, args.follow_poll_interval_seconds)?;
     let auth = crate::client::build_client().await?;
 
     let request = DebugLogQueryRequest {
         organization_id: auth.org_id,
         deployment_id: args.deploy_id,
         follow: args.follow,
-        follow_poll_interval_seconds,
-        tail_lines,
-        since_seconds,
+        follow_poll_interval_seconds: args.follow_poll_interval_seconds,
+        tail_lines: args.tail_lines,
+        since_seconds: args.since_seconds,
         include_platform_timestamp: args.include_platform_timestamp,
     };
 
-    query_debug_logs(&auth.client, &request).await
+    query_debug_logs(&auth.client, request).await
 }
 
 #[derive(Clone, Debug)]
@@ -104,112 +124,66 @@ struct DebugLogQueryRequest {
     include_platform_timestamp: bool,
 }
 
-impl DebugLogQueryRequest {
-    fn to_api_request(&self) -> GetTvcDeploymentDebugLogsRequest {
-        GetTvcDeploymentDebugLogsRequest {
-            organization_id: self.organization_id.clone(),
-            deployment_id: self.deployment_id.clone(),
-            tail_lines: self.tail_lines,
-            since_seconds: self.since_seconds,
+impl From<DebugLogQueryRequest> for GetTvcDeploymentDebugLogsRequest {
+    fn from(req: DebugLogQueryRequest) -> Self {
+        Self {
+            organization_id: req.organization_id,
+            deployment_id: req.deployment_id,
+            tail_lines: req.tail_lines,
+            since_seconds: req.since_seconds,
         }
     }
+}
 
-    fn followup_request(&self) -> Self {
+impl DebugLogQueryRequest {
+    fn into_followup_request(self) -> Self {
         Self {
             tail_lines: 0,
             since_seconds: self.follow_poll_interval_seconds + FOLLOW_OVERLAP_SECONDS,
-            ..self.clone()
+            ..self
         }
     }
 }
 
 async fn query_debug_logs(
     client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
-    request: &DebugLogQueryRequest,
+    request: DebugLogQueryRequest,
 ) -> anyhow::Result<()> {
     let mut log_printer =
         DebugLogPrinter::new(request.include_platform_timestamp, RECENT_LOG_LINE_CAPACITY);
-    let mut current_request = request.clone();
 
-    let response = fetch_debug_logs(client, &current_request).await?;
-    if request.follow {
-        eprintln!("Connected; polling for debug logs...");
-    }
+    let (current_request, followup_request) = if request.follow {
+        (request.clone(), Some(request.into_followup_request()))
+    } else {
+        (request, None)
+    };
+
+    let response = fetch_debug_logs(client, current_request).await?;
     log_printer.print_response(&response);
 
-    if !request.follow {
+    let Some(followup_request) = followup_request else {
         return Ok(());
-    }
+    };
 
-    current_request = request.followup_request();
+    eprintln!("Connected; polling for debug logs...");
 
-    let follow_poll_interval = Duration::from_secs(request.follow_poll_interval_seconds as u64);
+    let follow_poll_interval =
+        Duration::from_secs(followup_request.follow_poll_interval_seconds as u64);
     loop {
         tokio::time::sleep(follow_poll_interval).await;
-        let response = fetch_debug_logs(client, &current_request).await?;
+        let response = fetch_debug_logs(client, followup_request.clone()).await?;
         log_printer.print_response(&response);
     }
 }
 
 async fn fetch_debug_logs(
     client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
-    request: &DebugLogQueryRequest,
+    request: DebugLogQueryRequest,
 ) -> anyhow::Result<GetTvcDeploymentDebugLogsResponse> {
     client
-        .get_tvc_deployment_debug_logs(request.to_api_request())
+        .get_tvc_deployment_debug_logs(request.into())
         .await
         .context("failed to fetch debug logs")
-}
-
-fn tail_lines_or_default(tail_lines: Option<i32>) -> anyhow::Result<i32> {
-    let Some(tail_lines) = tail_lines else {
-        return Ok(0);
-    };
-
-    if tail_lines < 0 {
-        bail!("--tail-lines must be greater than or equal to 0");
-    }
-
-    Ok(tail_lines)
-}
-
-fn since_seconds_or_default(since_seconds: Option<i64>) -> anyhow::Result<i64> {
-    let Some(since_seconds) = since_seconds else {
-        return Ok(0);
-    };
-
-    if since_seconds < 0 {
-        bail!("--since-seconds must be greater than or equal to 0");
-    }
-
-    Ok(since_seconds)
-}
-
-fn follow_poll_interval_seconds_or_default(
-    follow: bool,
-    follow_poll_interval_seconds: Option<i64>,
-) -> anyhow::Result<i64> {
-    if !follow {
-        if follow_poll_interval_seconds.is_some() {
-            eprintln!(
-                "--follow is disabled, disregarding value for --follow-poll-interval-seconds"
-            );
-        }
-        return Ok(DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS);
-    }
-
-    let follow_poll_interval_seconds =
-        follow_poll_interval_seconds.unwrap_or(DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS);
-
-    if follow_poll_interval_seconds <= 0 {
-        bail!("--follow-poll-interval-seconds must be greater than 0");
-    }
-
-    if follow_poll_interval_seconds > i64::MAX - FOLLOW_OVERLAP_SECONDS {
-        bail!("--follow-poll-interval-seconds is too large");
-    }
-
-    Ok(follow_poll_interval_seconds)
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -269,7 +243,7 @@ impl RecentLogLines {
         true
     }
 
-    /// Records timestamped lines and returns whether they are new; untimestamped lines always pass.
+    /// Records timestamped lines and returns whether they are new; lines missing timestamps always pass.
     ///
     /// NOTE: Mutating filter
     fn record_if_new(&mut self, replica: &str, line: &LogLine) -> bool {
@@ -345,6 +319,7 @@ fn format_timestamp(timestamp: &Timestamp) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use turnkey_client::generated::TvcDeploymentDebugLogEntry;
 
     fn log_line(content: &str, ts: Option<Timestamp>) -> LogLine {
         LogLine {
@@ -368,89 +343,6 @@ mod tests {
     }
 
     #[test]
-    fn tail_lines_defaults_to_zero_when_omitted() {
-        assert_eq!(tail_lines_or_default(None).unwrap(), 0);
-    }
-
-    #[test]
-    fn tail_lines_accepts_zero_and_positive_values() {
-        assert_eq!(tail_lines_or_default(Some(0)).unwrap(), 0);
-        assert_eq!(tail_lines_or_default(Some(25)).unwrap(), 25);
-    }
-
-    #[test]
-    fn tail_lines_rejects_negative_values() {
-        let err = tail_lines_or_default(Some(-1)).unwrap_err();
-        assert!(err.to_string().contains("--tail-lines"));
-    }
-
-    #[test]
-    fn since_seconds_defaults_to_zero_when_omitted() {
-        assert_eq!(since_seconds_or_default(None).unwrap(), 0);
-    }
-
-    #[test]
-    fn since_seconds_accepts_zero_and_positive_values() {
-        assert_eq!(since_seconds_or_default(Some(0)).unwrap(), 0);
-        assert_eq!(since_seconds_or_default(Some(25)).unwrap(), 25);
-    }
-
-    #[test]
-    fn since_seconds_rejects_negative_values() {
-        let err = since_seconds_or_default(Some(-1)).unwrap_err();
-        assert!(err.to_string().contains("--since-seconds"));
-    }
-
-    #[test]
-    fn follow_poll_interval_seconds_defaults_to_two_when_omitted() {
-        assert_eq!(
-            follow_poll_interval_seconds_or_default(true, None).unwrap(),
-            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
-        );
-    }
-
-    #[test]
-    fn follow_poll_interval_seconds_accepts_positive_values() {
-        assert_eq!(
-            follow_poll_interval_seconds_or_default(true, Some(1)).unwrap(),
-            1
-        );
-        assert_eq!(
-            follow_poll_interval_seconds_or_default(true, Some(25)).unwrap(),
-            25
-        );
-    }
-
-    #[test]
-    fn follow_poll_interval_seconds_rejects_zero_and_negative_values() {
-        let zero_err = follow_poll_interval_seconds_or_default(true, Some(0)).unwrap_err();
-        assert!(
-            zero_err
-                .to_string()
-                .contains("--follow-poll-interval-seconds")
-        );
-
-        let negative_err = follow_poll_interval_seconds_or_default(true, Some(-1)).unwrap_err();
-        assert!(
-            negative_err
-                .to_string()
-                .contains("--follow-poll-interval-seconds")
-        );
-    }
-
-    #[test]
-    fn follow_poll_interval_seconds_ignores_values_without_follow() {
-        assert_eq!(
-            follow_poll_interval_seconds_or_default(false, Some(0)).unwrap(),
-            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
-        );
-        assert_eq!(
-            follow_poll_interval_seconds_or_default(false, Some(-1)).unwrap(),
-            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
-        );
-    }
-
-    #[test]
     fn request_maps_to_unary_api_request() {
         let request = DebugLogQueryRequest {
             organization_id: "org".to_string(),
@@ -462,7 +354,7 @@ mod tests {
             include_platform_timestamp: true,
         };
 
-        let api_request = request.to_api_request();
+        let api_request: GetTvcDeploymentDebugLogsRequest = request.into();
 
         assert_eq!(api_request.organization_id, "org");
         assert_eq!(api_request.deployment_id, "deployment");
@@ -471,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn followup_request_uses_overlapping_since_window() {
+    fn into_followup_request_uses_overlapping_since_window() {
         let request = DebugLogQueryRequest {
             organization_id: "org".to_string(),
             deployment_id: "deployment".to_string(),
@@ -482,7 +374,7 @@ mod tests {
             include_platform_timestamp: false,
         };
 
-        let followup = request.followup_request();
+        let followup = request.clone().into_followup_request();
 
         assert_eq!(followup.tail_lines, 0);
         assert_eq!(followup.since_seconds, 9);

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -1,0 +1,620 @@
+//! Deploy debug-logs command.
+
+use anyhow::{Context, bail};
+use chrono::{DateTime, SecondsFormat, Utc};
+use clap::Args as ClapArgs;
+use std::collections::{HashSet, VecDeque};
+use std::time::Duration;
+use turnkey_client::TurnkeyP256ApiKey;
+#[cfg(test)]
+use turnkey_client::generated::TvcDeploymentDebugLogEntry;
+use turnkey_client::generated::external::data::v1::{LogLine, Timestamp};
+use turnkey_client::generated::{
+    GetTvcDeploymentDebugLogsRequest, GetTvcDeploymentDebugLogsResponse,
+};
+
+const DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS: i64 = 2;
+const FOLLOW_OVERLAP_SECONDS: i64 = 2;
+const RECENT_LOG_LINE_CAPACITY: usize = 1000;
+
+pub(crate) const LONG_ABOUT: &str = r#"
+Fetch debug logs for a deployment.
+
+Debug logs are only available when debug mode has been enabled at both the app
+and deployment levels. First, the app must opt in to allowing debug-mode
+deployments with `--dangerous-enable-debug-mode-deployments`. That app-level
+opt-in only permits debug deployments; it does not make every deployment
+debuggable.
+
+The specific deployment must also be created in debug mode with
+`--dangerous-deploy-debug-mode`. Existing non-debug deployments cannot expose
+debug logs retroactively. Create a new debug-mode deployment, then pass that
+deployment ID to this command.
+
+Use `--follow` to keep polling for new log lines after the initial log window.
+Follow mode polls every 2 seconds by default and requests a 2-second overlap
+on each follow-up poll to avoid missing late-arriving log lines.
+By default, output omits the platform timestamp that Kubernetes prepends to each
+log line; pass `--include-platform-timestamp` to show it.
+See `tvc app create --help`, `tvc deploy create --help`, and `tvc --help`
+for more info."#;
+
+/// Fetch debug logs for a deployment.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = LONG_ABOUT)]
+pub struct Args {
+    /// ID of the deployment.
+    #[arg(short = 'd', long, env = "TVC_DEPLOY_ID")]
+    pub deploy_id: String,
+
+    /// Keep polling for new lines.
+    #[arg(long, env = "TVC_DEBUG_LOGS_FOLLOW")]
+    pub follow: bool,
+
+    /// Seconds to wait between follow-mode polls.
+    #[arg(
+        long,
+        env = "TVC_DEBUG_LOGS_FOLLOW_POLL_INTERVAL_SECONDS",
+        allow_hyphen_values = true
+    )]
+    pub follow_poll_interval_seconds: Option<i64>,
+
+    /// Limit raw pod log history requested per replica. Filtered output may contain (many) fewer lines.
+    #[arg(long, env = "TVC_DEBUG_LOGS_TAIL_LINES", allow_hyphen_values = true)]
+    pub tail_lines: Option<i32>,
+
+    /// Return logs newer than this many seconds ago.
+    #[arg(long, env = "TVC_DEBUG_LOGS_SINCE_SECONDS", allow_hyphen_values = true)]
+    pub since_seconds: Option<i64>,
+
+    /// Include the platform timestamp prepended by the Kubernetes log stream.
+    #[arg(long, env = "TVC_DEBUG_LOGS_INCLUDE_PLATFORM_TIMESTAMP")]
+    pub include_platform_timestamp: bool,
+}
+
+/// Run the `deploy debug-logs` command.
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    let tail_lines = tail_lines_or_default(args.tail_lines)?;
+    let since_seconds = since_seconds_or_default(args.since_seconds)?;
+    let follow_poll_interval_seconds =
+        follow_poll_interval_seconds_or_default(args.follow, args.follow_poll_interval_seconds)?;
+    let auth = crate::client::build_client().await?;
+
+    let request = DebugLogQueryRequest {
+        organization_id: auth.org_id,
+        deployment_id: args.deploy_id,
+        follow: args.follow,
+        follow_poll_interval_seconds,
+        tail_lines,
+        since_seconds,
+        include_platform_timestamp: args.include_platform_timestamp,
+    };
+
+    query_debug_logs(&auth.client, &request).await
+}
+
+#[derive(Clone, Debug)]
+struct DebugLogQueryRequest {
+    organization_id: String,
+    deployment_id: String,
+    follow: bool,
+    follow_poll_interval_seconds: i64,
+    tail_lines: i32,
+    since_seconds: i64,
+    include_platform_timestamp: bool,
+}
+
+impl DebugLogQueryRequest {
+    fn to_api_request(&self) -> GetTvcDeploymentDebugLogsRequest {
+        GetTvcDeploymentDebugLogsRequest {
+            organization_id: self.organization_id.clone(),
+            deployment_id: self.deployment_id.clone(),
+            tail_lines: self.tail_lines,
+            since_seconds: self.since_seconds,
+        }
+    }
+
+    fn followup_request(&self) -> Self {
+        Self {
+            tail_lines: 0,
+            since_seconds: self.follow_poll_interval_seconds + FOLLOW_OVERLAP_SECONDS,
+            ..self.clone()
+        }
+    }
+}
+
+async fn query_debug_logs(
+    client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
+    request: &DebugLogQueryRequest,
+) -> anyhow::Result<()> {
+    let mut log_printer =
+        DebugLogPrinter::new(request.include_platform_timestamp, RECENT_LOG_LINE_CAPACITY);
+    let mut current_request = request.clone();
+
+    let response = fetch_debug_logs(client, &current_request).await?;
+    if request.follow {
+        eprintln!("Connected; polling for debug logs...");
+    }
+    log_printer.print_response(&response);
+
+    if !request.follow {
+        return Ok(());
+    }
+
+    current_request = request.followup_request();
+
+    let follow_poll_interval = Duration::from_secs(request.follow_poll_interval_seconds as u64);
+    loop {
+        tokio::time::sleep(follow_poll_interval).await;
+        let response = fetch_debug_logs(client, &current_request).await?;
+        log_printer.print_response(&response);
+    }
+}
+
+async fn fetch_debug_logs(
+    client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
+    request: &DebugLogQueryRequest,
+) -> anyhow::Result<GetTvcDeploymentDebugLogsResponse> {
+    client
+        .get_tvc_deployment_debug_logs(request.to_api_request())
+        .await
+        .context("failed to fetch debug logs")
+}
+
+fn tail_lines_or_default(tail_lines: Option<i32>) -> anyhow::Result<i32> {
+    let Some(tail_lines) = tail_lines else {
+        return Ok(0);
+    };
+
+    if tail_lines < 0 {
+        bail!("--tail-lines must be greater than or equal to 0");
+    }
+
+    Ok(tail_lines)
+}
+
+fn since_seconds_or_default(since_seconds: Option<i64>) -> anyhow::Result<i64> {
+    let Some(since_seconds) = since_seconds else {
+        return Ok(0);
+    };
+
+    if since_seconds < 0 {
+        bail!("--since-seconds must be greater than or equal to 0");
+    }
+
+    Ok(since_seconds)
+}
+
+fn follow_poll_interval_seconds_or_default(
+    follow: bool,
+    follow_poll_interval_seconds: Option<i64>,
+) -> anyhow::Result<i64> {
+    if !follow {
+        if follow_poll_interval_seconds.is_some() {
+            eprintln!(
+                "--follow is disabled, disregarding value for --follow-poll-interval-seconds"
+            );
+        }
+        return Ok(DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS);
+    }
+
+    let follow_poll_interval_seconds =
+        follow_poll_interval_seconds.unwrap_or(DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS);
+
+    if follow_poll_interval_seconds <= 0 {
+        bail!("--follow-poll-interval-seconds must be greater than 0");
+    }
+
+    if follow_poll_interval_seconds > i64::MAX - FOLLOW_OVERLAP_SECONDS {
+        bail!("--follow-poll-interval-seconds is too large");
+    }
+
+    Ok(follow_poll_interval_seconds)
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct LogLineKey {
+    replica: String,
+    content: String,
+    seconds: String,
+    nanos: String,
+}
+
+impl LogLineKey {
+    fn new(replica: &str, line: &LogLine) -> Option<Self> {
+        let ts = line.ts.as_ref()?;
+
+        Some(Self {
+            replica: replica.into(),
+            content: line.content.clone(),
+            seconds: ts.seconds.clone(),
+            nanos: ts.nanos.clone(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct RecentLogLines {
+    seen: HashSet<LogLineKey>,
+    order: VecDeque<LogLineKey>,
+    capacity: usize,
+}
+
+impl RecentLogLines {
+    fn new(capacity: usize) -> Self {
+        Self {
+            seen: HashSet::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn insert(&mut self, key: LogLineKey) -> bool {
+        if self.capacity == 0 {
+            return true;
+        }
+
+        if !self.seen.insert(key.clone()) {
+            return false;
+        }
+
+        self.order.push_back(key);
+
+        while self.order.len() > self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.seen.remove(&oldest);
+            }
+        }
+
+        true
+    }
+
+    /// Records timestamped lines and returns whether they are new; untimestamped lines always pass.
+    ///
+    /// NOTE: Mutating filter
+    fn record_if_new(&mut self, replica: &str, line: &LogLine) -> bool {
+        match LogLineKey::new(replica, line) {
+            Some(key) => self.insert(key),
+            None => true,
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.seen.len()
+    }
+}
+
+#[derive(Debug)]
+struct DebugLogPrinter {
+    recent_lines: RecentLogLines,
+    include_platform_timestamp: bool,
+}
+
+impl DebugLogPrinter {
+    fn new(include_platform_timestamp: bool, recent_line_capacity: usize) -> Self {
+        Self {
+            recent_lines: RecentLogLines::new(recent_line_capacity),
+            include_platform_timestamp,
+        }
+    }
+
+    fn print_response(&mut self, response: &GetTvcDeploymentDebugLogsResponse) {
+        let recent_lines = &mut self.recent_lines;
+        let include_platform_timestamp = self.include_platform_timestamp;
+
+        // `record_if_new` updates the `recent_lines` cache while filtering duplicates.
+        response
+            .entries
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .line
+                    .as_ref()
+                    .map(|line| (entry.replica_label.as_str(), line))
+            })
+            .filter(|(replica, line)| recent_lines.record_if_new(replica, line))
+            .for_each(|(replica, line)| {
+                println!(
+                    "{}",
+                    format_log_line(replica, line, include_platform_timestamp)
+                );
+            });
+    }
+}
+
+fn format_log_line(replica: &str, line: &LogLine, include_platform_timestamp: bool) -> String {
+    if !include_platform_timestamp {
+        return format!("{replica} {}", line.content);
+    }
+
+    match line.ts.as_ref().and_then(format_timestamp) {
+        Some(ts) => format!("{ts} {replica} {}", line.content),
+        None => format!("{replica} {}", line.content),
+    }
+}
+
+fn format_timestamp(timestamp: &Timestamp) -> Option<String> {
+    let seconds = timestamp.seconds.parse::<i64>().ok()?;
+    let nanos = timestamp.nanos.parse::<u32>().ok()?;
+
+    DateTime::<Utc>::from_timestamp(seconds, nanos)
+        .map(|dt| dt.to_rfc3339_opts(SecondsFormat::Nanos, true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn log_line(content: &str, ts: Option<Timestamp>) -> LogLine {
+        LogLine {
+            content: content.to_string(),
+            ts,
+        }
+    }
+
+    fn timestamp(seconds: &str, nanos: &str) -> Timestamp {
+        Timestamp {
+            seconds: seconds.to_string(),
+            nanos: nanos.to_string(),
+        }
+    }
+
+    fn entry(replica: &str, line: Option<LogLine>) -> TvcDeploymentDebugLogEntry {
+        TvcDeploymentDebugLogEntry {
+            replica_label: replica.to_string(),
+            line,
+        }
+    }
+
+    #[test]
+    fn tail_lines_defaults_to_zero_when_omitted() {
+        assert_eq!(tail_lines_or_default(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn tail_lines_accepts_zero_and_positive_values() {
+        assert_eq!(tail_lines_or_default(Some(0)).unwrap(), 0);
+        assert_eq!(tail_lines_or_default(Some(25)).unwrap(), 25);
+    }
+
+    #[test]
+    fn tail_lines_rejects_negative_values() {
+        let err = tail_lines_or_default(Some(-1)).unwrap_err();
+        assert!(err.to_string().contains("--tail-lines"));
+    }
+
+    #[test]
+    fn since_seconds_defaults_to_zero_when_omitted() {
+        assert_eq!(since_seconds_or_default(None).unwrap(), 0);
+    }
+
+    #[test]
+    fn since_seconds_accepts_zero_and_positive_values() {
+        assert_eq!(since_seconds_or_default(Some(0)).unwrap(), 0);
+        assert_eq!(since_seconds_or_default(Some(25)).unwrap(), 25);
+    }
+
+    #[test]
+    fn since_seconds_rejects_negative_values() {
+        let err = since_seconds_or_default(Some(-1)).unwrap_err();
+        assert!(err.to_string().contains("--since-seconds"));
+    }
+
+    #[test]
+    fn follow_poll_interval_seconds_defaults_to_two_when_omitted() {
+        assert_eq!(
+            follow_poll_interval_seconds_or_default(true, None).unwrap(),
+            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
+        );
+    }
+
+    #[test]
+    fn follow_poll_interval_seconds_accepts_positive_values() {
+        assert_eq!(
+            follow_poll_interval_seconds_or_default(true, Some(1)).unwrap(),
+            1
+        );
+        assert_eq!(
+            follow_poll_interval_seconds_or_default(true, Some(25)).unwrap(),
+            25
+        );
+    }
+
+    #[test]
+    fn follow_poll_interval_seconds_rejects_zero_and_negative_values() {
+        let zero_err = follow_poll_interval_seconds_or_default(true, Some(0)).unwrap_err();
+        assert!(
+            zero_err
+                .to_string()
+                .contains("--follow-poll-interval-seconds")
+        );
+
+        let negative_err = follow_poll_interval_seconds_or_default(true, Some(-1)).unwrap_err();
+        assert!(
+            negative_err
+                .to_string()
+                .contains("--follow-poll-interval-seconds")
+        );
+    }
+
+    #[test]
+    fn follow_poll_interval_seconds_ignores_values_without_follow() {
+        assert_eq!(
+            follow_poll_interval_seconds_or_default(false, Some(0)).unwrap(),
+            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
+        );
+        assert_eq!(
+            follow_poll_interval_seconds_or_default(false, Some(-1)).unwrap(),
+            DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS
+        );
+    }
+
+    #[test]
+    fn request_maps_to_unary_api_request() {
+        let request = DebugLogQueryRequest {
+            organization_id: "org".to_string(),
+            deployment_id: "deployment".to_string(),
+            follow: true,
+            follow_poll_interval_seconds: DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS,
+            tail_lines: 10,
+            since_seconds: 30,
+            include_platform_timestamp: true,
+        };
+
+        let api_request = request.to_api_request();
+
+        assert_eq!(api_request.organization_id, "org");
+        assert_eq!(api_request.deployment_id, "deployment");
+        assert_eq!(api_request.tail_lines, 10);
+        assert_eq!(api_request.since_seconds, 30);
+    }
+
+    #[test]
+    fn followup_request_uses_overlapping_since_window() {
+        let request = DebugLogQueryRequest {
+            organization_id: "org".to_string(),
+            deployment_id: "deployment".to_string(),
+            follow: true,
+            follow_poll_interval_seconds: 7,
+            tail_lines: 100,
+            since_seconds: 0,
+            include_platform_timestamp: false,
+        };
+
+        let followup = request.followup_request();
+
+        assert_eq!(followup.tail_lines, 0);
+        assert_eq!(followup.since_seconds, 9);
+        assert_eq!(followup.organization_id, request.organization_id);
+        assert_eq!(followup.deployment_id, request.deployment_id);
+    }
+
+    #[test]
+    fn log_line_key_matches_duplicate_lines() {
+        let line = log_line("hello", Some(timestamp("1710000000", "123456789")));
+
+        assert_eq!(
+            LogLineKey::new("replica 1/3", &line),
+            LogLineKey::new("replica 1/3", &line)
+        );
+    }
+
+    #[test]
+    fn log_line_key_requires_timestamp() {
+        let line = log_line("hello", None);
+
+        assert_eq!(LogLineKey::new("replica 1/3", &line), None);
+    }
+
+    #[test]
+    fn format_log_line_omits_platform_timestamp_by_default() {
+        let line = log_line("hello", Some(timestamp("1710000000", "123456789")));
+
+        assert_eq!(
+            format_log_line("replica 1/3", &line, false),
+            "replica 1/3 hello"
+        );
+    }
+
+    #[test]
+    fn format_log_line_includes_platform_timestamp_when_requested() {
+        let line = log_line("hello", Some(timestamp("1710000000", "123456789")));
+
+        assert_eq!(
+            format_log_line("replica 1/3", &line, true),
+            "2024-03-09T16:00:00.123456789Z replica 1/3 hello"
+        );
+    }
+
+    #[test]
+    fn format_log_line_omits_timestamp_when_missing() {
+        let line = log_line("hello", None);
+
+        assert_eq!(
+            format_log_line("replica 1/3", &line, true),
+            "replica 1/3 hello"
+        );
+    }
+
+    #[test]
+    fn format_log_line_omits_invalid_timestamp() {
+        let line = log_line("hello", Some(timestamp("bad", "123")));
+
+        assert_eq!(
+            format_log_line("replica 1/3", &line, true),
+            "replica 1/3 hello"
+        );
+    }
+
+    #[test]
+    fn recent_log_lines_treats_untimestamped_lines_as_new() {
+        let line = log_line("hello", None);
+        let mut recent = RecentLogLines::new(RECENT_LOG_LINE_CAPACITY);
+
+        assert!(recent.record_if_new("replica 1/2", &line));
+        assert!(recent.record_if_new("replica 1/2", &line));
+        assert_eq!(recent.len(), 0);
+    }
+
+    #[test]
+    fn recent_log_lines_dedupes_timestamped_lines() {
+        let line = log_line("hello", Some(timestamp("1710000000", "1")));
+        let mut recent = RecentLogLines::new(RECENT_LOG_LINE_CAPACITY);
+
+        assert!(recent.record_if_new("replica 1/2", &line));
+        assert!(!recent.record_if_new("replica 1/2", &line));
+        assert_eq!(recent.len(), 1);
+    }
+
+    #[test]
+    fn debug_log_printer_skips_empty_entries_and_dedupes_timestamped_lines() {
+        let response = GetTvcDeploymentDebugLogsResponse {
+            entries: vec![
+                entry(
+                    "replica 1/2",
+                    Some(log_line("hello", Some(timestamp("1710000000", "1")))),
+                ),
+                entry(
+                    "replica 1/2",
+                    Some(log_line("hello", Some(timestamp("1710000000", "1")))),
+                ),
+                entry("replica 2/2", None),
+            ],
+        };
+        let mut printer = DebugLogPrinter::new(false, RECENT_LOG_LINE_CAPACITY);
+
+        printer.print_response(&response);
+
+        assert_eq!(printer.recent_lines.len(), 1);
+    }
+
+    #[test]
+    fn recent_log_lines_evicts_oldest_entries() {
+        let first = LogLineKey::new(
+            "replica 1/2",
+            &log_line("first", Some(timestamp("1710000000", "1"))),
+        )
+        .unwrap();
+        let second = LogLineKey::new(
+            "replica 1/2",
+            &log_line("second", Some(timestamp("1710000000", "2"))),
+        )
+        .unwrap();
+        let third = LogLineKey::new(
+            "replica 1/2",
+            &log_line("third", Some(timestamp("1710000000", "3"))),
+        )
+        .unwrap();
+        let mut recent = RecentLogLines::new(2);
+
+        assert!(recent.insert(first.clone()));
+        assert!(recent.insert(second.clone()));
+        assert!(!recent.insert(first.clone()));
+        assert!(recent.insert(third));
+
+        assert_eq!(recent.len(), 2);
+        assert!(recent.insert(first));
+        assert_eq!(recent.len(), 2);
+    }
+}

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -11,11 +11,11 @@ use turnkey_client::generated::{
     GetTvcDeploymentDebugLogsRequest, GetTvcDeploymentDebugLogsResponse,
 };
 
-const DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS: i64 = 2;
-const FOLLOW_OVERLAP_SECONDS: i64 = 2;
+const DEFAULT_POLL_INTERVAL_SECONDS: i64 = 2;
+const POLL_OVERLAP_SECONDS: i64 = 2;
 
-fn follow_poll_interval_seconds_parser() -> clap::builder::RangedI64ValueParser<i64> {
-    clap::value_parser!(i64).range(1..=i64::MAX - FOLLOW_OVERLAP_SECONDS)
+fn poll_interval_seconds_parser() -> clap::builder::RangedI64ValueParser<i64> {
+    clap::value_parser!(i64).range(1..=i64::MAX - POLL_OVERLAP_SECONDS)
 }
 
 fn non_negative_i32_parser() -> clap::builder::RangedI64ValueParser<i32> {
@@ -44,9 +44,9 @@ The specific deployment must also be created in debug mode with
 debug logs retroactively. Create a new debug-mode deployment, then pass that
 deployment ID to this command.
 
-Use `--follow` to keep polling for new log lines after the initial log window.
-Follow mode polls every 2 seconds by default and requests a 2-second overlap
-on each follow-up poll to avoid missing late-arriving log lines.
+Use `--poll` to keep polling for new log lines after the initial log window.
+Poll mode polls every 2 seconds by default and requests a 2-second overlap
+on each subsequent poll to avoid missing late-arriving log lines.
 By default, output omits the platform timestamp that Kubernetes prepends to each
 log line; pass `--include-platform-timestamp` to show it.
 See `tvc app create --help`, `tvc deploy create --help`, and `tvc --help`
@@ -61,18 +61,18 @@ pub struct Args {
     pub deploy_id: String,
 
     /// Keep polling for new lines.
-    #[arg(long, env = "TVC_DEBUG_LOGS_FOLLOW")]
-    pub follow: bool,
+    #[arg(long, env = "TVC_DEBUG_LOGS_POLL")]
+    pub poll: bool,
 
-    /// Seconds to wait between follow-mode polls.
+    /// Seconds to wait between polls.
     #[arg(
         long,
-        env = "TVC_DEBUG_LOGS_FOLLOW_POLL_INTERVAL_SECONDS",
-        default_value_t = DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS,
-        value_parser = follow_poll_interval_seconds_parser(),
+        env = "TVC_DEBUG_LOGS_POLL_INTERVAL_SECONDS",
+        default_value_t = DEFAULT_POLL_INTERVAL_SECONDS,
+        value_parser = poll_interval_seconds_parser(),
         allow_hyphen_values = true
     )]
-    pub follow_poll_interval_seconds: i64,
+    pub poll_interval_seconds: i64,
 
     /// Limit raw pod log history requested per replica. Filtered output may contain (many) fewer lines.
     #[arg(
@@ -98,7 +98,7 @@ pub struct Args {
     #[arg(long, env = "TVC_DEBUG_LOGS_INCLUDE_PLATFORM_TIMESTAMP")]
     pub include_platform_timestamp: bool,
 
-    /// Number of recently printed timestamped lines retained for follow-mode dedupe. This should
+    /// Number of recently printed timestamped lines retained for poll-mode dedupe. This should
     /// only be increased if high-volume logs still show duplicates across poll overlap windows.
     #[arg(
         long,
@@ -116,8 +116,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     let request = DebugLogQueryRequest {
         organization_id: auth.org_id,
         deployment_id: args.deploy_id,
-        follow: args.follow,
-        follow_poll_interval_seconds: args.follow_poll_interval_seconds,
+        poll: args.poll,
+        poll_interval_seconds: args.poll_interval_seconds,
         tail_lines: args.tail_lines,
         since_seconds: args.since_seconds,
         include_platform_timestamp: args.include_platform_timestamp,
@@ -131,8 +131,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
 struct DebugLogQueryRequest {
     organization_id: String,
     deployment_id: String,
-    follow: bool,
-    follow_poll_interval_seconds: i64,
+    poll: bool,
+    poll_interval_seconds: i64,
     tail_lines: i32,
     since_seconds: i64,
     include_platform_timestamp: bool,
@@ -151,10 +151,10 @@ impl From<DebugLogQueryRequest> for GetTvcDeploymentDebugLogsRequest {
 }
 
 impl DebugLogQueryRequest {
-    fn into_followup_request(self) -> Self {
+    fn into_poll_request(self) -> Self {
         Self {
             tail_lines: 0,
-            since_seconds: self.follow_poll_interval_seconds + FOLLOW_OVERLAP_SECONDS,
+            since_seconds: self.poll_interval_seconds + POLL_OVERLAP_SECONDS,
             ..self
         }
     }
@@ -169,8 +169,8 @@ async fn query_debug_logs(
         request.recent_line_capacity,
     );
 
-    let (current_request, followup_request) = if request.follow {
-        (request.clone(), Some(request.into_followup_request()))
+    let (current_request, poll_request) = if request.poll {
+        (request.clone(), Some(request.into_poll_request()))
     } else {
         (request, None)
     };
@@ -178,17 +178,16 @@ async fn query_debug_logs(
     let response = fetch_debug_logs(client, current_request).await?;
     log_printer.print_response(&response);
 
-    let Some(followup_request) = followup_request else {
+    let Some(poll_request) = poll_request else {
         return Ok(());
     };
 
     eprintln!("Connected; polling for debug logs...");
 
-    let follow_poll_interval =
-        Duration::from_secs(followup_request.follow_poll_interval_seconds as u64);
+    let poll_interval = Duration::from_secs(poll_request.poll_interval_seconds as u64);
     loop {
-        tokio::time::sleep(follow_poll_interval).await;
-        let response = fetch_debug_logs(client, followup_request.clone()).await?;
+        tokio::time::sleep(poll_interval).await;
+        let response = fetch_debug_logs(client, poll_request.clone()).await?;
         log_printer.print_response(&response);
     }
 }
@@ -374,8 +373,8 @@ mod tests {
         let request = DebugLogQueryRequest {
             organization_id: "org".to_string(),
             deployment_id: "deployment".to_string(),
-            follow: true,
-            follow_poll_interval_seconds: DEFAULT_FOLLOW_POLL_INTERVAL_SECONDS,
+            poll: true,
+            poll_interval_seconds: DEFAULT_POLL_INTERVAL_SECONDS,
             tail_lines: 10,
             since_seconds: 30,
             include_platform_timestamp: true,
@@ -391,24 +390,24 @@ mod tests {
     }
 
     #[test]
-    fn into_followup_request_uses_overlapping_since_window() {
+    fn into_poll_request_uses_overlapping_since_window() {
         let request = DebugLogQueryRequest {
             organization_id: "org".to_string(),
             deployment_id: "deployment".to_string(),
-            follow: true,
-            follow_poll_interval_seconds: 7,
+            poll: true,
+            poll_interval_seconds: 7,
             tail_lines: 100,
             since_seconds: 0,
             include_platform_timestamp: false,
             recent_line_capacity: 1000,
         };
 
-        let followup = request.clone().into_followup_request();
+        let poll_request = request.clone().into_poll_request();
 
-        assert_eq!(followup.tail_lines, 0);
-        assert_eq!(followup.since_seconds, 9);
-        assert_eq!(followup.organization_id, request.organization_id);
-        assert_eq!(followup.deployment_id, request.deployment_id);
+        assert_eq!(poll_request.tail_lines, 0);
+        assert_eq!(poll_request.since_seconds, 9);
+        assert_eq!(poll_request.organization_id, request.organization_id);
+        assert_eq!(poll_request.deployment_id, request.deployment_id);
     }
 
     #[test]

--- a/tvc/src/commands/deploy/mod.rs
+++ b/tvc/src/commands/deploy/mod.rs
@@ -4,6 +4,7 @@ use crate::config::deploy::DeployConfig;
 
 pub mod approve;
 pub mod create;
+pub mod debug_logs;
 pub mod delete;
 pub mod get_status;
 pub mod init;

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -1,0 +1,163 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn debug_logs_cmd(home: &TempDir) -> assert_cmd::Command {
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .env("HOME", home.path())
+        .arg("deploy")
+        .arg("debug-logs");
+    cmd
+}
+
+#[test]
+fn deploy_help_lists_debug_logs_subcommand() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("debug-logs"))
+        .stdout(predicate::str::contains(
+            "Fetch debug logs for a deployment",
+        ));
+}
+
+#[test]
+fn debug_logs_help_lists_expected_flags() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--deploy-id <DEPLOY_ID>"))
+        .stdout(predicate::str::contains("--follow"))
+        .stdout(predicate::str::contains(
+            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+        ))
+        .stdout(predicate::str::contains("--include-platform-timestamp"))
+        .stdout(predicate::str::contains("--since-seconds <SINCE_SECONDS>"))
+        .stdout(predicate::str::contains("--tail-lines <TAIL_LINES>"))
+        .stdout(predicate::str::contains(
+            "Limit raw pod log history requested per replica",
+        ))
+        .stdout(predicate::str::contains(
+            "--dangerous-enable-debug-mode-deployments",
+        ))
+        .stdout(predicate::str::contains("--dangerous-deploy-debug-mode"));
+}
+
+#[test]
+fn debug_logs_requires_deploy_id() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the following required arguments were not provided",
+        ))
+        .stderr(predicate::str::contains("--deploy-id <DEPLOY_ID>"));
+}
+
+#[test]
+fn debug_logs_accepts_flags_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--follow")
+        .arg("--follow-poll-interval-seconds")
+        .arg("3")
+        .arg("--tail-lines")
+        .arg("10")
+        .arg("--since-seconds")
+        .arg("30")
+        .arg("--include-platform-timestamp")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No active organization"));
+}
+
+#[test]
+fn debug_logs_rejects_negative_tail_lines_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--tail-lines")
+        .arg("-1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--tail-lines must be greater than or equal to 0",
+        ));
+}
+
+#[test]
+fn debug_logs_rejects_zero_follow_poll_interval_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--follow")
+        .arg("--follow-poll-interval-seconds")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--follow-poll-interval-seconds must be greater than 0",
+        ));
+}
+
+#[test]
+fn debug_logs_rejects_negative_follow_poll_interval_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--follow")
+        .arg("--follow-poll-interval-seconds")
+        .arg("-1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--follow-poll-interval-seconds must be greater than 0",
+        ));
+}
+
+#[test]
+fn debug_logs_ignores_follow_poll_interval_without_follow() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--follow-poll-interval-seconds")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No active organization"));
+}
+
+#[test]
+fn debug_logs_rejects_negative_since_seconds_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--since-seconds")
+        .arg("-1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--since-seconds must be greater than or equal to 0",
+        ));
+}

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -33,6 +33,7 @@ fn debug_logs_help_lists_expected_flags() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--deploy-id <DEPLOY_ID>"))
+        .stdout(predicate::str::contains("--disable-dedupe"))
         .stdout(predicate::str::contains("--poll"))
         .stdout(predicate::str::contains(
             "--poll-interval-seconds <POLL_INTERVAL_SECONDS>",
@@ -83,6 +84,7 @@ fn debug_logs_accepts_flags_before_authentication() {
         .arg("--since-seconds")
         .arg("30")
         .arg("--include-platform-timestamp")
+        .arg("--disable-dedupe")
         .arg("--recent-line-capacity")
         .arg("2000")
         .assert()

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -93,9 +93,9 @@ fn debug_logs_rejects_negative_tail_lines_before_authentication() {
         .arg("-1")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "--tail-lines must be greater than or equal to 0",
-        ));
+        .stderr(predicate::str::contains("invalid value '-1'"))
+        .stderr(predicate::str::contains("--tail-lines <TAIL_LINES>"))
+        .stderr(predicate::str::contains("is not in 0.."));
 }
 
 #[test]
@@ -110,9 +110,11 @@ fn debug_logs_rejects_zero_follow_poll_interval_before_authentication() {
         .arg("0")
         .assert()
         .failure()
+        .stderr(predicate::str::contains("invalid value '0'"))
         .stderr(predicate::str::contains(
-            "--follow-poll-interval-seconds must be greater than 0",
-        ));
+            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+        ))
+        .stderr(predicate::str::contains("is not in 1.."));
 }
 
 #[test]
@@ -127,13 +129,15 @@ fn debug_logs_rejects_negative_follow_poll_interval_before_authentication() {
         .arg("-1")
         .assert()
         .failure()
+        .stderr(predicate::str::contains("invalid value '-1'"))
         .stderr(predicate::str::contains(
-            "--follow-poll-interval-seconds must be greater than 0",
-        ));
+            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+        ))
+        .stderr(predicate::str::contains("is not in 1.."));
 }
 
 #[test]
-fn debug_logs_ignores_follow_poll_interval_without_follow() {
+fn debug_logs_rejects_zero_follow_poll_interval_without_follow_before_authentication() {
     let temp = TempDir::new().unwrap();
 
     debug_logs_cmd(&temp)
@@ -143,7 +147,11 @@ fn debug_logs_ignores_follow_poll_interval_without_follow() {
         .arg("0")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("No active organization"));
+        .stderr(predicate::str::contains("invalid value '0'"))
+        .stderr(predicate::str::contains(
+            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+        ))
+        .stderr(predicate::str::contains("is not in 1.."));
 }
 
 #[test]
@@ -157,7 +165,7 @@ fn debug_logs_rejects_negative_since_seconds_before_authentication() {
         .arg("-1")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "--since-seconds must be greater than or equal to 0",
-        ));
+        .stderr(predicate::str::contains("invalid value '-1'"))
+        .stderr(predicate::str::contains("--since-seconds <SINCE_SECONDS>"))
+        .stderr(predicate::str::contains("is not in 0.."));
 }

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -33,9 +33,9 @@ fn debug_logs_help_lists_expected_flags() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--deploy-id <DEPLOY_ID>"))
-        .stdout(predicate::str::contains("--follow"))
+        .stdout(predicate::str::contains("--poll"))
         .stdout(predicate::str::contains(
-            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+            "--poll-interval-seconds <POLL_INTERVAL_SECONDS>",
         ))
         .stdout(predicate::str::contains("--include-platform-timestamp"))
         .stdout(predicate::str::contains(
@@ -75,8 +75,8 @@ fn debug_logs_accepts_flags_before_authentication() {
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
         .arg("deploy-123")
-        .arg("--follow")
-        .arg("--follow-poll-interval-seconds")
+        .arg("--poll")
+        .arg("--poll-interval-seconds")
         .arg("3")
         .arg("--tail-lines")
         .arg("10")
@@ -107,57 +107,57 @@ fn debug_logs_rejects_negative_tail_lines_before_authentication() {
 }
 
 #[test]
-fn debug_logs_rejects_zero_follow_poll_interval_before_authentication() {
+fn debug_logs_rejects_zero_poll_interval_before_authentication() {
     let temp = TempDir::new().unwrap();
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
         .arg("deploy-123")
-        .arg("--follow")
-        .arg("--follow-poll-interval-seconds")
+        .arg("--poll")
+        .arg("--poll-interval-seconds")
         .arg("0")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value '0'"))
         .stderr(predicate::str::contains(
-            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+            "--poll-interval-seconds <POLL_INTERVAL_SECONDS>",
         ))
         .stderr(predicate::str::contains("is not in 1.."));
 }
 
 #[test]
-fn debug_logs_rejects_negative_follow_poll_interval_before_authentication() {
+fn debug_logs_rejects_negative_poll_interval_before_authentication() {
     let temp = TempDir::new().unwrap();
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
         .arg("deploy-123")
-        .arg("--follow")
-        .arg("--follow-poll-interval-seconds")
+        .arg("--poll")
+        .arg("--poll-interval-seconds")
         .arg("-1")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value '-1'"))
         .stderr(predicate::str::contains(
-            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+            "--poll-interval-seconds <POLL_INTERVAL_SECONDS>",
         ))
         .stderr(predicate::str::contains("is not in 1.."));
 }
 
 #[test]
-fn debug_logs_rejects_zero_follow_poll_interval_without_follow_before_authentication() {
+fn debug_logs_rejects_zero_poll_interval_without_poll_before_authentication() {
     let temp = TempDir::new().unwrap();
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
         .arg("deploy-123")
-        .arg("--follow-poll-interval-seconds")
+        .arg("--poll-interval-seconds")
         .arg("0")
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value '0'"))
         .stderr(predicate::str::contains(
-            "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
+            "--poll-interval-seconds <POLL_INTERVAL_SECONDS>",
         ))
         .stderr(predicate::str::contains("is not in 1.."));
 }

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -38,8 +38,14 @@ fn debug_logs_help_lists_expected_flags() {
             "--follow-poll-interval-seconds <FOLLOW_POLL_INTERVAL_SECONDS>",
         ))
         .stdout(predicate::str::contains("--include-platform-timestamp"))
+        .stdout(predicate::str::contains(
+            "--recent-line-capacity <RECENT_LINE_CAPACITY>",
+        ))
         .stdout(predicate::str::contains("--since-seconds <SINCE_SECONDS>"))
         .stdout(predicate::str::contains("--tail-lines <TAIL_LINES>"))
+        .stdout(predicate::str::contains(
+            "This should only be increased if high-volume logs still show duplicates",
+        ))
         .stdout(predicate::str::contains(
             "Limit raw pod log history requested per replica",
         ))
@@ -77,6 +83,8 @@ fn debug_logs_accepts_flags_before_authentication() {
         .arg("--since-seconds")
         .arg("30")
         .arg("--include-platform-timestamp")
+        .arg("--recent-line-capacity")
+        .arg("2000")
         .assert()
         .failure()
         .stderr(predicate::str::contains("No active organization"));
@@ -168,4 +176,22 @@ fn debug_logs_rejects_negative_since_seconds_before_authentication() {
         .stderr(predicate::str::contains("invalid value '-1'"))
         .stderr(predicate::str::contains("--since-seconds <SINCE_SECONDS>"))
         .stderr(predicate::str::contains("is not in 0.."));
+}
+
+#[test]
+fn debug_logs_rejects_zero_recent_line_capacity_before_authentication() {
+    let temp = TempDir::new().unwrap();
+
+    debug_logs_cmd(&temp)
+        .arg("--deploy-id")
+        .arg("deploy-123")
+        .arg("--recent-line-capacity")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value '0'"))
+        .stderr(predicate::str::contains(
+            "--recent-line-capacity <RECENT_LINE_CAPACITY>",
+        ))
+        .stderr(predicate::str::contains("is not in 1.."));
 }


### PR DESCRIPTION
~Depends on https://github.com/tkhq/rust-sdk/pull/171 to merge first.~ Done

## Summary

Adds `tvc deploy debug-logs`, backed by the unary `GetTvcDeploymentDebugLogs` endpoint at `/public/v1/query/get_tvc_deployment_debug_logs`.
___
### Sample command:
`tvc deploy debug-logs --deploy-id $MY_DEPLOY_ID --since-seconds 3600 --poll`
___
The command fetches debug-mode TVC deployment logs and supports bounded history.

**The recommended history control is `--since-seconds`,** which returns logs newer than a relative time window and is the most predictable way to inspect recent output.

`--tail-lines` is also available for advanced scoping, **but it corresponds to raw pod log history per replica, so filtered output will contain fewer visible app lines than requested.**

By default, output omits the Kubernetes-prepended platform timestamp. Use `--include-platform-timestamp` to show it.

Note that debug mode deployments now only have 1 replica by default, so most users will see `replica 1/1` when they use this command.

## Notes

Poll mode is implemented client-side by repeatedly calling the unary endpoint. Poll requests use a small overlapping time window: by default the CLI polls every 2 seconds and requests a 2-second overlap to avoid missing late-arriving lines.

The CLI keeps a bounded cache of recently printed timestamped lines to suppress duplicates across overlap windows. The cache defaults to 1000 entries and can be adjusted with `--recent-line-capacity` for unusually high-volume logs. Dedupe is enabled by default; pass `--disable-dedupe` to print every returned line.

CLI defaults and numeric flag validation are handled by clap.

~Requires the corresponding mono debug-logs unary endpoint PR to land/deploy.~ Done.

## Testing

- Added CLI tests for help text, required flags, flag validation, debug-log command parsing, poll-mode dedupe behavior, and the dedupe disable path.
- `cargo fmt --check`
- `cargo test -p turnkey_client`
- `cargo test -p tvc debug_logs`

- Tested in dev by deploying a test image with extra logs, connecting to that deployment, then refreshing the `/time` page for additional logs. This sample was captured from an older 3-replica dev deployment.
```logs
tvc deploy debug-logs --deploy-id e4b4d6b9-97e3-4b23-b6fa-a425f049f310 --since-seconds 3600 --poll
Connected; polling for debug logs...
replica 2/3 2026-06-18T22:10:38.731409Z  INFO helloworld: Server listening on 0.0.0.0:3000
replica 2/3 2026-06-18T22:10:38.731431Z  WARN helloworld: (Dummy warn): Server listening on 0.0.0.0:3000
replica 2/3 2026-06-18T22:10:38.731435Z ERROR helloworld: (Dummy error): Server listening on 0.0.0.0:3000
```
