### PR TITLE
feat(tvc): flexible --operator-seed source (env/stdin/file)

### DIFF
--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -59,10 +59,12 @@ pub struct Args {
     #[arg(long, env = "TVC_OPERATOR_ID")]
     pub operator_id: Option<String>,
 
-    /// Path to the file containing the master seed for the operator key.
-    /// If not provided, uses the operator key from the logged-in org config.
-    #[arg(long, value_name = "PATH", env = "TVC_OPERATOR_SEED")]
-    pub operator_seed: Option<PathBuf>,
+    /// Source of the operator key's hex master seed: a file path (back-compatible),
+    /// `env:NAME` (an environment variable), `stdin` (or `-`), or `file://<path>` —
+    /// so the seed needn't be written to disk. If not provided, uses the operator
+    /// key from the logged-in org config.
+    #[arg(long, value_name = "SOURCE", env = "TVC_OPERATOR_SEED")]
+    pub operator_seed: Option<String>,
 
     /// Walk through manifest approval prompts but do not generate an approval.
     #[arg(long, env = "TVC_DRY_RUN")]
@@ -95,7 +97,7 @@ struct PostTarget {
 
 struct ResolvedApproveInputs {
     manifest: VersionedManifest,
-    operator_seed: Option<PathBuf>,
+    operator_seed: Option<String>,
     approval_out: Option<PathBuf>,
     dry_run: bool,
     post_target: Option<PostTarget>,
@@ -249,7 +251,7 @@ async fn load_manifest(args: &Args) -> anyhow::Result<(VersionedManifest, Option
 }
 
 async fn sign_and_output(
-    operator_seed: Option<&Path>,
+    operator_seed: Option<&str>,
     approval_out: Option<&Path>,
     manifest: &VersionedManifest,
 ) -> anyhow::Result<Approval> {

--- a/tvc/src/commands/keys/re_encrypt_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_share.rs
@@ -26,10 +26,11 @@ pub struct Args {
     #[arg(long, value_name = "PATH", env = "TVC_PROVISION_BUNDLE")]
     pub provision_bundle: PathBuf,
 
-    /// Path to the file containing the master seed for the operator key.
-    /// If not provided, uses the operator key from the logged-in org config.
-    #[arg(long, value_name = "PATH", env = "TVC_OPERATOR_SEED")]
-    pub operator_seed: Option<PathBuf>,
+    /// Source of the operator key's hex master seed: a file path (back-compatible),
+    /// `env:NAME`, `stdin` (or `-`), or `file://<path>`. If not provided, uses the
+    /// operator key from the logged-in org config.
+    #[arg(long, value_name = "SOURCE", env = "TVC_OPERATOR_SEED")]
+    pub operator_seed: Option<String>,
 
     /// Never use for sensitive applications! Skip attestation, PCR, and manifest approval verification.
     #[arg(long, env = "TVC_DANGEROUS_SKIP_VERIFICATION")]

--- a/tvc/src/operator_key.rs
+++ b/tvc/src/operator_key.rs
@@ -1,15 +1,20 @@
-//! Resolve an operator's QOS key pair from CLI args or the active org config.
+//! Resolve an operator's QOS key pair from a seed SOURCE or the active org config.
 
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
 use crate::pair::LocalPair;
-use anyhow::anyhow;
-use std::path::Path;
+use anyhow::{Context, anyhow};
+use std::io::Read;
 
-/// Load the operator's QOS key pair, preferring an explicit seed file path
-/// and falling back to the operator key stored under the active org config.
-pub async fn load_operator_pair(operator_seed: Option<&Path>) -> anyhow::Result<LocalPair> {
-    match operator_seed {
-        Some(path) => LocalPair::from_master_seed(path).await,
+/// Load the operator's QOS key pair from a seed `source` spec, or fall back to
+/// the operator key stored under the active org config when `source` is `None`.
+///
+/// The source is flexible so the seed needn't be written to disk:
+///   - `env:NAME`             read the hex seed from environment variable `NAME`
+///   - `stdin` (or `-`)       read the hex seed from stdin
+///   - `file://<path>` / `file:<path>` / bare `<path>`  read the hex seed from a file
+pub async fn load_operator_pair(source: Option<&str>) -> anyhow::Result<LocalPair> {
+    match source {
+        Some(spec) => LocalPair::from_hex_seed(read_seed_source(spec)?.trim()),
         None => {
             let tvc_config = Config::load().await?;
             let (alias, org_config) = tvc_config.active_org_config().ok_or_else(|| {
@@ -27,5 +32,26 @@ pub async fn load_operator_pair(operator_seed: Option<&Path>) -> anyhow::Result<
 
             LocalPair::from_hex_seed(&operator_key.private_key)
         }
+    }
+}
+
+/// Read a hex seed from a source spec (see [`load_operator_pair`]). A bare value
+/// with no recognized scheme is treated as a file path (back-compatible with the
+/// previous `--operator-seed <PATH>` behavior).
+fn read_seed_source(spec: &str) -> anyhow::Result<String> {
+    if spec == "stdin" || spec == "-" {
+        let mut s = String::new();
+        std::io::stdin()
+            .read_to_string(&mut s)
+            .context("read operator seed from stdin")?;
+        Ok(s)
+    } else if let Some(name) = spec.strip_prefix("env:") {
+        std::env::var(name).with_context(|| format!("operator seed env var '{name}' is not set"))
+    } else {
+        let path = spec
+            .strip_prefix("file://")
+            .or_else(|| spec.strip_prefix("file:"))
+            .unwrap_or(spec);
+        std::fs::read_to_string(path).with_context(|| format!("read operator seed file '{path}'"))
     }
 }

--- a/tvc/tests/keys_re_encrypt_share.rs
+++ b/tvc/tests/keys_re_encrypt_share.rs
@@ -96,7 +96,7 @@ fn re_encrypt_share_help_lists_expected_flags() {
         .success()
         .stdout(predicate::str::contains("--quorum-key-metadata <PATH>"))
         .stdout(predicate::str::contains("--provision-bundle <PATH>"))
-        .stdout(predicate::str::contains("--operator-seed <PATH>"))
+        .stdout(predicate::str::contains("--operator-seed <SOURCE>"))
         .stdout(predicate::str::contains("--dangerous-skip-verification"))
         .stdout(predicate::str::contains("--re-encrypted-out <PATH>"));
 }


### PR DESCRIPTION
## What
`tvc deploy approve` (and `tvc keys re-encrypt-share`) currently take `--operator-seed <PATH>` — the operator master seed must be written to a file on disk. This makes `--operator-seed` (env `TVC_OPERATOR_SEED`) accept a **source spec** so the seed needn't touch disk:

- `env:NAME` — read the hex seed from environment variable `NAME`
- `stdin` (or `-`) — read the hex seed from stdin
- `file://<path>` — read from a file
- bare `<path>` — read from a file (**back-compatible** with today's behavior)

Unset still falls back to the logged-in org operator key. Resolution happens in one place (`operator_key::load_operator_pair`) via a small `read_seed_source` helper.

## Why
For CI/automation, requiring a file means materializing the operator seed onto disk (then trying to scrub it). Passing it via **stdin** keeps the secret off disk *and* out of `argv`/shell history; `env:` is convenient where a file is undesirable. This is a small quality-of-life + secret-hygiene improvement.

## Notes
- **No new dependencies** — `std` only (`from_hex_seed` already existed on `LocalPair`).
- Back-compatible: a bare path is still treated as a seed file.
- `cargo fmt` + `cargo clippy -p tvc` clean; `cargo check -p tvc` passes.
- Caveat: use `stdin` with non-interactive approval (`--dangerous-skip-interactive`), since stdin is consumed for the seed.