### PR TITLE
fix(tvc): clarify API key vs operator key labels in login output

### DIFF
--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -274,7 +274,7 @@ async fn generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
     println!();
     println!("API Key Generated!");
     println!();
-    println!("Public Key: {public_key}");
+    println!("API key public key: {public_key}");
     println!();
     let dashboard_url = dashboard_base_url(&org_config.api_base_url);
     println!("Add this API key to your Turnkey dashboard:");
@@ -325,7 +325,7 @@ async fn find_or_generate_operator_key(org_config: &OrgConfig) -> Result<StoredQ
     println!();
     println!("Operator Key Generated!");
     println!();
-    println!("Public Key: {public_key}");
+    println!("Operator public key: {public_key}");
     println!();
     println!("This key will be used for approving deployment manifests.");
     println!("Make sure to register this as an operator in your organization.");
@@ -391,15 +391,21 @@ fn print_success(
     );
     println!("User: {} ({})", whoami.username, whoami.user_id);
     println!("Active Org: {alias}");
-    println!("API Key: {}", api_key.public_key);
-    println!("Operator Key: {}", operator_key.public_key);
     println!();
+    println!("Credentials");
+    println!("  API key public key:    {}", api_key.public_key);
+    println!("  Operator public key:   {}", operator_key.public_key);
+    println!();
+    println!("Saved to");
     println!(
-        "Config: {}",
+        "  Config file:    {}",
         crate::config::turnkey::config_file_path()?.display()
     );
-    println!("API Key: {}", org_config.api_key_path.display());
-    println!("Operator Key: {}", org_config.operator_key_path.display());
+    println!("  API key:        {}", org_config.api_key_path.display());
+    println!(
+        "  Operator key:   {}",
+        org_config.operator_key_path.display()
+    );
 
     Ok(())
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -274,7 +274,7 @@ async fn generate_api_key(org_config: &OrgConfig) -> Result<StoredApiKey> {
     println!();
     println!("API Key Generated!");
     println!();
-    println!("API key public key: {public_key}");
+    println!("API public key: {public_key}");
     println!();
     let dashboard_url = dashboard_base_url(&org_config.api_base_url);
     println!("Add this API key to your Turnkey dashboard:");
@@ -393,7 +393,7 @@ fn print_success(
     println!("Active Org: {alias}");
     println!();
     println!("Credentials");
-    println!("  API key public key:    {}", api_key.public_key);
+    println!("  API public key:        {}", api_key.public_key);
     println!("  Operator public key:   {}", operator_key.public_key);
     println!();
     println!("Saved to");


### PR DESCRIPTION
## What
`tvc login` output The output text does not distinguish clearly between the API key, operator ID, and operator public key.

This change reworks the login success output into two distinct sections and made every value label explicit:

**Before**

```
Generating API key...

API Key Generated!

Public Key: abc...

...

Generating operator key...

Operator Key Generated!

Public Key: def...
```

```
API Key: 037ae4…5daa
Operator Key: 02be9f…c14a

Config: ~/.config/turnkey/tvc.config.toml
API Key: ~/.config/turnkey/orgs/dev/api_key.json
Operator Key: ~/.config/turnkey/orgs/dev/operator.json
```

**After**

```
Generating API key...

API Key Generated!

API public key: abc...

...

Generating operator key...

Operator Key Generated!

Operator public key:  def...
```

```
Credentials
  API public key:    037ae4…5daa
  Operator public key:   02be9f…c14a

Saved to
  Config file:    ~/.config/turnkey/tvc.config.toml
  API key:        ~/.config/turnkey/orgs/dev/api_key.json
  Operator key:   ~/.config/turnkey/orgs/dev/operator.json
```

Also relabeled the generate-step lines from the ambiguous `Public Key:` to
`API public key:` / `Operator public key:`, so the hex value is never confused with the UUID operator ID used later by `app create` /`deploy approve`.

## Test
- `make lint` + `cargo test -p tvc` clean
- Walked `tvc login` and confirmed the new labels/sections render

Closes [TVC-129](https://linear.app/turnkey/issue/TVC-129/in-the-rust-cli-make-it-more-clear-in-output-text-what-is-your-api-key)