### PR TITLE
feat(codegen): explicit activity-version pinning

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -10,3 +10,9 @@ This crate contains the code necessary to generate the `generated` portion of th
   * replaces `i32` enum types with proper types (e.g. `pub effect: i32` -> `pub effect: super::super::super::immutable::common::v1::Effect,`)
   * transform enums: remove `#[derive(...)]` prost traits, remove `#[prost(...)]` attributes, remove `#[repr(i32)]`, and add `#[serde(rename = "ENUM_NAME_VARIANT")]` (necesary for JSON serialization and deserialization to work correctly)
   * transform structs: remove `#[prost(...)]` attributes, add `#[serde(default)]` to help with deserialization of empty lists or optional params, add `#[serde(flatten)]` to ignore the `Inner` struct which is a result of the `oneof` structure of activity intent and results. The serialized JSON doesn't have "inner".
+
+## Activity Version Caps
+
+[`activity_version_caps.json`](./activity_version_caps.json) contains explicit activity-version pins for codegen. Each entry in `pins` maps a base `ACTIVITY_TYPE_*` family identity to the exact `ACTIVITY_TYPE_*` literal that generated client methods should emit, overriding the activity version from the proto annotation.
+
+Activities not listed in `pins` emit whatever the proto annotation specifies, usually the latest version. Adding or bumping a pin is a deliberate, reviewed opt-in to a specific activity version, and the pinned target must already exist in [`activities.json`](../proto/activities.json). This mirrors the version-capping convention used by other Turnkey SDKs, such as the TypeScript SDK's `VERSIONED_ACTIVITY_TYPES` map.

--- a/codegen/activity_version_caps.json
+++ b/codegen/activity_version_caps.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Explicit activity-version pins for codegen. Maps a base ACTIVITY_TYPE_* (the family identity) to the EXACT ACTIVITY_TYPE_* literal codegen should emit, overriding the version from the proto annotation. An activity NOT listed here emits whatever the proto annotation specifies (latest). Adding/bumping a pin is a deliberate, reviewed opt-in to a specific activity version that MUST already be released in production. Mirrors the TS SDK VERSIONED_ACTIVITY_TYPES map.",
+  "pins": {}
+}

--- a/codegen/activity_version_caps.json
+++ b/codegen/activity_version_caps.json
@@ -1,4 +1,3 @@
 {
-  "$comment": "Explicit activity-version pins for codegen. Maps a base ACTIVITY_TYPE_* (the family identity) to the EXACT ACTIVITY_TYPE_* literal codegen should emit, overriding the version from the proto annotation. An activity NOT listed here emits whatever the proto annotation specifies (latest). Adding/bumping a pin is a deliberate, reviewed opt-in to a specific activity version that MUST already be released in production. Mirrors the TS SDK VERSIONED_ACTIVITY_TYPES map.",
   "pins": {}
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
@@ -11,6 +11,7 @@ const PUBLIC_API_PROTO_PATH: &str = "proto/services/coordinator/public/v1/public
 const EXTERNAL_ACTIVITY_PROTO_PATH: &str = "proto/external/activity/v1/activity.proto";
 const INCLUDE_PROTO_PATH: &str = "proto";
 const ACTIVITIES_MAPPING_PATH: &str = "proto/activities.json";
+const ACTIVITY_VERSION_CAPS_PATH: &str = "codegen/activity_version_caps.json";
 const GENERATED_CLIENT_DIR: &str = "client/src/generated";
 const CLIENT_TEMPLATE_PATH: &str = "codegen/src/client.template.rs";
 
@@ -30,6 +31,12 @@ struct ActivityDetails {
 #[derive(Debug, serde::Deserialize)]
 struct ActivitiesFile {
     activities: HashMap<String, ActivityDetails>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct ActivityVersionCaps {
+    #[serde(default)]
+    pins: HashMap<String, String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -96,6 +103,7 @@ fn main() {
         fs::read_to_string(ACTIVITIES_MAPPING_PATH).expect("cannot read activities.json");
     let parsed_activities: ActivitiesFile =
         serde_json::from_str(&activities_mapping_data).expect("cannot parse activities.json");
+    let activity_version_caps = load_activity_version_caps(ACTIVITY_VERSION_CAPS_PATH);
 
     let external_activity_proto = fs::read_to_string(EXTERNAL_ACTIVITY_PROTO_PATH)
         .expect("Failed to read external activity proto file");
@@ -154,9 +162,23 @@ fn main() {
                 // If the request type is "external.activity.v1.DeletePolicyRequest" the sanitized
                 // request type will be "DeletePolicyRequest", and we'll need to import it from the external activity namespace
                 let short_req_type = req_type.rsplit(".").next().unwrap();
-                let activity_type = request_to_activity_type
+                let proto_activity_type = request_to_activity_type
                         .get(short_req_type)
                         .unwrap_or_else(|| panic!("no activity type annotation found for {short_req_type} in external activity proto"));
+                let activity_type = resolve_activity_type(
+                    proto_activity_type,
+                    &activity_version_caps.pins,
+                    &parsed_activities.activities,
+                )
+                .unwrap_or_else(|err| panic!("{err}"));
+                if activity_type != *proto_activity_type {
+                    println!(
+                        "Applying activity version pin for {}: {} -> {}",
+                        activity_base(proto_activity_type),
+                        proto_activity_type,
+                        activity_type
+                    );
+                }
                 let activities_details = parsed_activities
                     .activities
                     .get(activity_type.as_str())
@@ -310,6 +332,48 @@ fn main() {
             fs::write(path, new_content).expect("cannot write to file");
         }
     }
+}
+
+fn load_activity_version_caps(path: &str) -> ActivityVersionCaps {
+    match fs::read_to_string(path) {
+        Ok(data) => serde_json::from_str(&data).expect("cannot parse activity version caps"),
+        Err(err) if err.kind() == ErrorKind::NotFound => ActivityVersionCaps::default(),
+        Err(err) => panic!("cannot read activity version caps: {err}"),
+    }
+}
+
+fn activity_base(activity_type: &str) -> &str {
+    if let Some((base, suffix)) = activity_type.rsplit_once("_V") {
+        if !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit()) {
+            return base;
+        }
+    }
+
+    activity_type
+}
+
+fn resolve_activity_type(
+    activity_type: &str,
+    pins: &HashMap<String, String>,
+    activities: &HashMap<String, ActivityDetails>,
+) -> Result<String, String> {
+    for (base, target) in pins {
+        if activity_base(target) != base {
+            return Err(format!(
+                "activity version cap for {base} points to {target}, but base families differ"
+            ));
+        }
+        if !activities.contains_key(target) {
+            return Err(format!(
+                "activity version cap for {base} points to {target}, which was not found in activities.json"
+            ));
+        }
+    }
+
+    Ok(pins
+        .get(activity_base(activity_type))
+        .cloned()
+        .unwrap_or_else(|| activity_type.to_string()))
 }
 
 fn parse_rpcs(proto: &str) -> Vec<Rpc> {
@@ -555,5 +619,87 @@ message BazRequest {
         assert!(set.contains("FooRequest"));
         assert!(!set.contains("BarRequest"));
         assert!(set.contains("BazRequest"));
+    }
+
+    #[test]
+    fn activity_base_strips_numeric_version_suffix() {
+        assert_eq!(
+            activity_base("ACTIVITY_TYPE_SIGN_TRANSACTION_V2"),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION"
+        );
+        assert_eq!(
+            activity_base("ACTIVITY_TYPE_SIGN_TRANSACTION"),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION"
+        );
+        assert_eq!(
+            activity_base("ACTIVITY_TYPE_SIGN_TRANSACTION_V10"),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION"
+        );
+        assert_eq!(
+            activity_base("ACTIVITY_TYPE_EXPORT_WALLET_VAULT"),
+            "ACTIVITY_TYPE_EXPORT_WALLET_VAULT"
+        );
+    }
+
+    #[test]
+    fn resolve_activity_type_applies_matching_pin() {
+        let mut activities = HashMap::new();
+        activities.insert(
+            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+            ActivityDetails {
+                intent_type: "SignTransactionIntentV2".to_string(),
+                result_type: "SignTransactionResultV2".to_string(),
+                internal: false,
+            },
+        );
+
+        let mut pins = HashMap::new();
+        pins.insert(
+            "ACTIVITY_TYPE_SIGN_TRANSACTION".to_string(),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+        );
+
+        assert_eq!(
+            resolve_activity_type("ACTIVITY_TYPE_SIGN_TRANSACTION_V3", &pins, &activities).unwrap(),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
+        );
+    }
+
+    #[test]
+    fn resolve_activity_type_leaves_unlisted_family_unchanged() {
+        let mut activities = HashMap::new();
+        activities.insert(
+            "ACTIVITY_TYPE_CREATE_USERS_V2".to_string(),
+            ActivityDetails {
+                intent_type: "CreateUsersIntentV2".to_string(),
+                result_type: "CreateUsersResultV2".to_string(),
+                internal: false,
+            },
+        );
+
+        assert_eq!(
+            resolve_activity_type(
+                "ACTIVITY_TYPE_CREATE_USERS_V2",
+                &HashMap::new(),
+                &activities
+            )
+            .unwrap(),
+            "ACTIVITY_TYPE_CREATE_USERS_V2"
+        );
+    }
+
+    #[test]
+    fn resolve_activity_type_rejects_nonexistent_pin_target() {
+        let mut pins = HashMap::new();
+        pins.insert(
+            "ACTIVITY_TYPE_SIGN_TRANSACTION".to_string(),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+        );
+
+        let error =
+            resolve_activity_type("ACTIVITY_TYPE_SIGN_TRANSACTION_V3", &pins, &HashMap::new())
+                .unwrap_err();
+
+        assert!(error.contains("not found in activities.json"));
     }
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -179,7 +179,7 @@ fn main() {
                 }
                 let activities_details = parsed_activities
                     .activities
-                    .get(activity_type.as_str())
+                    .get(activity_type)
                     .unwrap_or_else(|| {
                         panic!("activity type {activity_type} not found in activities.json")
                     });
@@ -370,10 +370,10 @@ fn validate_activity_version_caps(
     Ok(())
 }
 
-fn resolve_activity_type(activity_type: &str, pins: &HashMap<String, String>) -> String {
+fn resolve_activity_type<'a>(activity_type: &'a str, pins: &'a HashMap<String, String>) -> &'a str {
     pins.get(activity_base(activity_type))
-        .cloned()
-        .unwrap_or_else(|| activity_type.to_string())
+        .map(String::as_str)
+        .unwrap_or(activity_type)
 }
 
 fn parse_rpcs(proto: &str) -> Vec<Rpc> {

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -104,6 +104,8 @@ fn main() {
     let parsed_activities: ActivitiesFile =
         serde_json::from_str(&activities_mapping_data).expect("cannot parse activities.json");
     let activity_version_caps = load_activity_version_caps(ACTIVITY_VERSION_CAPS_PATH);
+    validate_activity_version_caps(&activity_version_caps.pins, &parsed_activities.activities)
+        .unwrap_or_else(|err| panic!("{err}"));
 
     let external_activity_proto = fs::read_to_string(EXTERNAL_ACTIVITY_PROTO_PATH)
         .expect("Failed to read external activity proto file");
@@ -165,12 +167,8 @@ fn main() {
                 let proto_activity_type = request_to_activity_type
                         .get(short_req_type)
                         .unwrap_or_else(|| panic!("no activity type annotation found for {short_req_type} in external activity proto"));
-                let activity_type = resolve_activity_type(
-                    proto_activity_type,
-                    &activity_version_caps.pins,
-                    &parsed_activities.activities,
-                )
-                .unwrap_or_else(|err| panic!("{err}"));
+                let activity_type =
+                    resolve_activity_type(proto_activity_type, &activity_version_caps.pins);
                 if activity_type != *proto_activity_type {
                     println!(
                         "Applying activity version pin for {}: {} -> {}",
@@ -352,11 +350,10 @@ fn activity_base(activity_type: &str) -> &str {
     activity_type
 }
 
-fn resolve_activity_type(
-    activity_type: &str,
+fn validate_activity_version_caps(
     pins: &HashMap<String, String>,
     activities: &HashMap<String, ActivityDetails>,
-) -> Result<String, String> {
+) -> Result<(), String> {
     for (base, target) in pins {
         if activity_base(target) != base {
             return Err(format!(
@@ -370,10 +367,13 @@ fn resolve_activity_type(
         }
     }
 
-    Ok(pins
-        .get(activity_base(activity_type))
+    Ok(())
+}
+
+fn resolve_activity_type(activity_type: &str, pins: &HashMap<String, String>) -> String {
+    pins.get(activity_base(activity_type))
         .cloned()
-        .unwrap_or_else(|| activity_type.to_string()))
+        .unwrap_or_else(|| activity_type.to_string())
 }
 
 fn parse_rpcs(proto: &str) -> Vec<Rpc> {
@@ -643,16 +643,6 @@ message BazRequest {
 
     #[test]
     fn resolve_activity_type_applies_matching_pin() {
-        let mut activities = HashMap::new();
-        activities.insert(
-            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
-            ActivityDetails {
-                intent_type: "SignTransactionIntentV2".to_string(),
-                result_type: "SignTransactionResultV2".to_string(),
-                internal: false,
-            },
-        );
-
         let mut pins = HashMap::new();
         pins.insert(
             "ACTIVITY_TYPE_SIGN_TRANSACTION".to_string(),
@@ -660,13 +650,34 @@ message BazRequest {
         );
 
         assert_eq!(
-            resolve_activity_type("ACTIVITY_TYPE_SIGN_TRANSACTION_V3", &pins, &activities).unwrap(),
+            resolve_activity_type("ACTIVITY_TYPE_SIGN_TRANSACTION_V3", &pins),
             "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
         );
     }
 
     #[test]
     fn resolve_activity_type_leaves_unlisted_family_unchanged() {
+        assert_eq!(
+            resolve_activity_type("ACTIVITY_TYPE_CREATE_USERS_V2", &HashMap::new()),
+            "ACTIVITY_TYPE_CREATE_USERS_V2"
+        );
+    }
+
+    #[test]
+    fn validate_activity_version_caps_rejects_nonexistent_pin_target() {
+        let mut pins = HashMap::new();
+        pins.insert(
+            "ACTIVITY_TYPE_SIGN_TRANSACTION".to_string(),
+            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+        );
+
+        let error = validate_activity_version_caps(&pins, &HashMap::new()).unwrap_err();
+
+        assert!(error.contains("not found in activities.json"));
+    }
+
+    #[test]
+    fn validate_activity_version_caps_rejects_pin_across_base_families() {
         let mut activities = HashMap::new();
         activities.insert(
             "ACTIVITY_TYPE_CREATE_USERS_V2".to_string(),
@@ -677,29 +688,14 @@ message BazRequest {
             },
         );
 
-        assert_eq!(
-            resolve_activity_type(
-                "ACTIVITY_TYPE_CREATE_USERS_V2",
-                &HashMap::new(),
-                &activities
-            )
-            .unwrap(),
-            "ACTIVITY_TYPE_CREATE_USERS_V2"
-        );
-    }
-
-    #[test]
-    fn resolve_activity_type_rejects_nonexistent_pin_target() {
         let mut pins = HashMap::new();
         pins.insert(
             "ACTIVITY_TYPE_SIGN_TRANSACTION".to_string(),
-            "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".to_string(),
+            "ACTIVITY_TYPE_CREATE_USERS_V2".to_string(),
         );
 
-        let error =
-            resolve_activity_type("ACTIVITY_TYPE_SIGN_TRANSACTION_V3", &pins, &HashMap::new())
-                .unwrap_err();
+        let error = validate_activity_version_caps(&pins, &activities).unwrap_err();
 
-        assert!(error.contains("not found in activities.json"));
+        assert!(error.contains("base families differ"));
     }
 }


### PR DESCRIPTION
## Summary

Adds an explicit activity-version pinning mechanism to Rust SDK codegen, mirroring the TypeScript SDK's `VERSIONED_ACTIVITY_TYPES` map.

## Problem

Today, proto sync can auto-bump generated activity submission methods to whatever `ACTIVITY_TYPE_*` literal is present in the proto annotation, even if that activity version has not been released to production yet.

## Mechanism

- Adds `codegen/activity_version_caps.json` with an explicit `pins` map.
- The map keys are base activity families, e.g. `ACTIVITY_TYPE_SIGN_TRANSACTION`.
- The map values are the exact `ACTIVITY_TYPE_*` literals codegen should emit, e.g. `ACTIVITY_TYPE_SIGN_TRANSACTION_V2`.
- Codegen strips trailing `_V<number>` suffixes to derive the base family, checks for a pin, and overrides the emitted activity type before looking up intent/result types in `proto/activities.json`.
- Pin targets are validated against `activities.json`, and pins that cross base activity families are rejected.

## No-op default

This PR seeds the config with empty pins, so it is mechanism-only and generated client output remains unchanged. The actual pins should be set in #171.

## How to add a pin

Add an entry to `codegen/activity_version_caps.json`:

```json
{
  "pins": {
    "ACTIVITY_TYPE_SIGN_TRANSACTION": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2"
  }
}
```

The target activity version must already exist in `proto/activities.json` and must already be released in production.

## Ordering

This should merge before #171 so that PR can add/bump pins using this mechanism.

## Verification

- `PATH="/workspace/.cargo/bin:$PATH" make generate`
- `git diff --stat -- client/src/generated` produced no output
- `PATH="/workspace/.cargo/bin:$PATH" make lint`
- `PATH="/workspace/.cargo/bin:$PATH" make test`
