### PR TITLE
Am/tvc 127/use dev dashboard link

### DIFF
--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -407,6 +407,10 @@ fn print_success(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::turnkey::{
+        API_BASE_URL_DEV, API_BASE_URL_PREPROD, DASHBOARD_URL_DEV, DASHBOARD_URL_PREPROD,
+        DASHBOARD_URL_PROD,
+    };
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -424,11 +428,6 @@ mod tests {
 
     #[test]
     fn dashboard_url_matches_selected_environment() {
-        use crate::config::turnkey::{
-            API_BASE_URL_DEV, API_BASE_URL_PREPROD, DASHBOARD_URL_DEV, DASHBOARD_URL_PREPROD,
-            DASHBOARD_URL_PROD,
-        };
-
         assert_eq!(dashboard_base_url(API_BASE_URL_PROD), DASHBOARD_URL_PROD);
         assert_eq!(
             dashboard_base_url(API_BASE_URL_PREPROD),
@@ -439,8 +438,6 @@ mod tests {
 
     #[test]
     fn dashboard_url_falls_back_to_prod_for_unknown_hosts() {
-        use crate::config::turnkey::DASHBOARD_URL_PROD;
-
         // Local and other unrecognized hosts fall back to the prod dashboard.
         assert_eq!(dashboard_base_url(OVERRIDE_URL), DASHBOARD_URL_PROD);
         assert_eq!(

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -64,7 +64,7 @@ pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
 fn build_login_plan_interactive(args: Args, config: &Config) -> Result<LoginPlan> {
     let org = match args.org {
         Some(query) => OrgPlan::Existing(query),
-        None => prompt_for_org_plan(config)?,
+        None => prompt_for_org_plan(config, args.api_base_url.as_deref())?,
     };
     Ok(LoginPlan {
         org,
@@ -143,7 +143,7 @@ async fn execute_login(mut config: Config, plan: LoginPlan) -> Result<()> {
     print_success(&alias, &org_config, &api_key, &operator_key, &whoami)
 }
 
-fn prompt_for_org_plan(config: &Config) -> Result<OrgPlan> {
+fn prompt_for_org_plan(config: &Config, api_base_url_override: Option<&str>) -> Result<OrgPlan> {
     debug!(
         configured_org_count = config.orgs.len(),
         active_org = ?config.active_org,
@@ -153,7 +153,7 @@ fn prompt_for_org_plan(config: &Config) -> Result<OrgPlan> {
     if config.orgs.is_empty() {
         debug!("no organizations configured; prompting for new organization");
         println!("No organization configured.");
-        return prompt_for_new_org_inputs();
+        return prompt_for_new_org_inputs(api_base_url_override);
     }
 
     let mut options: Vec<OrgChoice> = config
@@ -175,12 +175,13 @@ fn prompt_for_org_plan(config: &Config) -> Result<OrgPlan> {
 
     match prompts::select("Select organization", options)? {
         OrgChoice::Existing { alias, .. } => Ok(OrgPlan::Existing(alias)),
-        OrgChoice::New => prompt_for_new_org_inputs(),
+        OrgChoice::New => prompt_for_new_org_inputs(api_base_url_override),
     }
 }
 
-fn prompt_for_new_org_inputs() -> Result<OrgPlan> {
-    println!("You can find your Organization ID at: https://app.turnkey.com/dashboard/welcome");
+fn prompt_for_new_org_inputs(api_base_url_override: Option<&str>) -> Result<OrgPlan> {
+    let dashboard_url = dashboard_base_url(api_base_url_override.unwrap_or(API_BASE_URL_PROD));
+    println!("You can find your Organization ID at: {dashboard_url}/dashboard/welcome");
     println!();
 
     let id = prompts::text("Organization ID", None)?;

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -2,6 +2,7 @@
 
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, OrgConfig, StoredApiKey, StoredQosOperatorKey,
+    dashboard_base_url,
 };
 use crate::prompts::{self, error_required_in_non_interactive};
 use anyhow::{Context, Result, anyhow, bail};
@@ -274,8 +275,9 @@ async fn generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
     println!();
     println!("Public Key: {public_key}");
     println!();
+    let dashboard_url = dashboard_base_url(&org_config.api_base_url);
     println!("Add this API key to your Turnkey dashboard:");
-    println!("  1. Go to https://app.turnkey.com/dashboard/v2/users and click your user");
+    println!("  1. Go to {dashboard_url}/dashboard/v2/users and click your user");
     println!(
         "  2. Click \"New API Key\", expand \"Advanced Settings\", then check \"Generate API key via CLI\""
     );
@@ -417,6 +419,33 @@ mod tests {
     #[test]
     fn new_org_api_base_url_uses_override() {
         assert_eq!(new_org_api_base_url(Some(OVERRIDE_URL)), OVERRIDE_URL);
+    }
+
+    #[test]
+    fn dashboard_url_matches_selected_environment() {
+        use crate::config::turnkey::{
+            API_BASE_URL_DEV, API_BASE_URL_PREPROD, DASHBOARD_URL_DEV, DASHBOARD_URL_PREPROD,
+            DASHBOARD_URL_PROD,
+        };
+
+        assert_eq!(dashboard_base_url(API_BASE_URL_PROD), DASHBOARD_URL_PROD);
+        assert_eq!(
+            dashboard_base_url(API_BASE_URL_PREPROD),
+            DASHBOARD_URL_PREPROD
+        );
+        assert_eq!(dashboard_base_url(API_BASE_URL_DEV), DASHBOARD_URL_DEV);
+    }
+
+    #[test]
+    fn dashboard_url_falls_back_to_prod_for_unknown_hosts() {
+        use crate::config::turnkey::DASHBOARD_URL_PROD;
+
+        // Local and other unrecognized hosts fall back to the prod dashboard.
+        assert_eq!(dashboard_base_url(OVERRIDE_URL), DASHBOARD_URL_PROD);
+        assert_eq!(
+            dashboard_base_url("https://api.staging.turnkey.engineering"),
+            DASHBOARD_URL_PROD
+        );
     }
 
     #[test]

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -47,6 +47,24 @@ pub const API_BASE_URL_PREPROD: &str = "https://api.preprod.turnkey.engineering"
 pub const API_BASE_URL_DEV: &str = "https://api.dev.turnkey.engineering";
 pub const API_BASE_URL_LOCAL: &str = "http://localhost:8081";
 
+/// Dashboard base URLs corresponding to each environment.
+pub const DASHBOARD_URL_PROD: &str = "https://app.turnkey.com";
+pub const DASHBOARD_URL_PREPROD: &str = "https://app.preprod.turnkey.engineering";
+pub const DASHBOARD_URL_DEV: &str = "https://app.dev.turnkey.engineering";
+
+/// Maps an API base URL to the dashboard base URL for the same environment.
+///
+/// Any URL that isn't a known Turnkey environment (e.g. a local API) falls back
+/// to the production dashboard.
+pub fn dashboard_base_url(api_base_url: &str) -> String {
+    match api_base_url {
+        API_BASE_URL_PROD => DASHBOARD_URL_PROD.to_string(),
+        API_BASE_URL_PREPROD => DASHBOARD_URL_PREPROD.to_string(),
+        API_BASE_URL_DEV => DASHBOARD_URL_DEV.to_string(),
+        _ => DASHBOARD_URL_PROD.to_string(),
+    }
+}
+
 /// Configuration for a single organization
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrgConfig {

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -56,12 +56,12 @@ pub const DASHBOARD_URL_DEV: &str = "https://app.dev.turnkey.engineering";
 ///
 /// Any URL that isn't a known Turnkey environment (e.g. a local API) falls back
 /// to the production dashboard.
-pub fn dashboard_base_url(api_base_url: &str) -> String {
+pub fn dashboard_base_url(api_base_url: &str) -> &'static str {
     match api_base_url {
-        API_BASE_URL_PROD => DASHBOARD_URL_PROD.to_string(),
-        API_BASE_URL_PREPROD => DASHBOARD_URL_PREPROD.to_string(),
-        API_BASE_URL_DEV => DASHBOARD_URL_DEV.to_string(),
-        _ => DASHBOARD_URL_PROD.to_string(),
+        API_BASE_URL_PROD => DASHBOARD_URL_PROD,
+        API_BASE_URL_PREPROD => DASHBOARD_URL_PREPROD,
+        API_BASE_URL_DEV => DASHBOARD_URL_DEV,
+        _ => DASHBOARD_URL_PROD,
     }
 }
 


### PR DESCRIPTION
## What

The dashboard links printed by `tvc login` were hardcoded to
`app.turnkey.com`, so selecting a dev/preprod environment still sent users
to the prod dashboard.

Adds a `dashboard_base_url()` helper that maps an API base URL to the
matching dashboard, and uses it for both printed links:
- API-key **registration** link (`.../dashboard/v2/users`), -> the reported bug
- org-ID **welcome** link (`.../dashboard/welcome`), -> same bug class

Unknown/local hosts fall back to the prod dashboard.

## Test
- `cargo test -p tvc` (incl. new mapping tests), fmt + clippy clean
- Manually walked `tvc login --api-base-url …dev/preprod…` and confirmed both links render the matching dashboard host

Closes [TVC-127](https://linear.app/turnkey/issue/TVC-127/when-you-select-dev-environment-it-still-gives-you-the-prod-dashboard)