### PR TITLE
feat(tvc): seed `deploy init` config from an existing deployment

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -160,7 +160,8 @@ enum DeployCommands {
         after_help = commands::deploy::PORT_GUIDANCE
     )]
     Create(commands::deploy::create::Args),
-    /// Generate a template deployment configuration file.
+    /// Generate a deployment configuration file
+    #[command(long_about = commands::deploy::init::LONG_ABOUT)]
     Init(commands::deploy::init::Args),
     /// Fetch debug logs for a deployment.
     #[command(long_about = commands::deploy::debug_logs::LONG_ABOUT)]

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -4,9 +4,13 @@ use crate::config::turnkey::{Config, StoredApiKey};
 use anyhow::{Context, Result, anyhow, bail};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use turnkey_client::TurnkeyClient;
-use turnkey_client::generated::GetTvcAppRequest;
-use turnkey_client::generated::external::data::v1::TvcApp;
+use turnkey_client::{
+    TurnkeyClient,
+    generated::{
+        GetTvcAppRequest, GetTvcDeploymentRequest,
+        external::data::v1::{TvcApp, TvcDeployment},
+    },
+};
 
 /// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
 /// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.
@@ -68,6 +72,25 @@ pub async fn fetch_tvc_app(auth: &AuthenticatedClient, app_id: &str) -> Result<T
     response
         .tvc_app
         .ok_or_else(|| anyhow!("app not found: {app_id}"))
+}
+
+pub async fn fetch_tvc_deployment(
+    auth: &AuthenticatedClient,
+    organization_id: String,
+    deployment_id: String,
+) -> Result<TvcDeployment> {
+    let response = auth
+        .client
+        .get_tvc_deployment(GetTvcDeploymentRequest {
+            organization_id,
+            deployment_id,
+        })
+        .await
+        .context("failed to fetch deployment")?;
+
+    response
+        .tvc_deployment
+        .ok_or_else(|| anyhow!("deployment not found"))
 }
 
 async fn load_credentials_from_config() -> Result<(String, String, String, String)> {

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -27,7 +27,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         deploy_id: deployment_id,
     } = args;
 
-    // TODO:
+    // TODO (TVC-154):
     // this is a little backwards, all the variables that are needed to build the client
     // are resolved INSIDE the `build-client`. Instead, all the necessary data for the client
     // should be resolved, then passed into an infallible constructor

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -2,11 +2,15 @@
 
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
-use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
-use turnkey_client::generated::{GetAppStatusRequest, GetTvcDeploymentRequest};
+use turnkey_client::generated::{
+    GetAppStatusRequest,
+    external::data::v1::{AppStatus, DeploymentStatus},
+};
 
-use crate::client::fetch_tvc_app;
-use crate::commands::display::format_egress_enabled;
+use crate::{
+    client::{fetch_tvc_app, fetch_tvc_deployment},
+    commands::display::format_egress_enabled,
+};
 
 /// Get the live status of a deployment from the app status API.
 #[derive(Debug, ClapArgs)]
@@ -19,25 +23,21 @@ pub struct Args {
 
 /// Run the deploy get-status command.
 pub async fn run(args: Args) -> anyhow::Result<()> {
+    let Args {
+        deploy_id: deployment_id,
+    } = args;
+
+    // TODO:
+    // this is a little backwards, all the variables that are needed to build the client
+    // are resolved INSIDE the `build-client`. Instead, all the necessary data for the client
+    // should be resolved, then passed into an infallible constructor
     let auth = crate::client::build_client().await?;
+    let org_id = auth.org_id.clone();
 
-    let deployment_request = GetTvcDeploymentRequest {
-        organization_id: auth.org_id.clone(),
-        deployment_id: args.deploy_id.clone(),
-    };
-
-    let deployment_response = auth
-        .client
-        .get_tvc_deployment(deployment_request)
-        .await
-        .context("failed to fetch deployment")?;
-
-    let deployment = deployment_response
-        .tvc_deployment
-        .ok_or_else(|| anyhow!("deployment not found: {}", args.deploy_id))?;
+    let deployment = fetch_tvc_deployment(&auth, org_id.clone(), deployment_id.clone()).await?;
 
     let app_request = GetAppStatusRequest {
-        organization_id: auth.org_id.clone(),
+        organization_id: org_id.clone(),
         app_id: deployment.app_id.clone(),
     };
 
@@ -59,13 +59,13 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     println!("{}", format_egress_enabled(app.enable_egress));
     println!(
         "Is Targeted Deployment: {}",
-        if app_status.targeted_deployment_id == args.deploy_id {
+        if app_status.targeted_deployment_id == deployment_id {
             "yes"
         } else {
             "no"
         }
     );
-    if let Some(deployment_status) = find_deployment_status(&app_status, &args.deploy_id) {
+    if let Some(deployment_status) = find_deployment_status(&app_status, &deployment_id) {
         println!(
             "{}",
             crate::commands::app_status::format_replica_status(deployment_status)

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -77,8 +77,8 @@ async fn execute(args: Args) -> Result<()> {
     // Seed the config either from an existing deployment or a blank template.
     let mut config = match from_deployment {
         Some(deploy_id) => {
-            // TODO:
-            // see other TODO. TL;DR split fetching the data/resources separately
+            // TODO (TVC-154):
+            // TL;DR split fetching the data/resources separately
             // from building the client
             let auth = build_client().await?;
             let org_id = auth.org_id.clone();

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -1,13 +1,23 @@
 //! Deploy init command - generates a template config file.
 
 use super::PORT_GUIDANCE;
-use crate::config::deploy::DeployConfig;
-use crate::config::turnkey;
-use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
+use crate::{
+    client::{build_client, fetch_tvc_deployment},
+    config::{deploy::DeployConfig, turnkey},
+    prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty},
+};
 use anyhow::{Context, Result, bail};
 use chrono::Local;
 use clap::Args as ClapArgs;
 use std::path::PathBuf;
+
+pub(crate) const LONG_ABOUT: &str = r#"
+Generate a deployment config file to edit, then pass to `tvc deploy create`.
+
+--from-deployment <DEPLOY_ID> copies every field from that deployment, including
+the expected pivot digest and debug mode (read from its manifest); a private-image
+pull secret cannot be recovered and must be re-supplied. Without the flag, a blank
+placeholder template is written."#;
 
 /// Generate a template deployment configuration file.
 #[derive(Debug, ClapArgs)]
@@ -16,6 +26,15 @@ pub struct Args {
     /// Output file path.
     #[arg(short, long, value_name = "PATH", env = "TVC_DEPLOY_CONFIG_OUT")]
     pub output: Option<PathBuf>,
+
+    /// Seed the config from an existing deployment instead of a blank template.
+    ///
+    /// Fetches the deployment and copies every recoverable field, including the
+    /// expected pivot digest and debug mode (read from its manifest). The digest
+    /// is tied to the container image, so recompute it if you change the image. A
+    /// pull secret, if the source used one, must be re-supplied.
+    #[arg(long, value_name = "DEPLOY_ID", env = "TVC_FROM_DEPLOYMENT")]
+    pub from_deployment: Option<String>,
 
     /// Walk through prompts for each field and write a filled config instead
     /// of a placeholder template.
@@ -36,8 +55,14 @@ pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
 }
 
 async fn execute(args: Args) -> Result<()> {
+    let Args {
+        output,
+        from_deployment,
+        interactive: is_interactive,
+    } = args;
+
     // Generate output filename with timestamp if not provided
-    let output = args.output.unwrap_or_else(|| {
+    let output = output.unwrap_or_else(|| {
         let timestamp = Local::now().format("%Y-%m-%d-%H%M%S");
         PathBuf::from(format!("deploy-{timestamp}.json"))
     });
@@ -47,17 +72,42 @@ async fn execute(args: Args) -> Result<()> {
         bail!("File already exists: {}", output.display());
     }
 
-    // Try to get the last created app ID
-    let last_app_id = turnkey::Config::load()
-        .await
-        .ok()
-        .and_then(|config| config.get_last_app_id());
+    let is_from_deployment = from_deployment.is_some();
 
-    // Generate template (optionally walking prompts to fill it in)
-    let mut config = DeployConfig::template(last_app_id.as_deref());
-    if args.interactive {
-        config.fill_interactively(last_app_id.as_deref())?;
+    // Seed the config either from an existing deployment or a blank template.
+    let mut config = match from_deployment {
+        Some(deploy_id) => {
+            // TODO:
+            // see other TODO. TL;DR split fetching the data/resources separately
+            // from building the client
+            let auth = build_client().await?;
+            let org_id = auth.org_id.clone();
+            let deployment = fetch_tvc_deployment(&auth, org_id, deploy_id).await?;
+            DeployConfig::try_from(deployment)?
+        }
+        None => {
+            // Try to get the last created app ID to prefill the template.
+            let last_app_id = turnkey::Config::load()
+                .await
+                .ok()
+                .and_then(|config| config.get_last_app_id());
+            DeployConfig::template(last_app_id.as_deref())
+        }
+    };
+
+    // Optionally walk prompts to fill any remaining placeholders (e.g. the
+    // expected pivot digest that `--from-deployment` deliberately leaves blank).
+    // In `--from-deployment` mode the app ID is already set, so the saved-app-id
+    // default is only consulted for a blank template.
+    if is_interactive {
+        let saved_app_id = turnkey::Config::load()
+            .await
+            .ok()
+            .and_then(|config| config.get_last_app_id());
+        config.fill_interactively(saved_app_id.as_deref())?;
     }
+
+    let needs_pull_secret = config.pull_secret_is_placeholder();
 
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
 
@@ -65,13 +115,39 @@ async fn execute(args: Args) -> Result<()> {
     std::fs::write(&output, json)
         .with_context(|| format!("failed to write file: {}", output.display()))?;
 
-    if args.interactive {
+    if is_interactive {
         println!("Created deployment config: {}", output.display());
-        println!();
-        println!("Run: tvc deploy create --config-file {}", output.display());
     } else {
         println!("Created deployment config template: {}", output.display());
+    }
+    println!();
+
+    // Print the reminders specific to seeding a config from an existing deployment:
+    // the digest and debug mode were copied from the source manifest (the digest is
+    // image-coupled, so it must be recomputed if the image changes), and a pull secret
+    // (if the source used one) cannot be recovered and must be re-supplied.
+    if is_from_deployment {
+        println!("Seeded from an existing deployment. Before deploying:");
+        println!(
+            "  - expectedPivotDigest and debug mode were copied from the source deployment.\n    \
+             The digest is tied to the container image, so if you change\n    \
+             pivotContainerImageUrl you MUST recompute the digest to match."
+        );
+
+        if needs_pull_secret {
+            println!(
+                "  - The source deployment used a private image. Its pull secret cannot be\n    \
+                 recovered; pass `--pivot-pull-secret <PATH>` to `tvc deploy create` (or\n    \
+                 remove pivotContainerEncryptedPullSecret if the new image is public)."
+            );
+        }
+
         println!();
+    }
+
+    if is_interactive {
+        println!("Run: tvc deploy create --config-file {}", output.display());
+    } else {
         println!("Edit the file to fill in your values, then run:");
         println!("  tvc deploy create --config-file {}", output.display());
     }

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -1,12 +1,15 @@
 //! Deployment configuration file format for `tvc deploy create`.
 
-use std::fmt::Display;
-
 use crate::prompts;
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow};
+use qos_core::protocol::services::boot::VersionedManifest;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use thiserror::Error;
-use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
+use turnkey_client::generated::{
+    external::data::v1::{TvcContainerSpec, TvcDeployment},
+    immutable::common::v1::TvcHealthCheckType,
+};
 
 /// Sentinel written by `tvc deploy init` to remind the user to either remove
 /// the field (public image) or replace it with an encrypted pull secret
@@ -34,6 +37,73 @@ pub struct DeployConfig {
     pub health_check_type: TvcHealthCheckType,
     pub health_check_port: u16,
     pub public_ingress_port: u16,
+}
+
+/// Build a config seeded from an existing deployment, for use as a template.
+///
+/// Copies every recoverable field. `expected_pivot_digest` and
+/// `dangerous_deploy_debug_mode` are not on the fetched container spec — they
+/// live in the QOS manifest — so the manifest bytes are decoded and both are
+/// copied from it: the digest via `pivot_hash()`, debug mode via `debug_mode()`.
+/// The digest is coupled to the container image, so if the user repoints the
+/// config at a different image they must recompute it.
+///
+/// Errors if the deployment has no manifest or it cannot be decoded. The
+/// manifest is only `Option` because of how the proto is defined; a real
+/// deployment always carries one.
+///
+/// The pull-secret plaintext is unrecoverable (it is encrypted for the
+/// enclave), so a source deployment that used one gets the placeholder to
+/// prompt the user to re-supply it via `--pivot-pull-secret`.
+impl TryFrom<TvcDeployment> for DeployConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(deployment: TvcDeployment) -> std::result::Result<Self, Self::Error> {
+        let TvcDeployment {
+            id,
+            app_id,
+            qos_version,
+            pivot_container,
+            manifest,
+            ..
+        } = deployment;
+
+        let tvc_manifest =
+            manifest.ok_or_else(|| anyhow!("deployment {id} has no manifest to seed from"))?;
+        let manifest = VersionedManifest::try_from_slice_compat(&tvc_manifest.manifest)
+            .with_context(|| format!("failed to decode QOS manifest for deployment {id}"))?;
+
+        let TvcContainerSpec {
+            container_url,
+            path,
+            args,
+            has_pull_secret,
+            health_check_type,
+            health_check_port,
+            public_ingress_port,
+        } = pivot_container
+            .ok_or_else(|| anyhow!("deployment {id} has no pivot container spec"))?;
+
+        let health_check_port = u16::try_from(health_check_port)
+            .context("deployment health check port does not fit in u16")?;
+        let public_ingress_port = u16::try_from(public_ingress_port)
+            .context("deployment public ingress port does not fit in u16")?;
+
+        Ok(Self {
+            app_id,
+            qos_version,
+            pivot_container_image_url: container_url,
+            pivot_path: path,
+            pivot_args: args,
+            expected_pivot_digest: hex::encode(manifest.pivot_hash()),
+            dangerous_deploy_debug_mode: manifest.debug_mode(),
+            pivot_container_encrypted_pull_secret: has_pull_secret
+                .then(|| PULL_SECRET_PLACEHOLDER.to_string()),
+            health_check_type,
+            health_check_port,
+            public_ingress_port,
+        })
+    }
 }
 
 impl DeployConfig {
@@ -225,6 +295,134 @@ impl Display for DeployConfigValidationErrors {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use turnkey_client::generated::external::data::v1::{
+        TvcContainerSpec, TvcDeployment, TvcManifest,
+    };
+
+    /// A real (JSON) QOS manifest fixture, shared with the approve tests.
+    const MANIFEST_JSON: &str = include_str!("../../fixtures/manifest.json");
+    /// The `pivot.hash` value inside [`MANIFEST_JSON`].
+    const FIXTURE_PIVOT_HASH: &str =
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    /// Build a `TvcManifest` from the fixture, optionally flipping debug mode on.
+    fn manifest(debug_mode: bool) -> TvcManifest {
+        let json = if debug_mode {
+            MANIFEST_JSON.replace("\"debugMode\": false", "\"debugMode\": true")
+        } else {
+            MANIFEST_JSON.to_string()
+        };
+        TvcManifest {
+            id: "manifest-1".into(),
+            manifest: json.into_bytes(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_deployment(has_pull_secret: bool) -> TvcDeployment {
+        TvcDeployment {
+            id: "deploy-123".into(),
+            organization_id: "org-1".into(),
+            app_id: "app-1".into(),
+            manifest_set: None,
+            share_set: None,
+            manifest: Some(manifest(false)),
+            manifest_approvals: vec![],
+            qos_version: "0.6.1".into(),
+            pivot_container: Some(TvcContainerSpec {
+                container_url: "ghcr.io/x/y@sha256:img".into(),
+                path: "/bin/pivot".into(),
+                args: vec!["--flag".into(), "value".into()],
+                has_pull_secret,
+                health_check_type: TvcHealthCheckType::Http,
+                health_check_port: 8080,
+                public_ingress_port: 9090,
+            }),
+            created_at: None,
+            updated_at: None,
+            delete: false,
+            debug_mode: false,
+        }
+    }
+
+    #[test]
+    fn from_deployment_copies_recoverable_fields() {
+        let config = DeployConfig::try_from(sample_deployment(false)).unwrap();
+        assert_eq!(config.app_id, "app-1");
+        assert_eq!(config.qos_version, "0.6.1");
+        assert_eq!(config.pivot_container_image_url, "ghcr.io/x/y@sha256:img");
+        assert_eq!(config.pivot_path, "/bin/pivot");
+        assert_eq!(config.pivot_args, vec!["--flag", "value"]);
+        assert_eq!(config.health_check_type, TvcHealthCheckType::Http);
+        assert_eq!(config.health_check_port, 8080);
+        assert_eq!(config.public_ingress_port, 9090);
+    }
+
+    #[test]
+    fn from_deployment_copies_digest_and_debug_from_manifest() {
+        let config = DeployConfig::try_from(sample_deployment(false)).unwrap();
+        // Digest and debug mode are copied from the QOS manifest, not left blank.
+        assert_eq!(config.expected_pivot_digest, FIXTURE_PIVOT_HASH);
+        assert!(!config.dangerous_deploy_debug_mode);
+        // A seeded config therefore has no remaining placeholder fields.
+        assert!(config.missing_required_fields().is_empty());
+    }
+
+    #[test]
+    fn from_deployment_copies_debug_mode_when_source_is_debug() {
+        let mut deployment = sample_deployment(false);
+        deployment.manifest = Some(manifest(true));
+        let config = DeployConfig::try_from(deployment).unwrap();
+        // Debug mode is carried over as-is from the source manifest.
+        assert!(config.dangerous_deploy_debug_mode);
+    }
+
+    #[test]
+    fn from_deployment_sets_pull_secret_placeholder_only_for_private_images() {
+        let public = DeployConfig::try_from(sample_deployment(false)).unwrap();
+        assert_eq!(public.pivot_container_encrypted_pull_secret, None);
+
+        let private = DeployConfig::try_from(sample_deployment(true)).unwrap();
+        assert!(private.pull_secret_is_placeholder());
+    }
+
+    #[test]
+    fn from_deployment_errors_without_container_spec() {
+        let mut deployment = sample_deployment(false);
+        deployment.pivot_container = None;
+        assert!(DeployConfig::try_from(deployment).is_err());
+    }
+
+    #[test]
+    fn from_deployment_errors_when_port_exceeds_u16() {
+        let mut deployment = sample_deployment(false);
+        deployment
+            .pivot_container
+            .as_mut()
+            .unwrap()
+            .public_ingress_port = 70_000;
+        assert!(DeployConfig::try_from(deployment).is_err());
+    }
+
+    #[test]
+    fn from_deployment_errors_without_manifest() {
+        let mut deployment = sample_deployment(false);
+        deployment.manifest = None;
+        assert!(DeployConfig::try_from(deployment).is_err());
+    }
+
+    #[test]
+    fn from_deployment_errors_with_undecodable_manifest() {
+        let mut deployment = sample_deployment(false);
+        deployment.manifest = Some(TvcManifest {
+            id: "manifest-1".into(),
+            manifest: b"not a valid manifest".to_vec(),
+            created_at: None,
+            updated_at: None,
+        });
+        assert!(DeployConfig::try_from(deployment).is_err());
+    }
 
     #[test]
     fn fresh_template_is_all_placeholders() {

--- a/tvc/tests/deploy_init_help.rs
+++ b/tvc/tests/deploy_init_help.rs
@@ -1,0 +1,27 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn deploy_init_help_documents_from_deployment_flag() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("init")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--from-deployment"))
+        .stdout(predicate::str::contains("TVC_FROM_DEPLOYMENT"))
+        .stdout(predicate::str::contains("expected pivot digest"));
+}
+
+#[test]
+fn deploy_init_help_documents_interactive_and_output_flags() {
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("init")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--interactive"))
+        .stdout(predicate::str::contains("--output"));
+}


### PR DESCRIPTION
Closes ENG-3887.

## What

Adds `tvc deploy init --from-deployment <DEPLOY_ID>` (env `TVC_FROM_DEPLOYMENT`) to scaffold a new deployment config seeded from an existing deployment, reusing the existing **init → edit → create** flow. The user gets a pre-filled, editable `DeployConfig` JSON to feed to the unchanged `tvc deploy create --config-file`.

## Field mapping (`TvcDeployment` → `DeployConfig`)

| DeployConfig field | Source |
|---|---|
| `app_id`, `qos_version` | deployment top-level |
| `pivot_container_image_url` | `pivot_container.container_url` |
| `pivot_path`, `pivot_args` | `pivot_container` |
| `health_check_type` / `health_check_port` / `public_ingress_port` | `pivot_container` (u32→u16 checked) |
| `expected_pivot_digest` | **`<FILL_IN…>` placeholder** — forced re-entry |
| `dangerous_deploy_debug_mode` | **`false`** — safe default |
| `pivot_container_encrypted_pull_secret` | `Some(PLACEHOLDER)` iff `has_pull_secret`, else `None` |

## Why the digest/debug handling

The digest and debug mode aren't server-derivable (they live only in the manifest), so the digest is left blank to force re-entry, debug mode resets to off, and a loud warning is printed. The pull-secret plaintext is unrecoverable, so a private-image source writes a placeholder to prompt re-supply via `--pivot-pull-secret`.

## Changes

- `config/deploy.rs` — `DeployConfig::from_deployment(&TvcDeployment)` pure mapping leaf + unit tests.
- `client.rs` — `fetch_tvc_deployment` helper; `deploy get-status` refactored to reuse it.
- `commands/deploy/init.rs` — `--from-deployment` flag; composes with `--interactive` / `--non-interactive`; prints digest/image-coupling warning + pull-secret note.
- `cli.rs` — updated `deploy init` help.
- `tests/deploy_init_help.rs` — arg-parse/help test.

## Out of scope (possible follow-ups)

- `create --from-deployment` one-shot recreate.
- Recovering the exact digest/debug-mode by parsing the manifest.

## Testing

Ran through the quickstart to create a deployment, then used that deployment as the `--from-deployment` seed to create another.
