### PR TITLE
tvc: update login API key instructions copy

### DIFF
--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -275,9 +275,11 @@ async fn generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
     println!("Public Key: {public_key}");
     println!();
     println!("Add this API key to your Turnkey dashboard:");
-    println!("  1. Go to https://app.turnkey.com/dashboard/users");
-    println!("  2. Click your user > Create API Key > Generate API Keys via CLI > Continue");
-    println!("  3. Paste the public key > Name it \"TVC CLI\" > Continue > Approve");
+    println!("  1. Go to https://app.turnkey.com/dashboard/v2/users");
+    println!(
+        "  2. Click your user > New API Key > Advanced Settings: Generate API Keys via CLI > Paste in the key created above"
+    );
+    println!("  3. Name it \"TVC CLI\" > Continue > Approve");
     println!();
 
     Ok(api_key)


### PR DESCRIPTION
Updates the copy printed after `tvc login` generates an API key.

Changes:
- Dashboard link updated: `app.turnkey.com/dashboard/users` -> `app.turnkey.com/dashboard/v2/users`
- Step 2 now reads: "Click your user > New API Key > Advanced Settings: Generate API Keys via CLI > Paste in the key created above"
- Step 3 trimmed the now-redundant "Paste the public key" prefix (pasting is covered in step 2); it now reads: "Name it \"TVC CLI\" > Continue > Approve"

The surrounding structure ("API Key Generated!" header, public key print, "Press Enter when done..." prompt) is unchanged. Uses the same `println!` style as the rest of the file.
