### PR TITLE
feat(tvc): typed Outcome for every command

### DIFF
--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -19,6 +19,13 @@ Default guidance for coding-agent runs in this repository.
   `From<T>` over `From<&T>`. When a clone is genuinely needed, make it explicit
   at the call site — e.g. `value.clone().into()` or
   `items.iter().cloned().map(Into::into)`.
+- Prefer short (imported) names over fully-qualified paths. Add a `use` and
+  write `impl Display for Foo { fn fmt(&self, f: &mut Formatter<'_>) … }` rather
+  than `impl std::fmt::Display for Foo { … std::fmt::Formatter … }`. Only keep a
+  longer/module-qualified form when it disambiguates from another in-scope name —
+  e.g. `fmt::Result` stays qualified (via `use std::fmt::{self, Display, Formatter}`)
+  so it doesn't collide with `anyhow::Result`, and `std::fmt::Write` may need
+  `as _` where `std::io::Write` is also in scope.
 - When converting from an external/generated type (e.g. the API's `TvcApp`,
   `TvcDeployment`, `AppStatus`) into one of our own structs, destructure it
   exhaustively — `let Foo { a, b, c: _ } = value;` with no trailing `..` —

--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Default guidance for coding-agent runs in this repository.
+
+## Coding style
+
+- Prefer raw string literals (`r#"..."#`) over escaped quotation marks (`\"`) or
+  escaped newlines (`\n`) for any nontrivial string or multi-line output (e.g.
+  `human_message` bodies, help text, JSON fixtures, test goldens). Lay the text
+  out on real lines so it reads as it renders. If a line ends in significant
+  trailing whitespace, still use a raw literal but add a comment noting the
+  trailing whitespace so editors/formatters don't silently strip it.
+- Prefer moving owned values over cloning them. If you already own a value and
+  this is its last use (e.g. building the return value at the end of a
+  function), move it out — use `.into_iter()` or partial field moves instead of
+  `.clone()`.
+- Don't hide clones inside functions. A function or `From`/`TryFrom` impl should
+  take an owned value (`T`, not `&T`) rather than clone internally; prefer
+  `From<T>` over `From<&T>`. When a clone is genuinely needed, make it explicit
+  at the call site — e.g. `value.clone().into()` or
+  `items.iter().cloned().map(Into::into)`.
+- When converting from an external/generated type (e.g. the API's `TvcApp`,
+  `TvcDeployment`, `AppStatus`) into one of our own structs, destructure it
+  exhaustively — `let Foo { a, b, c: _ } = value;` with no trailing `..` —
+  rather than reading fields with `value.a`. Bind the fields you use and
+  `_`-bind the ones you don't. This way, when the upstream type gains a field, the destructure
+  fails to compile and forces a deliberate decision about whether the new field
+  belongs in our output — instead of it being silently dropped. Skip this only
+  where it adds noise for no value, e.g. reading one or two fields off a large
+  API response result.

--- a/tvc/CLAUDE.md
+++ b/tvc/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -1,6 +1,7 @@
 //! CLI parsing and dispatch.
 
 use crate::commands;
+use crate::outcome::Outcome;
 use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell, StdCtx};
 use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser};
 use std::io::Write;
@@ -85,7 +86,16 @@ impl Cli {
         let mut ctx = Ctx::new(shell, args.non_interactive);
         let result = args.command.run(&mut ctx).await;
         match result {
-            Ok(()) => ExitCode::SUCCESS,
+            Ok(outcome) => {
+                // Fail open: the command itself already succeeded, so a failure
+                // to deliver the outcome message should not flip the exit code.
+                // Make a best-effort warning on stderr and still exit successfully.
+                if let Err(emit_error) = ctx.shell().emit(&outcome) {
+                    let mut stderr = std::io::stderr();
+                    let _ = writeln!(stderr, "warning: failed to write CLI output: {emit_error}");
+                }
+                ExitCode::SUCCESS
+            }
             Err(error) => {
                 let shell = ctx.shell();
                 let emit_result = if shell.message_format().is_json() {
@@ -104,7 +114,7 @@ impl Cli {
 }
 
 impl Commands {
-    async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<()> {
+    async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<Outcome> {
         match self {
             Commands::Deploy { command } => match command {
                 DeployCommands::Approve(args) => commands::deploy::approve::run(ctx, args).await,

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -7,13 +7,13 @@ use crate::{
         turnkey::{self, StoredQosOperatorKey},
     },
     outcome::Outcome,
-    output::{Ctx, Message, StdCtx},
+    output::{Ctx, StdCtx},
     prompts, shell_println,
 };
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt::Write as _;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     io,
@@ -281,13 +281,10 @@ pub struct AppCreated {
     config_path: String,
 }
 
-impl Message for AppCreated {
-    fn reason(&self) -> &'static str {
-        "app-created"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = format!(
+impl Display for AppCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 App created successfully!
 
@@ -295,26 +292,24 @@ App ID: {}
 Name: {}
 Manifest Set ID: {}"#,
             self.app_id, self.name, self.manifest_set_id
-        );
+        )?;
 
         if !self.manifest_set_operator_ids.is_empty() {
-            let _ = write!(
-                message,
+            write!(
+                f,
                 "\nManifest Set Operator IDs: {}",
                 self.manifest_set_operator_ids.join(", ")
-            );
+            )?;
         }
 
-        let _ = write!(
-            message,
+        write!(
+            f,
             r#"
 Config: {}
 
 Use one of the Manifest Set Operator IDs above with `tvc deploy approve --operator-id`"#,
             self.config_path
-        );
-
-        message
+        )
     }
 }
 

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -6,11 +6,14 @@ use crate::{
         app::{AppConfig, AppConfigValidationErrors, OperatorSetParams},
         turnkey::{self, StoredQosOperatorKey},
     },
-    output::{Ctx, StdCtx},
+    outcome::Outcome,
+    output::{Ctx, Message, StdCtx},
     prompts, shell_println,
 };
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::Write as _;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     io,
@@ -51,7 +54,7 @@ struct Overrides {
     pub dangerous_enable_debug_mode_deployments: bool,
 }
 
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let config = if ctx.is_non_interactive() {
         build_app_config_non_interactive(&args).await?
     } else {
@@ -233,7 +236,7 @@ async fn load_saved_operator_public_key() -> Option<String> {
     Some(operator_key.public_key)
 }
 
-async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) -> Result<()> {
+async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) -> Result<Outcome> {
     shell_println!(ctx, "Creating app '{}'...", app_config.name)?;
 
     let auth = build_client().await?;
@@ -259,27 +262,60 @@ async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) ->
     config.set_last_operator_ids(&operator_ids)?;
     config.save().await?;
 
-    shell_println!(ctx)?;
-    shell_println!(ctx, "App created successfully!")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "App ID: {app_id}")?;
-    shell_println!(ctx, "Name: {}", app_config.name)?;
-    shell_println!(ctx, "Manifest Set ID: {}", result.result.manifest_set_id)?;
-    if !operator_ids.is_empty() {
-        shell_println!(
-            ctx,
-            "Manifest Set Operator IDs: {}",
-            operator_ids.join(", ")
-        )?;
-    }
-    shell_println!(ctx, "Config: {}", args.config_file.display())?;
-    shell_println!(ctx)?;
-    shell_println!(
-        ctx,
-        "Use one of the Manifest Set Operator IDs above with `tvc deploy approve --operator-id`"
-    )?;
+    Ok(Outcome::AppCreate(AppCreated {
+        app_id,
+        name: app_config.name,
+        manifest_set_id: result.result.manifest_set_id,
+        manifest_set_operator_ids: operator_ids,
+        config_path: args.config_file.display().to_string(),
+    }))
+}
 
-    Ok(())
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppCreated {
+    app_id: String,
+    name: String,
+    manifest_set_id: String,
+    manifest_set_operator_ids: Vec<String>,
+    config_path: String,
+}
+
+impl Message for AppCreated {
+    fn reason(&self) -> &'static str {
+        "app-created"
+    }
+
+    fn human_message(&self) -> String {
+        let mut message = format!(
+            r#"
+App created successfully!
+
+App ID: {}
+Name: {}
+Manifest Set ID: {}"#,
+            self.app_id, self.name, self.manifest_set_id
+        );
+
+        if !self.manifest_set_operator_ids.is_empty() {
+            let _ = write!(
+                message,
+                "\nManifest Set Operator IDs: {}",
+                self.manifest_set_operator_ids.join(", ")
+            );
+        }
+
+        let _ = write!(
+            message,
+            r#"
+Config: {}
+
+Use one of the Manifest Set Operator IDs above with `tvc deploy approve --operator-id`"#,
+            self.config_path
+        );
+
+        message
+    }
 }
 
 fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -2,10 +2,11 @@
 
 use crate::client::build_client;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, DeleteTvcAppAndDeploymentsIntent};
 
@@ -65,13 +66,10 @@ impl Default for AppDeleted {
     }
 }
 
-impl Message for AppDeleted {
-    fn reason(&self) -> &'static str {
-        "app-deleted"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for AppDeleted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"App delete accepted.
 App and deployments marked for deletion.
 

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -1,12 +1,13 @@
 //! App delete command - marks an app and all deployments for deletion.
 
 use crate::client::build_client;
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::generated::DeleteTvcAppAndDeploymentsIntent;
+use turnkey_client::generated::{ActivityStatus, DeleteTvcAppAndDeploymentsIntent};
 
 /// Delete a TVC application and all of its deployments.
 #[derive(Debug, ClapArgs)]
@@ -18,7 +19,7 @@ pub struct Args {
 }
 
 /// Run the app delete command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcAppAndDeploymentsIntent {
@@ -36,11 +37,48 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
         .await
         .context("failed to delete TVC app and deployments")?;
 
-    shell_println!(ctx, "App delete accepted.")?;
-    shell_println!(ctx, "App and deployments marked for deletion.")?;
-    shell_println!(ctx, "App ID: {}", result.result.app_id)?;
-    shell_println!(ctx, "Activity ID: {}", result.activity_id)?;
-    shell_println!(ctx, "Activity Status: {:?}", result.status)?;
+    Ok(Outcome::AppDelete(AppDeleted {
+        app_id: result.result.app_id,
+        activity_id: result.activity_id,
+        activity_status: result.status,
+    }))
+}
 
-    Ok(())
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppDeleted {
+    app_id: String,
+    activity_id: String,
+    /// Stable proto status name, e.g. `ACTIVITY_STATUS_COMPLETED`.
+    activity_status: ActivityStatus,
+}
+
+/// Manual because the generated `ActivityStatus` does not implement
+/// `Default`; the zero value is the enum's `Unspecified` variant.
+impl Default for AppDeleted {
+    fn default() -> Self {
+        Self {
+            app_id: String::default(),
+            activity_id: String::default(),
+            activity_status: ActivityStatus::Unspecified,
+        }
+    }
+}
+
+impl Message for AppDeleted {
+    fn reason(&self) -> &'static str {
+        "app-deleted"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"App delete accepted.
+App and deployments marked for deletion.
+
+App ID: {}
+Activity ID: {}
+Activity Status: {}"#,
+            self.app_id, self.activity_id, self.activity_status.as_str_name()
+        )
+    }
 }

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -78,7 +78,9 @@ App and deployments marked for deletion.
 App ID: {}
 Activity ID: {}
 Activity Status: {}"#,
-            self.app_id, self.activity_id, self.activity_status.as_str_name()
+            self.app_id,
+            self.activity_id,
+            self.activity_status.as_str_name()
         )
     }
 }

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -2,11 +2,12 @@
 
 use crate::config::app::AppConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::output::StdCtx;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
-use crate::shell_println;
 use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::path::PathBuf;
 
 /// Generate a template app configuration file.
@@ -30,7 +31,7 @@ pub struct Args {
 }
 
 /// Run the app init command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -38,10 +39,10 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
             ensure_stdin_is_tty()?;
         }
     }
-    execute(ctx, args).await
+    execute(args).await
 }
 
-async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
+async fn execute(args: Args) -> Result<Outcome> {
     // Check if file already exists
     if args.output.exists() {
         bail!("File already exists: {}", args.output.display());
@@ -62,30 +63,45 @@ async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
     std::fs::write(&args.output, json)
         .with_context(|| format!("failed to write file: {}", args.output.display()))?;
 
-    if args.interactive {
-        shell_println!(ctx, "Created app config: {}", args.output.display())?;
-        shell_println!(ctx)?;
-        shell_println!(
-            ctx,
-            "Run: tvc app create --config-file {}",
-            args.output.display()
-        )?;
-    } else {
-        shell_println!(
-            ctx,
-            "Created app config template: {}",
-            args.output.display()
-        )?;
-        shell_println!(ctx)?;
-        shell_println!(ctx, "Edit the file to fill in your values, then run:")?;
-        shell_println!(
-            ctx,
-            "  tvc app create --config-file {}",
-            args.output.display()
-        )?;
+    Ok(Outcome::AppInit(AppConfigCreated {
+        command: "app init",
+        path: args.output.display().to_string(),
+        template: !args.interactive,
+        interactive: args.interactive,
+    }))
+}
+
+#[derive(Default, Serialize)]
+pub struct AppConfigCreated {
+    command: &'static str,
+    path: String,
+    template: bool,
+    interactive: bool,
+}
+
+impl Message for AppConfigCreated {
+    fn reason(&self) -> &'static str {
+        "app-config-created"
     }
 
-    Ok(())
+    fn human_message(&self) -> String {
+        if self.interactive {
+            format!(
+                r#"Created app config: {}
+
+Run: tvc app create --config-file {}"#,
+                self.path, self.path
+            )
+        } else {
+            format!(
+                r#"Created app config template: {}
+
+Edit the file to fill in your values, then run:
+  tvc app create --config-file {}"#,
+                self.path, self.path
+            )
+        }
+    }
 }
 
 /// Load the operator public key from the active org's config

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -3,11 +3,12 @@
 use crate::config::app::AppConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
 use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 /// Generate a template app configuration file.
@@ -79,21 +80,19 @@ pub struct AppConfigCreated {
     interactive: bool,
 }
 
-impl Message for AppConfigCreated {
-    fn reason(&self) -> &'static str {
-        "app-config-created"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for AppConfigCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.interactive {
-            format!(
+            write!(
+                f,
                 r#"Created app config: {}
 
 Run: tvc app create --config-file {}"#,
                 self.path, self.path
             )
         } else {
-            format!(
+            write!(
+                f,
                 r#"Created app config template: {}
 
 Edit the file to fill in your values, then run:

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -2,12 +2,15 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt;
+use std::fmt::Display;
 use turnkey_client::generated::GetTvcAppsRequest;
 use turnkey_client::generated::external::data::v1::TvcApp;
 
-use crate::commands::display::format_egress_enabled;
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::commands::display::{format_egress_enabled, yes_no};
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 
 const SEPARATOR_WIDTH: usize = 40;
 
@@ -21,7 +24,7 @@ pub struct Args {
 }
 
 /// Run the app list command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let response = auth
@@ -36,16 +39,9 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
 
     filter_by_name(&mut apps, args.name.as_deref());
 
-    if apps.is_empty() {
-        shell_println!(ctx, "No apps found.")?;
-        return Ok(());
-    }
-
-    for app in &apps {
-        render_app(ctx, app)?;
-    }
-
-    Ok(())
+    Ok(Outcome::AppList(AppsListed {
+        apps: apps.into_iter().map(AppSummary::from).collect(),
+    }))
 }
 
 fn filter_by_name(apps: &mut Vec<TvcApp>, name: Option<&str>) {
@@ -54,24 +50,99 @@ fn filter_by_name(apps: &mut Vec<TvcApp>, name: Option<&str>) {
     }
 }
 
-fn render_app(ctx: &mut StdCtx, app: &TvcApp) -> anyhow::Result<()> {
-    let live = app.live_deployment_id.as_deref().unwrap_or("(none)");
-    let mut lines = vec![
-        format!("Name: {}", app.name),
-        format!("ID: {}", app.id),
-        format!("Quorum Public Key: {}", app.quorum_public_key),
-        format!("Live Deployment: {live}"),
-        format_egress_enabled(app.enable_egress),
-    ];
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppsListed {
+    apps: Vec<AppSummary>,
+}
 
-    if !app.public_domain.is_empty() {
-        lines.push(format!("Public Domain: {}", app.public_domain));
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AppSummary {
+    id: String,
+    name: String,
+    quorum_public_key: String,
+    live_deployment_id: Option<String>,
+    egress_enabled: bool,
+    debug_mode_deployments_enabled: bool,
+    /// Empty when the app has no public domain configured.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    public_domain: String,
+}
+
+impl From<TvcApp> for AppSummary {
+    fn from(app: TvcApp) -> Self {
+        // Destructure exhaustively (rather than `..`) so that adding a field to
+        // the generated `TvcApp` forces a compile error here 
+        let TvcApp {
+            id,
+            name,
+            quorum_public_key,
+            live_deployment_id,
+            public_domain,
+            enable_egress: egress_enabled,
+            enable_debug_mode_deployments: debug_mode_deployments_enabled,
+            organization_id: _,
+            manifest_set: _,
+            share_set: _,
+            created_at: _,
+            updated_at: _,
+        } = app;
+
+        Self {
+            id,
+            name,
+            quorum_public_key,
+            live_deployment_id,
+            egress_enabled,
+            debug_mode_deployments_enabled,
+            public_domain,
+        }
+    }
+}
+
+impl Message for AppsListed {
+    fn reason(&self) -> &'static str {
+        "apps-listed"
     }
 
-    lines.push("─".repeat(SEPARATOR_WIDTH));
+    fn human_message(&self) -> String {
+        if self.apps.is_empty() {
+            return "No apps found.".to_string();
+        }
 
-    shell_println!(ctx, "{}", lines.join("\n"))?;
-    Ok(())
+        self.apps
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+impl Display for AppSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let live = self.live_deployment_id.as_deref().unwrap_or("(none)");
+        write!(
+            f,
+            r#"Name: {}
+ID: {}
+Quorum Public Key: {}
+Live Deployment: {live}
+{}
+Debug Mode Deployments: {}"#,
+            self.name,
+            self.id,
+            self.quorum_public_key,
+            format_egress_enabled(self.egress_enabled),
+            yes_no(self.debug_mode_deployments_enabled),
+        )?;
+
+        if !self.public_domain.is_empty() {
+            write!(f, "\nPublic Domain: {}", self.public_domain)?;
+        }
+
+        write!(f, "\n{}", "─".repeat(SEPARATOR_WIDTH))
+    }
 }
 
 #[cfg(test)]
@@ -168,6 +239,59 @@ mod tests {
         assert_eq!(
             format_egress_enabled(app.enable_egress),
             "Egress Enabled: yes"
+        );
+    }
+
+    fn full_summary() -> AppSummary {
+        AppSummary {
+            id: "app-1".to_string(),
+            name: "my-app".to_string(),
+            quorum_public_key: "04abcd".to_string(),
+            live_deployment_id: Some("dep-9".to_string()),
+            egress_enabled: true,
+            debug_mode_deployments_enabled: true,
+            public_domain: "my-app.example.com".to_string(),
+        }
+    }
+
+    fn minimal_summary() -> AppSummary {
+        AppSummary {
+            id: "app-2".to_string(),
+            name: "bare".to_string(),
+            quorum_public_key: "04ef".to_string(),
+            live_deployment_id: None,
+            egress_enabled: false,
+            debug_mode_deployments_enabled: false,
+            public_domain: String::new(),
+        }
+    }
+
+    #[test]
+    fn render_full_golden() {
+        assert_eq!(
+            full_summary().to_string(),
+            r#"Name: my-app
+ID: app-1
+Quorum Public Key: 04abcd
+Live Deployment: dep-9
+Egress Enabled: yes
+Debug Mode Deployments: yes
+Public Domain: my-app.example.com
+────────────────────────────────────────"#
+        );
+    }
+
+    #[test]
+    fn render_minimal_golden() {
+        assert_eq!(
+            minimal_summary().to_string(),
+            r#"Name: bare
+ID: app-2
+Quorum Public Key: 04ef
+Live Deployment: (none)
+Egress Enabled: no
+Debug Mode Deployments: no
+────────────────────────────────────────"#
         );
     }
 }

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -73,7 +73,7 @@ struct AppSummary {
 impl From<TvcApp> for AppSummary {
     fn from(app: TvcApp) -> Self {
         // Destructure exhaustively (rather than `..`) so that adding a field to
-        // the generated `TvcApp` forces a compile error here 
+        // the generated `TvcApp` forces a compile error here
         let TvcApp {
             id,
             name,

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -3,14 +3,13 @@
 use anyhow::Context;
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt;
-use std::fmt::Display;
+use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::GetTvcAppsRequest;
 use turnkey_client::generated::external::data::v1::TvcApp;
 
 use crate::commands::display::{format_egress_enabled, yes_no};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 
 const SEPARATOR_WIDTH: usize = 40;
 
@@ -101,26 +100,24 @@ impl From<TvcApp> for AppSummary {
     }
 }
 
-impl Message for AppsListed {
-    fn reason(&self) -> &'static str {
-        "apps-listed"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for AppsListed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.apps.is_empty() {
-            return "No apps found.".to_string();
+            return f.write_str("No apps found.");
         }
 
-        self.apps
+        let body = self
+            .apps
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>()
-            .join("\n")
+            .join("\n");
+        f.write_str(&body)
     }
 }
 
 impl Display for AppSummary {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let live = self.live_deployment_id.as_deref().unwrap_or("(none)");
         write!(
             f,

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -78,7 +78,9 @@ Set-live-deploy accepted.
 Deployment ID: {}
 Activity ID: {}
 Activity Status: {}"#,
-            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+            self.deployment_id,
+            self.activity_id,
+            self.activity_status.as_str_name()
         )
     }
 }

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -1,12 +1,13 @@
 //! App set-live-deploy command.
 
 use crate::client::build_client;
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::generated::UpdateTvcAppLiveDeploymentIntent;
+use turnkey_client::generated::{ActivityStatus, UpdateTvcAppLiveDeploymentIntent};
 
 /// Set the live deployment for a TVC app.
 #[derive(Debug, ClapArgs)]
@@ -18,7 +19,7 @@ pub struct Args {
 }
 
 /// Run the app set-live-deploy command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
     let intent = UpdateTvcAppLiveDeploymentIntent {
@@ -36,12 +37,48 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
         .await
         .context("failed to set TVC app live deployment")?;
 
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Set-live-deploy accepted.")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Deployment ID: {}", args.deploy_id)?;
-    shell_println!(ctx, "Activity ID: {}", result.activity_id)?;
-    shell_println!(ctx, "Activity Status: {:?}", result.status)?;
+    Ok(Outcome::AppSetLiveDeploy(LiveDeploymentSet {
+        deployment_id: args.deploy_id,
+        activity_id: result.activity_id,
+        activity_status: result.status,
+    }))
+}
 
-    Ok(())
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveDeploymentSet {
+    deployment_id: String,
+    activity_id: String,
+    /// Stable proto status name, e.g. `ACTIVITY_STATUS_COMPLETED`.
+    activity_status: ActivityStatus,
+}
+
+/// Manual because the generated `ActivityStatus` does not implement
+/// `Default`; the zero value is the enum's `Unspecified` variant.
+impl Default for LiveDeploymentSet {
+    fn default() -> Self {
+        Self {
+            deployment_id: String::default(),
+            activity_id: String::default(),
+            activity_status: ActivityStatus::Unspecified,
+        }
+    }
+}
+
+impl Message for LiveDeploymentSet {
+    fn reason(&self) -> &'static str {
+        "live-deployment-set"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"
+Set-live-deploy accepted.
+
+Deployment ID: {}
+Activity ID: {}
+Activity Status: {}"#,
+            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+        )
+    }
 }

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -2,10 +2,11 @@
 
 use crate::client::build_client;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, UpdateTvcAppLiveDeploymentIntent};
 
@@ -65,13 +66,10 @@ impl Default for LiveDeploymentSet {
     }
 }
 
-impl Message for LiveDeploymentSet {
-    fn reason(&self) -> &'static str {
-        "live-deployment-set"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for LiveDeploymentSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 Set-live-deploy accepted.
 

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt::Write as _;
+use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::GetAppStatusRequest;
 use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
 
@@ -13,7 +13,7 @@ use crate::commands::app_status::{
 };
 use crate::commands::display::format_egress_enabled;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 
 /// Get the live status of an app from the cluster.
 #[derive(Debug, ClapArgs)]
@@ -97,45 +97,42 @@ struct DeploymentReplicaStatus {
     last_updated: Option<TimestampPayload>,
 }
 
-impl Message for AppStatusReport {
-    fn reason(&self) -> &'static str {
-        "app-status"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = format!(
+impl Display for AppStatusReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"App ID: {}
 Targeted Deployment: {}
 {}"#,
             self.app_id,
             self.targeted_deployment_id,
             format_egress_enabled(self.egress_enabled)
-        );
+        )?;
 
         if self.deployments.is_empty() {
-            message.push_str("\n\nNo deployments found.");
+            f.write_str("\n\nNo deployments found.")?;
         } else {
             for deployment in &self.deployments {
-                let _ = write!(
-                    message,
+                write!(
+                    f,
                     r#"
 
 Deployment: {}
   {}"#,
                     deployment.deployment_id,
                     format_replica_counts(deployment.replicas.ready, deployment.replicas.desired)
-                );
+                )?;
 
                 if let Some(updated) = &deployment.last_updated {
-                    let _ = write!(
-                        message,
+                    write!(
+                        f,
                         "\n  Last Updated: {}.{:0>9}s",
                         updated.seconds, updated.nanos
-                    );
+                    )?;
                 }
             }
         }
 
-        message
+        Ok(())
     }
 }

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -2,13 +2,18 @@
 
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::Write as _;
 use turnkey_client::generated::GetAppStatusRequest;
+use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
 
 use crate::client::fetch_tvc_app;
-use crate::commands::app_status::{format_replica_status, sanitize_app_status};
+use crate::commands::app_status::{
+    ReplicaCounts, TimestampPayload, format_replica_counts, sanitize_app_status,
+};
 use crate::commands::display::format_egress_enabled;
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 
 /// Get the live status of an app from the cluster.
 #[derive(Debug, ClapArgs)]
@@ -20,7 +25,7 @@ pub struct Args {
 }
 
 /// Run the app status command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let request = GetAppStatusRequest {
@@ -41,33 +46,96 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     );
     let app = fetch_tvc_app(&auth, &args.app_id).await?;
 
-    shell_println!(ctx, "App ID: {}", app_status.app_id)?;
-    shell_println!(
-        ctx,
-        "Targeted Deployment: {}",
-        app_status.targeted_deployment_id
-    )?;
-    shell_println!(ctx, "{}", format_egress_enabled(app.enable_egress))?;
+    // Exhaustive destructure so a new `AppStatus` field forces a decision here
+    // rather than being silently dropped.
+    let AppStatus {
+        app_id,
+        deployments,
+        targeted_deployment_id,
+    } = app_status;
 
-    if app_status.deployments.is_empty() {
-        shell_println!(ctx)?;
-        shell_println!(ctx, "No deployments found.")?;
-    } else {
-        for deployment in &app_status.deployments {
-            shell_println!(ctx)?;
-            shell_println!(ctx, "Deployment: {}", deployment.deployment_id)?;
-            shell_println!(ctx, "  {}", format_replica_status(deployment))?;
+    Ok(Outcome::AppStatus(AppStatusReport {
+        app_id,
+        targeted_deployment_id,
+        egress_enabled: app.enable_egress,
+        deployments: deployments
+            .into_iter()
+            .map(|deployment| {
+                let DeploymentStatus {
+                    deployment_id,
+                    ready_replicas,
+                    desired_replicas,
+                    last_updated_time,
+                } = deployment;
+                DeploymentReplicaStatus {
+                    deployment_id,
+                    replicas: ReplicaCounts {
+                        ready: ready_replicas,
+                        desired: desired_replicas,
+                    },
+                    last_updated: last_updated_time.map(Into::into),
+                }
+            })
+            .collect(),
+    }))
+}
 
-            if let Some(updated) = &deployment.last_updated_time {
-                shell_println!(
-                    ctx,
-                    "  Last Updated: {}.{:0>9}s",
-                    updated.seconds,
-                    updated.nanos
-                )?;
-            }
-        }
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStatusReport {
+    app_id: String,
+    targeted_deployment_id: String,
+    egress_enabled: bool,
+    deployments: Vec<DeploymentReplicaStatus>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeploymentReplicaStatus {
+    deployment_id: String,
+    replicas: ReplicaCounts,
+    last_updated: Option<TimestampPayload>,
+}
+
+impl Message for AppStatusReport {
+    fn reason(&self) -> &'static str {
+        "app-status"
     }
 
-    Ok(())
+    fn human_message(&self) -> String {
+        let mut message = format!(
+            r#"App ID: {}
+Targeted Deployment: {}
+{}"#,
+            self.app_id,
+            self.targeted_deployment_id,
+            format_egress_enabled(self.egress_enabled)
+        );
+
+        if self.deployments.is_empty() {
+            message.push_str("\n\nNo deployments found.");
+        } else {
+            for deployment in &self.deployments {
+                let _ = write!(
+                    message,
+                    r#"
+
+Deployment: {}
+  {}"#,
+                    deployment.deployment_id,
+                    format_replica_counts(deployment.replicas.ready, deployment.replicas.desired)
+                );
+
+                if let Some(updated) = &deployment.last_updated {
+                    let _ = write!(
+                        message,
+                        "\n  Last Updated: {}.{:0>9}s",
+                        updated.seconds, updated.nanos
+                    );
+                }
+            }
+        }
+
+        message
+    }
 }

--- a/tvc/src/commands/app_status.rs
+++ b/tvc/src/commands/app_status.rs
@@ -1,6 +1,7 @@
 //! Shared app status normalization and formatting helpers.
 
-use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
+use serde::Serialize;
+use turnkey_client::generated::external::data::v1::{AppStatus, Timestamp};
 
 /// Normalize API-specific deployment ID prefixes so CLI commands compare bare IDs.
 pub fn sanitize_app_status(mut app_status: AppStatus) -> AppStatus {
@@ -13,12 +14,34 @@ pub fn sanitize_app_status(mut app_status: AppStatus) -> AppStatus {
     app_status
 }
 
+/// Serializable `{seconds, nanos}` pair for outcome payloads (both values are
+/// stringified integers, mirroring the API's `Timestamp`).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimestampPayload {
+    pub seconds: String,
+    pub nanos: String,
+}
+
+impl From<Timestamp> for TimestampPayload {
+    fn from(timestamp: Timestamp) -> Self {
+        // Exhaustive destructure so a new `Timestamp` field forces a decision here.
+        let Timestamp { seconds, nanos } = timestamp;
+        Self { seconds, nanos }
+    }
+}
+
+/// Ready/desired replica counts for outcome payloads.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplicaCounts {
+    pub ready: i32,
+    pub desired: i32,
+}
+
 /// Render replica counts consistently across app and deployment status commands.
-pub fn format_replica_status(deployment_status: &DeploymentStatus) -> String {
-    format!(
-        "Healthy / Desired Replicas: {}/{}",
-        deployment_status.ready_replicas, deployment_status.desired_replicas
-    )
+pub fn format_replica_counts(ready: i32, desired: i32) -> String {
+    format!("Healthy / Desired Replicas: {ready}/{desired}")
 }
 
 fn strip_deploy_prefix(deploy_id: &str) -> String {
@@ -30,7 +53,7 @@ fn strip_deploy_prefix(deploy_id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_replica_status, sanitize_app_status};
+    use super::{format_replica_counts, sanitize_app_status};
     use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
 
     #[test]
@@ -59,16 +82,9 @@ mod tests {
     }
 
     #[test]
-    fn format_replica_status_uses_shared_label() {
-        let deployment_status = DeploymentStatus {
-            deployment_id: "deploy-123".to_string(),
-            ready_replicas: 3,
-            desired_replicas: 5,
-            last_updated_time: None,
-        };
-
+    fn format_replica_counts_uses_shared_label() {
         assert_eq!(
-            format_replica_status(&deployment_status),
+            format_replica_counts(3, 5),
             "Healthy / Desired Replicas: 3/5"
         );
     }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -3,7 +3,7 @@
 use crate::config::turnkey::Config;
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::pair::HexSeed;
 use crate::prompts;
 use crate::prompts::{bail_required_in_non_interactive, stdin_can_prompt};
@@ -18,6 +18,7 @@ use qos_core::protocol::services::boot::{
 use serde::{Serialize, Serializer};
 use std::collections::HashSet;
 use std::fmt::Write;
+use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -135,28 +136,12 @@ impl Serialize for ApproveOutcome {
     }
 }
 
-impl Message for ApproveOutcome {
-    fn reason(&self) -> &'static str {
+impl Display for ApproveOutcome {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ApproveOutcome::Posted(msg) => msg.reason(),
-            ApproveOutcome::NotPosted(msg) => msg.reason(),
-            ApproveOutcome::DryRun(msg) => msg.reason(),
-        }
-    }
-
-    fn human_message(&self) -> String {
-        match self {
-            ApproveOutcome::Posted(msg) => msg.human_message(),
-            ApproveOutcome::NotPosted(msg) => msg.human_message(),
-            ApproveOutcome::DryRun(msg) => msg.human_message(),
-        }
-    }
-
-    fn to_json_string(&self) -> String {
-        match self {
-            ApproveOutcome::Posted(msg) => msg.to_json_string(),
-            ApproveOutcome::NotPosted(msg) => msg.to_json_string(),
-            ApproveOutcome::DryRun(msg) => msg.to_json_string(),
+            ApproveOutcome::Posted(msg) => msg.fmt(f),
+            ApproveOutcome::NotPosted(msg) => msg.fmt(f),
+            ApproveOutcome::DryRun(msg) => msg.fmt(f),
         }
     }
 }
@@ -192,15 +177,14 @@ pub struct ApprovalPosted {
     quorum_reached: Option<bool>,
 }
 
-impl Message for ApprovalPosted {
-    fn reason(&self) -> &'static str {
-        "manifest-approval-posted"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = approval_payload_human_message(&self.approval, &self.written_to);
-        let _ = write!(
-            message,
+impl Display for ApprovalPosted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&approval_payload_human_message(
+            &self.approval,
+            &self.written_to,
+        ))?;
+        write!(
+            f,
             r#"
 Approval posted successfully!
 
@@ -208,7 +192,7 @@ Approval IDs: {:?}
 Manifest ID: {}
 Operator ID: {}"#,
             self.approval_ids, self.manifest_id, self.operator_id
-        );
+        )?;
 
         if let Some(reached) = self.quorum_reached {
             let quorum_line = if reached {
@@ -216,10 +200,10 @@ Operator ID: {}"#,
             } else {
                 "Your approval has been posted. Deployment requires additional manifest approvals before it can be deployed on TVC."
             };
-            let _ = write!(message, "\n\n{quorum_line}");
+            write!(f, "\n\n{quorum_line}")?;
         }
 
-        message
+        Ok(())
     }
 }
 
@@ -234,26 +218,21 @@ pub struct ApprovalGenerated {
     written_to: Option<String>,
 }
 
-impl Message for ApprovalGenerated {
-    fn reason(&self) -> &'static str {
-        "manifest-approval-generated"
-    }
-
-    fn human_message(&self) -> String {
-        approval_payload_human_message(&self.approval, &self.written_to)
+impl Display for ApprovalGenerated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&approval_payload_human_message(
+            &self.approval,
+            &self.written_to,
+        ))
     }
 }
 
 #[derive(Default, Serialize)]
 pub struct ApprovalDryRun {}
 
-impl Message for ApprovalDryRun {
-    fn reason(&self) -> &'static str {
-        "manifest-approval-dry-run"
-    }
-
-    fn human_message(&self) -> String {
-        "Dry run complete. No approval generated.".to_string()
+impl Display for ApprovalDryRun {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("Dry run complete. No approval generated.")
     }
 }
 
@@ -775,6 +754,7 @@ async fn fetch_manifest_from_deploy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output::Message;
     use turnkey_client::generated::external::data::v1::{
         TvcOperator, TvcOperatorApproval, TvcOperatorSet,
     };
@@ -947,8 +927,10 @@ mod tests {
 
     #[test]
     fn approval_posted_serializes_expected_json() {
-        let value: serde_json::Value =
-            serde_json::from_str(&posted_to_file().to_json_string()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(
+            &Outcome::DeployApprove(ApproveOutcome::Posted(posted_to_file())).to_json_string(),
+        )
+        .unwrap();
 
         assert_eq!(
             value,
@@ -976,7 +958,10 @@ mod tests {
             written_to: None,
         };
 
-        let value: serde_json::Value = serde_json::from_str(&generated.to_json_string()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(
+            &Outcome::DeployApprove(ApproveOutcome::NotPosted(generated)).to_json_string(),
+        )
+        .unwrap();
 
         assert_eq!(
             value,
@@ -995,8 +980,10 @@ mod tests {
 
     #[test]
     fn approval_dry_run_serializes_reason_only() {
-        let value: serde_json::Value =
-            serde_json::from_str(&ApprovalDryRun {}.to_json_string()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(
+            &Outcome::DeployApprove(ApproveOutcome::DryRun(ApprovalDryRun {})).to_json_string(),
+        )
+        .unwrap();
 
         assert_eq!(
             value,
@@ -1015,19 +1002,19 @@ mod tests {
         posted.quorum_reached = Some(true);
         assert!(
             posted
-                .human_message()
+                .to_string()
                 .contains("Manifest approval quorum reached.")
         );
 
         posted.quorum_reached = Some(false);
         assert!(
             posted
-                .human_message()
+                .to_string()
                 .contains("requires additional manifest approvals")
         );
 
         posted.quorum_reached = None;
-        let human = posted.human_message();
+        let human = posted.to_string();
         assert!(!human.contains("quorum"));
         assert!(human.ends_with("Operator ID: operator-456"));
     }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -2,6 +2,7 @@
 
 use crate::config::turnkey::Config;
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
+use crate::outcome::Outcome;
 use crate::output::{Message, StdCtx};
 use crate::pair::HexSeed;
 use crate::prompts;
@@ -14,7 +15,7 @@ use qos_core::protocol::services::boot::Approval;
 use qos_core::protocol::services::boot::{
     ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::Path;
@@ -105,6 +106,157 @@ struct PostApprovalPlan<'a> {
     deploy_id: Option<&'a str>,
 }
 
+/// What `post_approval_to_api` learned from the API: the created approval IDs
+/// and whether the manifest approval quorum is now reached (`None` when the
+/// post-check deployment fetch failed or was not attempted).
+struct PostedApproval {
+    approval_ids: Vec<String>,
+    quorum_reached: Option<bool>,
+}
+
+/// Terminal shapes for `deploy approve` (reasons share the
+/// `manifest-approval-*` prefix).
+pub enum ApproveOutcome {
+    /// Approval generated and posted to the API.
+    Posted(ApprovalPosted),
+    /// Approval generated but not posted (`--skip-post`).
+    NotPosted(ApprovalGenerated),
+    /// `--dry-run`: manifest review completed, no approval generated.
+    DryRun(ApprovalDryRun),
+}
+
+impl Serialize for ApproveOutcome {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ApproveOutcome::Posted(msg) => msg.serialize(serializer),
+            ApproveOutcome::NotPosted(msg) => msg.serialize(serializer),
+            ApproveOutcome::DryRun(msg) => msg.serialize(serializer),
+        }
+    }
+}
+
+impl Message for ApproveOutcome {
+    fn reason(&self) -> &'static str {
+        match self {
+            ApproveOutcome::Posted(msg) => msg.reason(),
+            ApproveOutcome::NotPosted(msg) => msg.reason(),
+            ApproveOutcome::DryRun(msg) => msg.reason(),
+        }
+    }
+
+    fn human_message(&self) -> String {
+        match self {
+            ApproveOutcome::Posted(msg) => msg.human_message(),
+            ApproveOutcome::NotPosted(msg) => msg.human_message(),
+            ApproveOutcome::DryRun(msg) => msg.human_message(),
+        }
+    }
+
+    fn to_json_string(&self) -> String {
+        match self {
+            ApproveOutcome::Posted(msg) => msg.to_json_string(),
+            ApproveOutcome::NotPosted(msg) => msg.to_json_string(),
+            ApproveOutcome::DryRun(msg) => msg.to_json_string(),
+        }
+    }
+}
+
+/// Render the approval payload part of a human message: the pretty-printed
+/// approval JSON, or the path it was written to (`--approval-out`).
+fn approval_payload_human_message(
+    approval: &Option<Approval>,
+    written_to: &Option<String>,
+) -> String {
+    match (approval, written_to) {
+        (Some(approval), _) => serde_json::to_string_pretty(approval)
+            .expect("serializing manifest approval should not fail"),
+        (None, Some(path)) => format!("Approval written to: {path}"),
+        (None, None) => String::new(),
+    }
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalPosted {
+    /// Present when the approval was printed inline (no `--approval-out`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    approval: Option<Approval>,
+    /// Present when the approval was written to a file via `--approval-out`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    written_to: Option<String>,
+    manifest_id: String,
+    operator_id: String,
+    approval_ids: Vec<String>,
+    /// `None` when the post-check deployment fetch failed or was not
+    /// attempted (no `--deploy-id`), so quorum state is unknown.
+    quorum_reached: Option<bool>,
+}
+
+impl Message for ApprovalPosted {
+    fn reason(&self) -> &'static str {
+        "manifest-approval-posted"
+    }
+
+    fn human_message(&self) -> String {
+        let mut message = approval_payload_human_message(&self.approval, &self.written_to);
+        let _ = write!(
+            message,
+            r#"
+Approval posted successfully!
+
+Approval IDs: {:?}
+Manifest ID: {}
+Operator ID: {}"#,
+            self.approval_ids, self.manifest_id, self.operator_id
+        );
+
+        if let Some(reached) = self.quorum_reached {
+            let quorum_line = if reached {
+                QUORUM_REACHED_MESSAGE
+            } else {
+                "Your approval has been posted. Deployment requires additional manifest approvals before it can be deployed on TVC."
+            };
+            let _ = write!(message, "\n\n{quorum_line}");
+        }
+
+        message
+    }
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalGenerated {
+    /// Present when the approval was printed inline (no `--approval-out`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    approval: Option<Approval>,
+    /// Present when the approval was written to a file via `--approval-out`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    written_to: Option<String>,
+}
+
+impl Message for ApprovalGenerated {
+    fn reason(&self) -> &'static str {
+        "manifest-approval-generated"
+    }
+
+    fn human_message(&self) -> String {
+        approval_payload_human_message(&self.approval, &self.written_to)
+    }
+}
+
+#[derive(Default, Serialize)]
+pub struct ApprovalDryRun {}
+
+impl Message for ApprovalDryRun {
+    fn reason(&self) -> &'static str {
+        "manifest-approval-dry-run"
+    }
+
+    fn human_message(&self) -> String {
+        "Dry run complete. No approval generated.".to_string()
+    }
+}
+
 struct PostTarget {
     manifest_id: String,
     operator_id: String,
@@ -119,7 +271,7 @@ struct ResolvedApproveInputs {
     post_target: Option<PostTarget>,
 }
 
-pub async fn run(ctx: &mut StdCtx, mut args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, mut args: Args) -> anyhow::Result<Outcome> {
     let operator_seed_source = LocalOperatorSeedSource::from_args(
         args.operator_seed.take(),
         args.operator_seed_path.take(),
@@ -131,7 +283,8 @@ pub async fn run(ctx: &mut StdCtx, mut args: Args) -> anyhow::Result<()> {
         build_inputs_interactive(ctx, args, operator_seed_source).await?
     };
 
-    run_with_resolved_inputs(ctx, inputs).await
+    let outcome = run_with_resolved_inputs(ctx, inputs).await?;
+    Ok(Outcome::DeployApprove(outcome))
 }
 
 async fn build_inputs_interactive(
@@ -246,30 +399,53 @@ async fn build_inputs_non_interactive(
 async fn run_with_resolved_inputs(
     ctx: &mut StdCtx,
     inputs: ResolvedApproveInputs,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ApproveOutcome> {
     if inputs.dry_run {
-        shell_println!(ctx, "Dry run complete. No approval generated.")?;
-        return Ok(());
+        return Ok(ApproveOutcome::DryRun(ApprovalDryRun {}));
     }
 
-    let approval = sign_and_output(
-        ctx,
+    let approval = sign_and_write_approval(
         inputs.operator_seed_source,
         inputs.approval_out.as_deref(),
         &inputs.manifest,
     )
     .await?;
 
-    if let Some(target) = inputs.post_target {
-        let plan = PostApprovalPlan {
-            manifest_id: target.manifest_id.as_str(),
-            operator_id: target.operator_id.as_str(),
-            deploy_id: target.deploy_id.as_deref(),
-        };
-        post_approval_to_api(ctx, plan, &approval).await?;
-    }
+    let written_to = inputs
+        .approval_out
+        .as_ref()
+        .map(|path| path.display().to_string());
+    // The approval payload rides in the outcome only when it was not written
+    // to a file; otherwise the outcome carries the file path.
+    let inline_approval = if written_to.is_none() {
+        Some(approval.clone())
+    } else {
+        None
+    };
 
-    Ok(())
+    match inputs.post_target {
+        Some(target) => {
+            let plan = PostApprovalPlan {
+                manifest_id: target.manifest_id.as_str(),
+                operator_id: target.operator_id.as_str(),
+                deploy_id: target.deploy_id.as_deref(),
+            };
+            let posted = post_approval_to_api(ctx, plan, &approval).await?;
+
+            Ok(ApproveOutcome::Posted(ApprovalPosted {
+                approval: inline_approval,
+                written_to,
+                manifest_id: target.manifest_id,
+                operator_id: target.operator_id,
+                approval_ids: posted.approval_ids,
+                quorum_reached: posted.quorum_reached,
+            }))
+        }
+        None => Ok(ApproveOutcome::NotPosted(ApprovalGenerated {
+            approval: inline_approval,
+            written_to,
+        })),
+    }
 }
 
 async fn load_manifest(
@@ -286,8 +462,10 @@ async fn load_manifest(
     }
 }
 
-async fn sign_and_output(
-    ctx: &mut StdCtx,
+/// Sign the manifest and, when `--approval-out` is set, write the approval to
+/// that file. Reporting the approval (inline payload or file path) is the
+/// terminal outcome's job.
+async fn sign_and_write_approval(
     operator_seed_source: Option<LocalOperatorSeedSource>,
     approval_out: Option<&Path>,
     manifest: &VersionedManifest,
@@ -300,34 +478,9 @@ async fn sign_and_output(
     if let Some(path) = approval_out {
         let json = serde_json::to_string_pretty(&approval)?;
         write_file(path, &json).await?;
-        shell_println!(ctx, "Approval written to: {}", path.display())?;
-    } else {
-        // Emit the approval as the machine-relevant payload. In human mode this
-        // prints the pretty JSON exactly as before; in JSON mode it is wrapped
-        // in a stable `reason` envelope so the approval survives suppression.
-        ctx.shell().emit(&ManifestApprovalGenerated {
-            approval: &approval,
-        })?;
     }
 
     Ok(approval)
-}
-
-#[derive(Serialize)]
-struct ManifestApprovalGenerated<'a> {
-    approval: &'a Approval,
-}
-
-impl Message for ManifestApprovalGenerated<'_> {
-    fn reason(&self) -> &'static str {
-        "manifest-approval-generated"
-    }
-
-    fn human_message(&self) -> String {
-        // Preserve the previous human behavior: pretty-printed approval JSON.
-        serde_json::to_string_pretty(self.approval)
-            .expect("serializing manifest approval should not fail")
-    }
 }
 
 fn resolve_manifest_id(args: &Args, fetched_manifest_id: Option<&str>) -> anyhow::Result<String> {
@@ -351,7 +504,7 @@ async fn post_approval_to_api(
     ctx: &mut StdCtx,
     plan: PostApprovalPlan<'_>,
     approval: &Approval,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<PostedApproval> {
     shell_println!(ctx)?;
     shell_println!(ctx, "Posting approval to Turnkey...")?;
 
@@ -378,47 +531,37 @@ async fn post_approval_to_api(
         .await
         .context("failed to post manifest approval")?;
 
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Approval posted successfully!")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Approval IDs: {:?}", result.result.approval_ids)?;
-    shell_println!(ctx, "Manifest ID: {}", plan.manifest_id)?;
-    shell_println!(ctx, "Operator ID: {}", plan.operator_id)?;
+    let quorum_reached = match plan.deploy_id {
+        Some(deploy_id) => {
+            let request = GetTvcDeploymentRequest {
+                organization_id: auth.org_id.clone(),
+                deployment_id: deploy_id.to_string(),
+            };
 
-    if let Some(deploy_id) = plan.deploy_id {
-        let request = GetTvcDeploymentRequest {
-            organization_id: auth.org_id.clone(),
-            deployment_id: deploy_id.to_string(),
-        };
-
-        match auth.client.get_tvc_deployment(request).await {
-            Ok(response) => {
-                shell_println!(ctx)?;
-
-                if response
-                    .tvc_deployment
-                    .as_ref()
-                    .is_some_and(manifest_approval_quorum_reached)
-                {
-                    shell_println!(ctx, "{QUORUM_REACHED_MESSAGE}")?;
-                } else {
-                    shell_println!(
-                        ctx,
-                        "Your approval has been posted. Deployment requires additional manifest approvals before it can be deployed on TVC."
-                    )?;
-                };
-            }
-            Err(error) => {
-                debug!(
-                    deploy_id,
-                    %error,
-                    "failed to fetch deployment after posting manifest approval"
-                );
+            match auth.client.get_tvc_deployment(request).await {
+                Ok(response) => Some(
+                    response
+                        .tvc_deployment
+                        .as_ref()
+                        .is_some_and(manifest_approval_quorum_reached),
+                ),
+                Err(error) => {
+                    debug!(
+                        deploy_id,
+                        %error,
+                        "failed to fetch deployment after posting manifest approval"
+                    );
+                    None
+                }
             }
         }
-    }
+        None => None,
+    };
 
-    Ok(())
+    Ok(PostedApproval {
+        approval_ids: result.result.approval_ids,
+        quorum_reached,
+    })
 }
 
 fn manifest_approval_quorum_reached(deployment: &TvcDeployment) -> bool {
@@ -789,5 +932,103 @@ mod tests {
         let deployment = test_deployment(Some(1), &[Some("")]);
 
         assert!(!manifest_approval_quorum_reached(&deployment));
+    }
+
+    fn posted_to_file() -> ApprovalPosted {
+        ApprovalPosted {
+            approval: None,
+            written_to: Some("approval.json".to_string()),
+            manifest_id: "manifest-123".to_string(),
+            operator_id: "operator-456".to_string(),
+            approval_ids: vec!["approval-1".to_string()],
+            quorum_reached: Some(true),
+        }
+    }
+
+    #[test]
+    fn approval_posted_serializes_expected_json() {
+        let value: serde_json::Value =
+            serde_json::from_str(&posted_to_file().to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "reason": "manifest-approval-posted",
+                "writtenTo": "approval.json",
+                "manifestId": "manifest-123",
+                "operatorId": "operator-456",
+                "approvalIds": ["approval-1"],
+                "quorumReached": true,
+            })
+        );
+    }
+
+    #[test]
+    fn approval_generated_serializes_expected_json() {
+        let generated = ApprovalGenerated {
+            approval: Some(Approval {
+                signature: vec![0xde, 0xad],
+                member: QuorumMember {
+                    alias: "operator-alice".to_string(),
+                    pub_key: vec![0xaa],
+                },
+            }),
+            written_to: None,
+        };
+
+        let value: serde_json::Value = serde_json::from_str(&generated.to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "reason": "manifest-approval-generated",
+                "approval": {
+                    "signature": "dead",
+                    "member": {
+                        "alias": "operator-alice",
+                        "pubKey": "aa",
+                    },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn approval_dry_run_serializes_reason_only() {
+        let value: serde_json::Value =
+            serde_json::from_str(&ApprovalDryRun {}.to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({ "reason": "manifest-approval-dry-run" })
+        );
+    }
+
+    /// The quorum line is branch-dependent: present with the reached/pending
+    /// sentence when the post-check fetch succeeded, absent when quorum state
+    /// is unknown (matching the pre-outcome behavior of a silent failed
+    /// fetch).
+    #[test]
+    fn approval_posted_human_message_includes_quorum_line_only_when_known() {
+        let mut posted = posted_to_file();
+
+        posted.quorum_reached = Some(true);
+        assert!(
+            posted
+                .human_message()
+                .contains("Manifest approval quorum reached.")
+        );
+
+        posted.quorum_reached = Some(false);
+        assert!(
+            posted
+                .human_message()
+                .contains("requires additional manifest approvals")
+        );
+
+        posted.quorum_reached = None;
+        let human = posted.human_message();
+        assert!(!human.contains("quorum"));
+        assert!(human.ends_with("Operator ID: operator-456"));
     }
 }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -4,12 +4,15 @@ use super::format_port_summary;
 use crate::client::{build_client, fetch_tvc_app};
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
-use crate::output::StdCtx;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use crate::prompts;
 use crate::pull_secret::encrypt_pivot_pull_secret;
 use crate::shell_println;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
@@ -146,7 +149,7 @@ struct ResolvedDeployInputs {
     pivot_pull_secret: Option<String>,
 }
 
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let inputs = if ctx.is_non_interactive() {
         build_inputs_non_interactive(args).await?
     } else {
@@ -370,7 +373,10 @@ fn pin_image_url(image_url: &str, resolved_digest: &str) -> String {
     }
 }
 
-async fn run_with_resolved_inputs(ctx: &mut StdCtx, inputs: ResolvedDeployInputs) -> Result<()> {
+async fn run_with_resolved_inputs(
+    ctx: &mut StdCtx,
+    inputs: ResolvedDeployInputs,
+) -> Result<Outcome> {
     let deploy_config = inputs.config;
 
     shell_println!(
@@ -417,7 +423,7 @@ async fn run_with_resolved_inputs(ctx: &mut StdCtx, inputs: ResolvedDeployInputs
 
     let intent = build_create_intent(
         &deploy_config,
-        pinned_image_url,
+        pinned_image_url.clone(),
         pivot_container_encrypted_pull_secret,
     );
 
@@ -432,28 +438,59 @@ async fn run_with_resolved_inputs(ctx: &mut StdCtx, inputs: ResolvedDeployInputs
         .await
         .context("failed to create TVC deployment")?;
 
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Deployment created successfully!")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Deployment ID: {}", result.result.deployment_id)?;
-    shell_println!(ctx, "App ID: {}", deploy_config.app_id)?;
-    if let Some(path) = &inputs.config_path {
-        shell_println!(ctx, "Config: {}", path.display())?;
-    }
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Next steps:")?;
-    shell_println!(
-        ctx,
-        "  - Run `tvc deploy status --deploy-id {}` to check deployment status",
-        result.result.deployment_id
-    )?;
-    shell_println!(
-        ctx,
-        "  - Run `tvc deploy approve --deploy-id {} --operator-id <operator-id>` to approve the manifest",
-        result.result.deployment_id
-    )?;
+    Ok(Outcome::DeployCreate(DeploymentCreated {
+        deployment_id: result.result.deployment_id,
+        app_id: deploy_config.app_id,
+        pinned_image_url,
+        config_path: inputs
+            .config_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+    }))
+}
 
-    Ok(())
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentCreated {
+    deployment_id: String,
+    app_id: String,
+    pinned_image_url: String,
+    /// Present when the deployment was created from a config file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_path: Option<String>,
+}
+
+impl Message for DeploymentCreated {
+    fn reason(&self) -> &'static str {
+        "deployment-created"
+    }
+
+    fn human_message(&self) -> String {
+        let mut message = format!(
+            r#"
+Deployment created successfully!
+
+Deployment ID: {}
+App ID: {}"#,
+            self.deployment_id, self.app_id
+        );
+
+        if let Some(path) = &self.config_path {
+            let _ = write!(message, "\nConfig: {path}");
+        }
+
+        let _ = write!(
+            message,
+            r#"
+
+Next steps:
+  - Run `tvc deploy status --deploy-id {}` to check deployment status
+  - Run `tvc deploy approve --deploy-id {} --operator-id <operator-id>` to approve the manifest"#,
+            self.deployment_id, self.deployment_id
+        );
+
+        message
+    }
 }
 
 #[cfg(test)]

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -5,14 +5,14 @@ use crate::client::{build_client, fetch_tvc_app};
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::prompts;
 use crate::pull_secret::encrypt_pivot_pull_secret;
 use crate::shell_println;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt::Write as _;
+use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
@@ -460,36 +460,31 @@ pub struct DeploymentCreated {
     config_path: Option<String>,
 }
 
-impl Message for DeploymentCreated {
-    fn reason(&self) -> &'static str {
-        "deployment-created"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = format!(
+impl Display for DeploymentCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 Deployment created successfully!
 
 Deployment ID: {}
 App ID: {}"#,
             self.deployment_id, self.app_id
-        );
+        )?;
 
         if let Some(path) = &self.config_path {
-            let _ = write!(message, "\nConfig: {path}");
+            write!(f, "\nConfig: {path}")?;
         }
 
-        let _ = write!(
-            message,
+        write!(
+            f,
             r#"
 
 Next steps:
   - Run `tvc deploy status --deploy-id {}` to check deployment status
   - Run `tvc deploy approve --deploy-id {} --operator-id <operator-id>` to approve the manifest"#,
             self.deployment_id, self.deployment_id
-        );
-
-        message
+        )
     }
 }
 

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::collections::{HashSet, VecDeque};
+use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use std::time::Duration;
 use turnkey_client::TurnkeyP256ApiKey;
@@ -257,13 +258,10 @@ pub struct DebugLogsFetched {
     line_count: usize,
 }
 
-impl Message for DebugLogsFetched {
-    fn reason(&self) -> &'static str {
-        "debug-logs-fetched"
-    }
-
-    fn human_message(&self) -> String {
-        String::new()
+impl Display for DebugLogsFetched {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
+        // Machine-only terminal outcome; no human rendering.
+        Ok(())
     }
 }
 
@@ -673,6 +671,6 @@ mod tests {
 
     #[test]
     fn debug_logs_fetched_is_machine_only_in_human_mode() {
-        assert!(DebugLogsFetched::default().human_message().is_empty());
+        assert!(DebugLogsFetched::default().to_string().is_empty());
     }
 }

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -1,10 +1,13 @@
 //! Deploy debug-logs command.
 
-use crate::output::{Ctx, StdCtx};
-use crate::{shell_eprintln, shell_println};
+use crate::commands::app_status::TimestampPayload;
+use crate::outcome::Outcome;
+use crate::output::{Ctx, Message, StdCtx};
+use crate::shell_eprintln;
 use anyhow::Context;
 use chrono::{DateTime, SecondsFormat, Utc};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::collections::{HashSet, VecDeque};
 use std::io::Write;
 use std::time::Duration;
@@ -119,7 +122,7 @@ pub struct Args {
 }
 
 /// Run the `deploy debug-logs` command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let request = DebugLogQueryRequest {
@@ -175,7 +178,8 @@ async fn query_debug_logs(
     ctx: &mut StdCtx,
     client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
     request: DebugLogQueryRequest,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Outcome> {
+    let deployment_id = request.deployment_id.clone();
     let mut log_printer = DebugLogPrinter::new(
         request.include_platform_timestamp,
         request.recent_line_capacity,
@@ -189,10 +193,15 @@ async fn query_debug_logs(
     };
 
     let response = fetch_debug_logs(client, current_request).await?;
-    log_printer.print_response(ctx, &response)?;
+    let line_count = log_printer.print_response(ctx, &response)?;
 
+    // In poll mode the loop below runs until killed (or errors), so the
+    // terminal outcome is only reachable in non-poll mode.
     let Some(poll_request) = poll_request else {
-        return Ok(());
+        return Ok(Outcome::DeployDebugLogs(DebugLogsFetched {
+            deployment_id,
+            line_count,
+        }));
     };
 
     shell_eprintln!(ctx, "Connected; polling for debug logs...")?;
@@ -202,6 +211,59 @@ async fn query_debug_logs(
         tokio::time::sleep(poll_interval).await;
         let response = fetch_debug_logs(client, poll_request.clone()).await?;
         log_printer.print_response(ctx, &response)?;
+    }
+}
+
+/// One streamed log line (NDJSON in JSON mode; the formatted line in human
+/// mode). Emitted inline by `deploy debug-logs`, not part of `Outcome`.
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DebugLogLine {
+    replica: String,
+    content: String,
+    ts: Option<TimestampPayload>,
+    /// Human-rendering knob only; not part of the JSON payload.
+    #[serde(skip)]
+    include_platform_timestamp: bool,
+}
+
+impl Message for DebugLogLine {
+    fn reason(&self) -> &'static str {
+        "debug-log-line"
+    }
+
+    fn human_message(&self) -> String {
+        // Rebuild the API line and defer to `format_log_line` so human output
+        // stays byte-identical to the pre-outcome rendering.
+        let line = LogLine {
+            content: self.content.clone(),
+            ts: self.ts.as_ref().map(|ts| Timestamp {
+                seconds: ts.seconds.clone(),
+                nanos: ts.nanos.clone(),
+            }),
+        };
+        format_log_line(&self.replica, &line, self.include_platform_timestamp)
+    }
+}
+
+/// Terminal outcome for non-poll `deploy debug-logs` runs. Machine-only: the
+/// log lines themselves stream as `debug-log-line` messages, so human mode
+/// prints nothing extra for this outcome.
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugLogsFetched {
+    deployment_id: String,
+    /// Number of log lines actually printed (after dedupe).
+    line_count: usize,
+}
+
+impl Message for DebugLogsFetched {
+    fn reason(&self) -> &'static str {
+        "debug-logs-fetched"
+    }
+
+    fn human_message(&self) -> String {
+        String::new()
     }
 }
 
@@ -282,16 +344,6 @@ impl RecentLogLineDeduper {
 
         self.insert(key)
     }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.seen.len()
-    }
-
-    #[cfg(test)]
-    fn capacity(&self) -> usize {
-        self.order.capacity()
-    }
 }
 
 #[derive(Debug)]
@@ -325,11 +377,13 @@ impl DebugLogPrinter {
         }
     }
 
+    /// Emit new log lines and return how many were printed.
     fn print_response<W: Write, W2: Write>(
         &mut self,
         ctx: &mut Ctx<W, W2>,
         response: &GetTvcDeploymentDebugLogsResponse,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<usize> {
+        let mut printed = 0;
         for entry in &response.entries {
             let Some(line) = entry.line.as_ref() else {
                 continue;
@@ -337,14 +391,16 @@ impl DebugLogPrinter {
             let replica = entry.replica_label.as_str();
 
             if self.should_print_line(replica, line) {
-                shell_println!(
-                    ctx,
-                    "{}",
-                    format_log_line(replica, line, self.include_platform_timestamp)
-                )?;
+                ctx.shell().emit(&DebugLogLine {
+                    replica: replica.to_string(),
+                    content: line.content.clone(),
+                    ts: line.ts.clone().map(Into::into),
+                    include_platform_timestamp: self.include_platform_timestamp,
+                })?;
+                printed += 1;
             }
         }
-        Ok(())
+        Ok(printed)
     }
 }
 
@@ -456,7 +512,7 @@ mod tests {
 
         assert!(deduper.record_if_new("replica 1/3", &line));
         assert!(deduper.record_if_new("replica 1/3", &line));
-        assert_eq!(deduper.len(), 0);
+        assert_eq!(deduper.seen.len(), 0);
     }
 
     #[test]
@@ -506,7 +562,7 @@ mod tests {
 
         assert!(deduper.record_if_new("replica 1/2", &line));
         assert!(deduper.record_if_new("replica 1/2", &line));
-        assert_eq!(deduper.len(), 0);
+        assert_eq!(deduper.seen.len(), 0);
     }
 
     #[test]
@@ -516,7 +572,7 @@ mod tests {
 
         assert!(deduper.record_if_new("replica 1/2", &line));
         assert!(!deduper.record_if_new("replica 1/2", &line));
-        assert_eq!(deduper.len(), 1);
+        assert_eq!(deduper.seen.len(), 1);
     }
 
     #[test]
@@ -545,7 +601,7 @@ mod tests {
 
         printer.print_response(&mut ctx, &response).unwrap();
 
-        assert_eq!(printer.deduper.as_ref().unwrap().len(), 1);
+        assert_eq!(printer.deduper.as_ref().unwrap().seen.len(), 1);
     }
 
     #[test]
@@ -570,9 +626,9 @@ mod tests {
         assert!(!deduper.insert(first.clone()));
         assert!(deduper.insert(third));
 
-        assert_eq!(deduper.len(), 2);
+        assert_eq!(deduper.seen.len(), 2);
         assert!(deduper.insert(first));
-        assert_eq!(deduper.len(), 2);
+        assert_eq!(deduper.seen.len(), 2);
     }
 
     #[test]
@@ -581,13 +637,42 @@ mod tests {
         let second = log_line_key("replica 1/2", "second", "1710000000", "2");
         let third = log_line_key("replica 1/2", "third", "1710000000", "3");
         let mut deduper = RecentLogLineDeduper::new(2);
-        let initial_capacity = deduper.capacity();
+        let initial_capacity = deduper.order.capacity();
 
         assert!(deduper.insert(first));
         assert!(deduper.insert(second));
         assert!(deduper.insert(third));
 
-        assert_eq!(deduper.len(), 2);
-        assert_eq!(deduper.capacity(), initial_capacity);
+        assert_eq!(deduper.seen.len(), 2);
+        assert_eq!(deduper.order.capacity(), initial_capacity);
+    }
+
+    fn sample_debug_log_line() -> DebugLogLine {
+        DebugLogLine {
+            replica: "replica 1/2".to_string(),
+            content: "hello".to_string(),
+            ts: Some(TimestampPayload {
+                seconds: "1710000000".to_string(),
+                nanos: "123456789".to_string(),
+            }),
+            include_platform_timestamp: false,
+        }
+    }
+
+    #[test]
+    fn debug_log_line_human_message_matches_previous_rendering() {
+        let mut line = sample_debug_log_line();
+        assert_eq!(line.human_message(), "replica 1/2 hello");
+
+        line.include_platform_timestamp = true;
+        assert_eq!(
+            line.human_message(),
+            "2024-03-09T16:00:00.123456789Z replica 1/2 hello"
+        );
+    }
+
+    #[test]
+    fn debug_logs_fetched_is_machine_only_in_human_mode() {
+        assert!(DebugLogsFetched::default().human_message().is_empty());
     }
 }

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -1,12 +1,13 @@
 //! Deploy delete command - marks a deployment for deletion.
 
 use crate::client::build_client;
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::generated::DeleteTvcDeploymentIntent;
+use turnkey_client::generated::{ActivityStatus, DeleteTvcDeploymentIntent};
 
 /// Delete a TVC deployment by marking it for deletion.
 #[derive(Debug, ClapArgs)]
@@ -18,7 +19,7 @@ pub struct Args {
 }
 
 /// Run the deploy delete command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcDeploymentIntent {
@@ -36,15 +37,48 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
         .await
         .context("failed to delete TVC deployment")?;
 
-    shell_println!(ctx)?;
-    shell_println!(
-        ctx,
-        "Deployment delete accepted; deployment is marked for deletion."
-    )?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Deployment ID: {}", result.result.deployment_id)?;
-    shell_println!(ctx, "Activity ID: {}", result.activity_id)?;
-    shell_println!(ctx, "Activity Status: {:?}", result.status)?;
+    Ok(Outcome::DeployDelete(DeploymentDeleted {
+        deployment_id: result.result.deployment_id,
+        activity_id: result.activity_id,
+        activity_status: result.status,
+    }))
+}
 
-    Ok(())
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentDeleted {
+    deployment_id: String,
+    activity_id: String,
+    /// Stable proto status name, e.g. `ACTIVITY_STATUS_COMPLETED`.
+    activity_status: ActivityStatus,
+}
+
+/// Manual because the generated `ActivityStatus` does not implement
+/// `Default`; the zero value is the enum's `Unspecified` variant.
+impl Default for DeploymentDeleted {
+    fn default() -> Self {
+        Self {
+            deployment_id: String::default(),
+            activity_id: String::default(),
+            activity_status: ActivityStatus::Unspecified,
+        }
+    }
+}
+
+impl Message for DeploymentDeleted {
+    fn reason(&self) -> &'static str {
+        "deployment-deleted"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"
+Deployment delete accepted; deployment is marked for deletion.
+
+Deployment ID: {}
+Activity ID: {}
+Activity Status: {}"#,
+            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+        )
+    }
 }

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -78,7 +78,9 @@ Deployment delete accepted; deployment is marked for deletion.
 Deployment ID: {}
 Activity ID: {}
 Activity Status: {}"#,
-            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+            self.deployment_id,
+            self.activity_id,
+            self.activity_status.as_str_name()
         )
     }
 }

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -2,10 +2,11 @@
 
 use crate::client::build_client;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, DeleteTvcDeploymentIntent};
 
@@ -65,13 +66,10 @@ impl Default for DeploymentDeleted {
     }
 }
 
-impl Message for DeploymentDeleted {
-    fn reason(&self) -> &'static str {
-        "deployment-deleted"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for DeploymentDeleted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 Deployment delete accepted; deployment is marked for deletion.
 

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -2,6 +2,8 @@
 
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::Write as _;
 use turnkey_client::generated::{
     GetAppStatusRequest,
     external::data::v1::{AppStatus, DeploymentStatus},
@@ -9,9 +11,10 @@ use turnkey_client::generated::{
 
 use crate::{
     client::{fetch_tvc_app, fetch_tvc_deployment},
+    commands::app_status::{ReplicaCounts, TimestampPayload, format_replica_counts},
     commands::display::format_egress_enabled,
-    output::StdCtx,
-    shell_println,
+    outcome::Outcome,
+    output::{Message, StdCtx},
 };
 
 /// Get the live status of a deployment from the app status API.
@@ -24,7 +27,7 @@ pub struct Args {
 }
 
 /// Run the deploy get-status command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let Args {
         deploy_id: deployment_id,
     } = args;
@@ -56,39 +59,76 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     );
     let app = fetch_tvc_app(&auth, &deployment.app_id).await?;
 
-    shell_println!(ctx, "Deployment: {}", deployment.id)?;
-    shell_println!(ctx, "App ID: {}", app_status.app_id)?;
-    shell_println!(ctx, "{}", format_egress_enabled(app.enable_egress))?;
-    shell_println!(
-        ctx,
-        "Is Targeted Deployment: {}",
-        if app_status.targeted_deployment_id == deployment_id {
-            "yes"
-        } else {
-            "no"
-        }
-    )?;
-    if let Some(deployment_status) = find_deployment_status(&app_status, &deployment_id) {
-        shell_println!(
-            ctx,
-            "{}",
-            crate::commands::app_status::format_replica_status(deployment_status)
-        )?;
+    let deployment_status = find_deployment_status(&app_status, &deployment_id);
 
-        if let Some(updated) = &deployment_status.last_updated_time {
-            shell_println!(
-                ctx,
-                "Last Updated: {}.{:0>9}s",
-                updated.seconds,
-                updated.nanos
-            )?;
-        }
-    } else {
-        shell_println!(ctx, "Live Status: unavailable")?;
-        shell_println!(ctx, "Reason: deployment not present in current app status")?;
+    Ok(Outcome::DeployGetStatus(DeploymentRuntimeStatus {
+        deployment_id: deployment.id,
+        app_id: app_status.app_id.clone(),
+        egress_enabled: app.enable_egress,
+        is_targeted: app_status.targeted_deployment_id == deployment_id,
+        replicas: deployment_status.map(|status| ReplicaCounts {
+            ready: status.ready_replicas,
+            desired: status.desired_replicas,
+        }),
+        last_updated: deployment_status
+            .and_then(|status| status.last_updated_time.clone().map(Into::into)),
+    }))
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentRuntimeStatus {
+    deployment_id: String,
+    app_id: String,
+    egress_enabled: bool,
+    is_targeted: bool,
+    /// `None` when the deployment is not present in the current app status.
+    replicas: Option<ReplicaCounts>,
+    last_updated: Option<TimestampPayload>,
+}
+
+impl Message for DeploymentRuntimeStatus {
+    fn reason(&self) -> &'static str {
+        "deployment-runtime-status"
     }
 
-    Ok(())
+    fn human_message(&self) -> String {
+        let mut message = format!(
+            r#"Deployment: {}
+App ID: {}
+{}
+Is Targeted Deployment: {}"#,
+            self.deployment_id,
+            self.app_id,
+            format_egress_enabled(self.egress_enabled),
+            if self.is_targeted { "yes" } else { "no" }
+        );
+
+        match &self.replicas {
+            Some(replicas) => {
+                let _ = write!(
+                    message,
+                    "\n{}",
+                    format_replica_counts(replicas.ready, replicas.desired)
+                );
+
+                if let Some(updated) = &self.last_updated {
+                    let _ = write!(
+                        message,
+                        "\nLast Updated: {}.{:09}s",
+                        updated.seconds, updated.nanos
+                    );
+                }
+            }
+            None => message.push_str(
+                r#"
+Live Status: unavailable
+Reason: deployment not present in current app status"#,
+            ),
+        }
+
+        message
+    }
 }
 
 fn find_deployment_status<'a>(

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt::Write as _;
+use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::{
     GetAppStatusRequest,
     external::data::v1::{AppStatus, DeploymentStatus},
@@ -14,7 +14,7 @@ use crate::{
     commands::app_status::{ReplicaCounts, TimestampPayload, format_replica_counts},
     commands::display::format_egress_enabled,
     outcome::Outcome,
-    output::{Message, StdCtx},
+    output::StdCtx,
 };
 
 /// Get the live status of a deployment from the app status API.
@@ -87,13 +87,10 @@ pub struct DeploymentRuntimeStatus {
     last_updated: Option<TimestampPayload>,
 }
 
-impl Message for DeploymentRuntimeStatus {
-    fn reason(&self) -> &'static str {
-        "deployment-runtime-status"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = format!(
+impl Display for DeploymentRuntimeStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"Deployment: {}
 App ID: {}
 {}
@@ -102,32 +99,32 @@ Is Targeted Deployment: {}"#,
             self.app_id,
             format_egress_enabled(self.egress_enabled),
             if self.is_targeted { "yes" } else { "no" }
-        );
+        )?;
 
         match &self.replicas {
             Some(replicas) => {
-                let _ = write!(
-                    message,
+                write!(
+                    f,
                     "\n{}",
                     format_replica_counts(replicas.ready, replicas.desired)
-                );
+                )?;
 
                 if let Some(updated) = &self.last_updated {
-                    let _ = write!(
-                        message,
+                    write!(
+                        f,
                         "\nLast Updated: {}.{:09}s",
                         updated.seconds, updated.nanos
-                    );
+                    )?;
                 }
             }
-            None => message.push_str(
+            None => f.write_str(
                 r#"
 Live Status: unavailable
 Reason: deployment not present in current app status"#,
-            ),
+            )?,
         }
 
-        message
+        Ok(())
     }
 }
 

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -5,13 +5,14 @@ use crate::{
     client::{build_client, fetch_tvc_deployment},
     config::{deploy::DeployConfig, turnkey},
     outcome::Outcome,
-    output::{Message, StdCtx},
+    output::StdCtx,
     prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty},
 };
 use anyhow::{Context, Result, bail};
 use chrono::Local;
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 pub(crate) const LONG_ABOUT: &str = r#"
@@ -151,49 +152,45 @@ pub struct DeploymentConfigCreated {
     needs_pull_secret: bool,
 }
 
-impl Message for DeploymentConfigCreated {
-    fn reason(&self) -> &'static str {
-        "deployment-config-created"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = if self.interactive {
-            format!("Created deployment config: {}\n", self.path)
+impl Display for DeploymentConfigCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.interactive {
+            writeln!(f, "Created deployment config: {}", self.path)?;
         } else {
-            format!("Created deployment config template: {}\n", self.path)
-        };
+            writeln!(f, "Created deployment config template: {}", self.path)?;
+        }
 
         // The digest and debug mode were copied from the source manifest (the
         // digest is image-coupled, so it must be recomputed if the image
         // changes), and a pull secret (if the source used one) cannot be
         // recovered and must be re-supplied.
         if self.from_deployment {
-            message.push_str(FROM_DEPLOYMENT_GUIDANCE);
+            f.write_str(FROM_DEPLOYMENT_GUIDANCE)?;
 
             if self.needs_pull_secret {
-                message.push_str(PULL_SECRET_GUIDANCE);
+                f.write_str(PULL_SECRET_GUIDANCE)?;
             }
         }
 
         if self.interactive {
-            message.push_str(&format!(
+            write!(
+                f,
                 r#"
 Run: tvc deploy create --config-file {}
 
 {PORT_GUIDANCE}"#,
                 self.path
-            ));
+            )
         } else {
-            message.push_str(&format!(
+            write!(
+                f,
                 r#"
 Edit the file to fill in your values, then run:
   tvc deploy create --config-file {}
 
 {PORT_GUIDANCE}"#,
                 self.path
-            ));
+            )
         }
-
-        message
     }
 }

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -4,6 +4,7 @@ use super::PORT_GUIDANCE;
 use crate::{
     client::{build_client, fetch_tvc_deployment},
     config::{deploy::DeployConfig, turnkey},
+    outcome::Outcome,
     output::{Message, StdCtx},
     prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty},
 };
@@ -45,7 +46,7 @@ pub struct Args {
 }
 
 /// Run the deploy init command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -56,7 +57,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     execute(ctx, args).await
 }
 
-async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
+async fn execute(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let Args {
         output,
         from_deployment,
@@ -117,16 +118,14 @@ async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
     std::fs::write(&output, json)
         .with_context(|| format!("failed to write file: {}", output.display()))?;
 
-    ctx.shell().emit(&DeploymentConfigCreated {
+    Ok(Outcome::DeployInit(DeploymentConfigCreated {
         command: "deploy init",
         path: output.display().to_string(),
         template: !is_interactive,
         interactive: is_interactive,
         from_deployment: is_from_deployment,
         needs_pull_secret,
-    })?;
-
-    Ok(())
+    }))
 }
 
 const FROM_DEPLOYMENT_GUIDANCE: &str = r#"
@@ -141,8 +140,9 @@ const PULL_SECRET_GUIDANCE: &str = r#"  - The source deployment used a private i
     remove pivotContainerEncryptedPullSecret if the new image is public).
 "#;
 
-#[derive(Serialize)]
-struct DeploymentConfigCreated {
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentConfigCreated {
     command: &'static str,
     path: String,
     template: bool,
@@ -177,12 +177,19 @@ impl Message for DeploymentConfigCreated {
 
         if self.interactive {
             message.push_str(&format!(
-                "\nRun: tvc deploy create --config-file {}\n\n{PORT_GUIDANCE}",
+                r#"
+Run: tvc deploy create --config-file {}
+
+{PORT_GUIDANCE}"#,
                 self.path
             ));
         } else {
             message.push_str(&format!(
-                "\nEdit the file to fill in your values, then run:\n  tvc deploy create --config-file {}\n\n{PORT_GUIDANCE}",
+                r#"
+Edit the file to fill in your values, then run:
+  tvc deploy create --config-file {}
+
+{PORT_GUIDANCE}"#,
                 self.path
             ));
         }

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -1,6 +1,7 @@
 //! Deploy post-share command.
 
 use crate::commands::keys::re_encrypt_local_share::ReEncryptedShareOutput;
+use crate::outcome::Outcome;
 use crate::output::{Message, StdCtx};
 use crate::util::read_json_file;
 use anyhow::Context;
@@ -24,7 +25,7 @@ pub struct Args {
 }
 
 /// Run the deploy post-share command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let re_encrypted_share: ReEncryptedShareOutput =
         read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;
     let intent =
@@ -42,16 +43,14 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
         .await
         .context("failed to post quorum key share")?;
 
-    ctx.shell().emit(&QuorumKeySharePosted {
+    Ok(Outcome::DeployPostShare(QuorumKeySharePosted {
         provisioning_share_id: result.result.provisioning_share_id,
-    })?;
-
-    Ok(())
+    }))
 }
 
-#[derive(Serialize)]
+#[derive(Default, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct QuorumKeySharePosted {
+pub struct QuorumKeySharePosted {
     provisioning_share_id: String,
 }
 

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -2,11 +2,12 @@
 
 use crate::commands::keys::re_encrypt_local_share::ReEncryptedShareOutput;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::util::read_json_file;
 use anyhow::Context;
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{PostTvcQuorumKeyShareIntent, QuorumKeyShareApprovalBundle};
@@ -54,13 +55,9 @@ pub struct QuorumKeySharePosted {
     provisioning_share_id: String,
 }
 
-impl Message for QuorumKeySharePosted {
-    fn reason(&self) -> &'static str {
-        "quorum-key-share-posted"
-    }
-
-    fn human_message(&self) -> String {
-        format!("Provisioning Share ID: {}", self.provisioning_share_id)
+impl Display for QuorumKeySharePosted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Provisioning Share ID: {}", self.provisioning_share_id)
     }
 }
 

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -1,7 +1,7 @@
 //! Deploy provisioning-details command.
 
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::provisioning::{
     ProvisionBundle, extract_ephemeral_public_key_bytes, verify_provisioning_details,
 };
@@ -12,6 +12,7 @@ use qos_core::protocol::services::boot::{Approval, VersionedManifestEnvelope};
 use qos_nsm::types::NsmDigest;
 use serde::Serialize;
 use std::fmt::Write;
+use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{
@@ -276,12 +277,8 @@ fn approval_entries(approvals: &[ApprovalSummary]) -> Vec<ApprovalEntry> {
         .collect()
 }
 
-impl Message for ProvisioningDetails {
-    fn reason(&self) -> &'static str {
-        "provisioning-details"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for ProvisioningDetails {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut message = String::new();
 
         if let Some(path) = &self.bundle_path {
@@ -345,7 +342,7 @@ Manifest Set Approvals: {}/{}"#,
             write_approval_entries(&mut message, &self.share_set_approvals);
         }
 
-        message
+        f.write_str(&message)
     }
 }
 
@@ -428,7 +425,6 @@ mod tests {
     }
 
     use super::{ApprovalEntry, PcrEntry, ProvisioningDetails};
-    use crate::output::Message;
 
     fn full_details() -> ProvisioningDetails {
         ProvisioningDetails {
@@ -478,7 +474,7 @@ mod tests {
     #[test]
     fn human_message_full_golden() {
         assert_eq!(
-            full_details().human_message(),
+            full_details().to_string(),
             r#"Provision bundle written to: /tmp/bundle.json
 
 Deployment: dep_123
@@ -509,7 +505,7 @@ Share Set Approvals: 1
         // NOTE: the first five lines have empty values, so they end in a
         // significant trailing space — do not strip trailing whitespace here.
         assert_eq!(
-            details.human_message(),
+            details.to_string(),
             r#"Deployment: 
 Verification: 
 Ephemeral Key: 

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -441,16 +441,31 @@ mod tests {
             user_data: Some("aa".to_string()),
             nonce: Some("bb".to_string()),
             pcrs: vec![
-                PcrEntry { index: 0, value: "00".to_string() },
-                PcrEntry { index: 16, value: "1616".to_string() },
-                PcrEntry { index: 17, value: "1717".to_string() },
+                PcrEntry {
+                    index: 0,
+                    value: "00".to_string(),
+                },
+                PcrEntry {
+                    index: 16,
+                    value: "1616".to_string(),
+                },
+                PcrEntry {
+                    index: 17,
+                    value: "1717".to_string(),
+                },
             ],
             certificate_length: 1234,
             ca_bundle_certificates: 3,
             manifest_set_threshold: 2,
             manifest_set_approvals: vec![
-                ApprovalEntry { alias: "alice".to_string(), public_key: "aaaa".to_string() },
-                ApprovalEntry { alias: "bob".to_string(), public_key: "bbbb".to_string() },
+                ApprovalEntry {
+                    alias: "alice".to_string(),
+                    public_key: "aaaa".to_string(),
+                },
+                ApprovalEntry {
+                    alias: "bob".to_string(),
+                    public_key: "bbbb".to_string(),
+                },
             ],
             share_set_approvals: vec![ApprovalEntry {
                 alias: "carol".to_string(),

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -1,15 +1,17 @@
 //! Deploy provisioning-details command.
 
-use crate::output::StdCtx;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use crate::provisioning::{
     ProvisionBundle, extract_ephemeral_public_key_bytes, verify_provisioning_details,
 };
-use crate::shell_println;
 use crate::util::write_file;
 use anyhow::{Context, bail};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, VersionedManifestEnvelope};
 use qos_nsm::types::NsmDigest;
+use serde::Serialize;
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{
@@ -58,7 +60,7 @@ struct AttestationSummary {
 const SUMMARY_PCR_MAX_INDEX: usize = 17;
 
 /// Run the deploy provisioning-details command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let request = GetTvcDeploymentProvisioningDetailsRequest {
@@ -100,37 +102,41 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
         None,
     )?;
 
-    if let Some(path) = args.provision_bundle_out.as_ref() {
-        let bundle = ProvisionBundle::new(
-            args.deploy_id.clone(),
-            &attestation_document,
-            manifest_envelope.clone(),
-            fetched_at_unix_ms,
-            &summary.ephemeral_key,
-        );
-        write_provision_bundle(ctx, path, &bundle).await?;
-        shell_println!(ctx)?;
-    }
+    let bundle_path = match args.provision_bundle_out.as_ref() {
+        Some(path) => {
+            let bundle = ProvisionBundle::new(
+                args.deploy_id.clone(),
+                &attestation_document,
+                manifest_envelope.clone(),
+                fetched_at_unix_ms,
+                &summary.ephemeral_key,
+            );
+            write_provision_bundle(path, &bundle).await?;
+            Some(path.display().to_string())
+        }
+        None => None,
+    };
 
     let verification_status = if args.dangerous_skip_verification {
         "skipped attestation, PCR, and approval verification (--dangerous-skip-verification)"
     } else {
         "verified (attestation + approvals)"
     };
-    print_summary(ctx, &args.deploy_id, verification_status, &summary)?;
 
-    Ok(())
+    Ok(Outcome::DeployProvisioningDetails(
+        ProvisioningDetails::from_summary(
+            args.deploy_id,
+            verification_status,
+            bundle_path,
+            &summary,
+        ),
+    ))
 }
 
-async fn write_provision_bundle(
-    ctx: &mut StdCtx,
-    path: &Path,
-    bundle: &ProvisionBundle,
-) -> anyhow::Result<()> {
+async fn write_provision_bundle(path: &Path, bundle: &ProvisionBundle) -> anyhow::Result<()> {
     let contents =
         serde_json::to_vec_pretty(bundle).context("failed to serialize provision bundle")?;
     write_file(path, &contents).await?;
-    shell_println!(ctx, "Provision bundle written to: {}", path.display())?;
     Ok(())
 }
 
@@ -187,88 +193,166 @@ fn approval_summaries(approvals: &[Approval]) -> Vec<ApprovalSummary> {
         .collect()
 }
 
-fn print_summary(
-    ctx: &mut StdCtx,
-    deploy_id: &str,
-    verification_status: &str,
-    summary: &AttestationSummary,
-) -> anyhow::Result<()> {
-    shell_println!(ctx, "Deployment: {deploy_id}")?;
-    shell_println!(ctx, "Verification: {verification_status}")?;
-    shell_println!(
-        ctx,
-        "Ephemeral Key: {}",
-        hex::encode(&summary.ephemeral_key)
-    )?;
-    shell_println!(ctx, "Module ID: {}", summary.module_id)?;
-    shell_println!(ctx, "Digest: {:?}", summary.digest)?;
-    shell_println!(ctx, "Timestamp (ms): {}", summary.timestamp_ms)?;
-    shell_println!(
-        ctx,
-        "User Data: {}",
-        summary
-            .user_data
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_else(|| "(none)".to_string())
-    )?;
-    shell_println!(
-        ctx,
-        "Nonce: {}",
-        summary
-            .nonce
-            .as_ref()
-            .map(hex::encode)
-            .unwrap_or_else(|| "(none)".to_string())
-    )?;
-    shell_println!(ctx, "PCRs:")?;
-    for (index, pcr) in &summary.pcrs {
-        let label = match *index {
-            16 => " (setup manifest/key commitment)",
-            17 => " (live manifest/key commitment)",
-            _ => "",
-        };
-        shell_println!(ctx, "  PCR{index}{label}: {}", hex::encode(pcr))?;
-    }
-    shell_println!(ctx, "Certificate Length: {} bytes", summary.certificate_len)?;
-    shell_println!(
-        ctx,
-        "CA Bundle Certificates: {}",
-        summary.ca_bundle_cert_count
-    )?;
-    shell_println!(
-        ctx,
-        "Manifest Set Approvals: {}/{}",
-        summary.manifest_set_approvals.len(),
-        summary.manifest_set_threshold
-    )?;
-    print_approval_summary_entries(ctx, &summary.manifest_set_approvals)?;
-    if summary.share_set_approvals.is_empty() {
-        shell_println!(ctx, "Share Set Approvals: (none)")?;
-    } else {
-        shell_println!(
-            ctx,
-            "Share Set Approvals: {}",
-            summary.share_set_approvals.len()
-        )?;
-        print_approval_summary_entries(ctx, &summary.share_set_approvals)?;
-    }
-    Ok(())
+/// Wide terminal outcome for `deploy provisioning-details`. Byte fields are
+/// hex-encoded; `digest` carries the Debug rendering of the NSM digest so the
+/// same string serves both the payload and the human line.
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvisioningDetails {
+    deployment_id: String,
+    verification: String,
+    ephemeral_key: String,
+    module_id: String,
+    digest: String,
+    timestamp_ms: u64,
+    user_data: Option<String>,
+    nonce: Option<String>,
+    pcrs: Vec<PcrEntry>,
+    certificate_length: usize,
+    ca_bundle_certificates: usize,
+    manifest_set_threshold: u32,
+    manifest_set_approvals: Vec<ApprovalEntry>,
+    share_set_approvals: Vec<ApprovalEntry>,
+    /// Present when `--provision-bundle-out` wrote a bundle file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bundle_path: Option<String>,
 }
 
-fn print_approval_summary_entries(
-    ctx: &mut StdCtx,
-    approvals: &[ApprovalSummary],
-) -> anyhow::Result<()> {
-    for approval in approvals {
-        shell_println!(
-            ctx,
-            "  {}: {}",
-            approval.alias,
-            hex::encode(&approval.public_key)
-        )?;
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PcrEntry {
+    index: usize,
+    value: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApprovalEntry {
+    alias: String,
+    public_key: String,
+}
+
+impl ProvisioningDetails {
+    fn from_summary(
+        deployment_id: String,
+        verification: &str,
+        bundle_path: Option<String>,
+        summary: &AttestationSummary,
+    ) -> Self {
+        Self {
+            deployment_id,
+            verification: verification.to_string(),
+            ephemeral_key: hex::encode(&summary.ephemeral_key),
+            module_id: summary.module_id.clone(),
+            digest: format!("{:?}", summary.digest),
+            timestamp_ms: summary.timestamp_ms,
+            user_data: summary.user_data.as_ref().map(hex::encode),
+            nonce: summary.nonce.as_ref().map(hex::encode),
+            pcrs: summary
+                .pcrs
+                .iter()
+                .map(|(index, pcr)| PcrEntry {
+                    index: *index,
+                    value: hex::encode(pcr),
+                })
+                .collect(),
+            certificate_length: summary.certificate_len,
+            ca_bundle_certificates: summary.ca_bundle_cert_count,
+            manifest_set_threshold: summary.manifest_set_threshold,
+            manifest_set_approvals: approval_entries(&summary.manifest_set_approvals),
+            share_set_approvals: approval_entries(&summary.share_set_approvals),
+            bundle_path,
+        }
     }
-    Ok(())
+}
+
+fn approval_entries(approvals: &[ApprovalSummary]) -> Vec<ApprovalEntry> {
+    approvals
+        .iter()
+        .map(|approval| ApprovalEntry {
+            alias: approval.alias.clone(),
+            public_key: hex::encode(&approval.public_key),
+        })
+        .collect()
+}
+
+impl Message for ProvisioningDetails {
+    fn reason(&self) -> &'static str {
+        "provisioning-details"
+    }
+
+    fn human_message(&self) -> String {
+        let mut message = String::new();
+
+        if let Some(path) = &self.bundle_path {
+            let _ = write!(message, "Provision bundle written to: {path}\n\n");
+        }
+
+        // Fixed attestation summary; `PCRs:` deliberately has no trailing
+        // newline so the PCR loop below appends its own leading-newline lines
+        // (and the section reads correctly even when there are no PCRs).
+        let _ = write!(
+            message,
+            r#"Deployment: {}
+Verification: {}
+Ephemeral Key: {}
+Module ID: {}
+Digest: {}
+Timestamp (ms): {}
+User Data: {}
+Nonce: {}
+PCRs:"#,
+            self.deployment_id,
+            self.verification,
+            self.ephemeral_key,
+            self.module_id,
+            self.digest,
+            self.timestamp_ms,
+            self.user_data.as_deref().unwrap_or("(none)"),
+            self.nonce.as_deref().unwrap_or("(none)"),
+        );
+
+        for pcr in &self.pcrs {
+            let label = match pcr.index {
+                16 => " (setup manifest/key commitment)",
+                17 => " (live manifest/key commitment)",
+                _ => "",
+            };
+            let _ = write!(message, "\n  PCR{}{label}: {}", pcr.index, pcr.value);
+        }
+
+        let _ = write!(
+            message,
+            r#"
+Certificate Length: {} bytes
+CA Bundle Certificates: {}
+Manifest Set Approvals: {}/{}"#,
+            self.certificate_length,
+            self.ca_bundle_certificates,
+            self.manifest_set_approvals.len(),
+            self.manifest_set_threshold,
+        );
+        write_approval_entries(&mut message, &self.manifest_set_approvals);
+
+        if self.share_set_approvals.is_empty() {
+            let _ = write!(message, "\nShare Set Approvals: (none)");
+        } else {
+            let _ = write!(
+                message,
+                "\nShare Set Approvals: {}",
+                self.share_set_approvals.len()
+            );
+            write_approval_entries(&mut message, &self.share_set_approvals);
+        }
+
+        message
+    }
+}
+
+fn write_approval_entries(message: &mut String, approvals: &[ApprovalEntry]) {
+    for approval in approvals {
+        let _ = write!(message, "\n  {}: {}", approval.alias, approval.public_key);
+    }
 }
 
 #[cfg(test)]
@@ -340,6 +424,90 @@ mod tests {
                 Some(fixture.validation_time_secs),
             )
             .is_err()
+        );
+    }
+
+    use super::{ApprovalEntry, PcrEntry, ProvisioningDetails};
+    use crate::output::Message;
+
+    fn full_details() -> ProvisioningDetails {
+        ProvisioningDetails {
+            deployment_id: "dep_123".to_string(),
+            verification: "verified".to_string(),
+            ephemeral_key: "abcd".to_string(),
+            module_id: "mod-1".to_string(),
+            digest: "SHA384".to_string(),
+            timestamp_ms: 1_700_000_000_000,
+            user_data: Some("aa".to_string()),
+            nonce: Some("bb".to_string()),
+            pcrs: vec![
+                PcrEntry { index: 0, value: "00".to_string() },
+                PcrEntry { index: 16, value: "1616".to_string() },
+                PcrEntry { index: 17, value: "1717".to_string() },
+            ],
+            certificate_length: 1234,
+            ca_bundle_certificates: 3,
+            manifest_set_threshold: 2,
+            manifest_set_approvals: vec![
+                ApprovalEntry { alias: "alice".to_string(), public_key: "aaaa".to_string() },
+                ApprovalEntry { alias: "bob".to_string(), public_key: "bbbb".to_string() },
+            ],
+            share_set_approvals: vec![ApprovalEntry {
+                alias: "carol".to_string(),
+                public_key: "cccc".to_string(),
+            }],
+            bundle_path: Some("/tmp/bundle.json".to_string()),
+        }
+    }
+
+    #[test]
+    fn human_message_full_golden() {
+        assert_eq!(
+            full_details().human_message(),
+            r#"Provision bundle written to: /tmp/bundle.json
+
+Deployment: dep_123
+Verification: verified
+Ephemeral Key: abcd
+Module ID: mod-1
+Digest: SHA384
+Timestamp (ms): 1700000000000
+User Data: aa
+Nonce: bb
+PCRs:
+  PCR0: 00
+  PCR16 (setup manifest/key commitment): 1616
+  PCR17 (live manifest/key commitment): 1717
+Certificate Length: 1234 bytes
+CA Bundle Certificates: 3
+Manifest Set Approvals: 2/2
+  alice: aaaa
+  bob: bbbb
+Share Set Approvals: 1
+  carol: cccc"#
+        );
+    }
+
+    #[test]
+    fn human_message_minimal_golden() {
+        let details = ProvisioningDetails::default();
+        // NOTE: the first five lines have empty values, so they end in a
+        // significant trailing space — do not strip trailing whitespace here.
+        assert_eq!(
+            details.human_message(),
+            r#"Deployment: 
+Verification: 
+Ephemeral Key: 
+Module ID: 
+Digest: 
+Timestamp (ms): 0
+User Data: (none)
+Nonce: (none)
+PCRs:
+Certificate Length: 0 bytes
+CA Bundle Certificates: 0
+Manifest Set Approvals: 0/0
+Share Set Approvals: (none)"#
         );
     }
 }

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -2,11 +2,12 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::generated::RestoreTvcDeploymentIntent;
+use turnkey_client::generated::{ActivityStatus, RestoreTvcDeploymentIntent};
 
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 
 /// Restore a deleted deployment.
 #[derive(Debug, ClapArgs)]
@@ -18,7 +19,7 @@ pub struct Args {
 }
 
 /// Run the deploy restore command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let intent = RestoreTvcDeploymentIntent {
@@ -36,15 +37,48 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
         .await
         .context("failed to restore TVC deployment")?;
 
-    shell_println!(ctx)?;
-    shell_println!(
-        ctx,
-        "Deployment restore accepted; deployment is no longer marked for deletion."
-    )?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Deployment ID: {}", result.result.deployment_id)?;
-    shell_println!(ctx, "Activity ID: {}", result.activity_id)?;
-    shell_println!(ctx, "Activity Status: {:?}", result.status)?;
+    Ok(Outcome::DeployRestore(DeploymentRestored {
+        deployment_id: result.result.deployment_id,
+        activity_id: result.activity_id,
+        activity_status: result.status,
+    }))
+}
 
-    Ok(())
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentRestored {
+    deployment_id: String,
+    activity_id: String,
+    /// Stable proto status name, e.g. `ACTIVITY_STATUS_COMPLETED`.
+    activity_status: ActivityStatus,
+}
+
+/// Manual because the generated `ActivityStatus` does not implement
+/// `Default`; the zero value is the enum's `Unspecified` variant.
+impl Default for DeploymentRestored {
+    fn default() -> Self {
+        Self {
+            deployment_id: String::default(),
+            activity_id: String::default(),
+            activity_status: ActivityStatus::Unspecified,
+        }
+    }
+}
+
+impl Message for DeploymentRestored {
+    fn reason(&self) -> &'static str {
+        "deployment-restored"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"
+Deployment restore accepted; deployment is no longer marked for deletion.
+
+Deployment ID: {}
+Activity ID: {}
+Activity Status: {}"#,
+            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+        )
+    }
 }

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -78,7 +78,9 @@ Deployment restore accepted; deployment is no longer marked for deletion.
 Deployment ID: {}
 Activity ID: {}
 Activity Status: {}"#,
-            self.deployment_id, self.activity_id, self.activity_status.as_str_name()
+            self.deployment_id,
+            self.activity_id,
+            self.activity_status.as_str_name()
         )
     }
 }

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -3,11 +3,12 @@
 use anyhow::Context;
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, RestoreTvcDeploymentIntent};
 
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 
 /// Restore a deleted deployment.
 #[derive(Debug, ClapArgs)]
@@ -65,13 +66,10 @@ impl Default for DeploymentRestored {
     }
 }
 
-impl Message for DeploymentRestored {
-    fn reason(&self) -> &'static str {
-        "deployment-restored"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for DeploymentRestored {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 Deployment restore accepted; deployment is no longer marked for deletion.
 

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::fmt::Write as _;
+use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::GetTvcDeploymentRequest;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 
@@ -11,7 +11,7 @@ use crate::client::fetch_tvc_app;
 use crate::commands::app_status::TimestampPayload;
 use crate::commands::display::{format_egress_enabled, yes_no};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 
 /// Get the status of a deployment.
 #[derive(Debug, ClapArgs)]
@@ -103,13 +103,10 @@ struct PivotContainerSummary {
     args: Vec<String>,
 }
 
-impl Message for DeploymentStatusReport {
-    fn reason(&self) -> &'static str {
-        "deployment-status"
-    }
-
-    fn human_message(&self) -> String {
-        let mut message = format!(
+impl Display for DeploymentStatusReport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"Deployment: {}
 App ID: {}
 {}
@@ -124,40 +121,32 @@ Debug Mode: {}"#,
             self.qos_version,
             format_marked_for_deletion(self.marked_for_deletion),
             yes_no(self.debug_mode)
-        );
+        )?;
 
         if let Some(pivot) = &self.pivot_container {
-            let _ = write!(
-                message,
+            write!(
+                f,
                 r#"
 
 Pivot Container:
   URL: {}
   Path: {}"#,
                 pivot.url, pivot.path
-            );
+            )?;
             if !pivot.args.is_empty() {
-                let _ = write!(message, "\n  Args: {:?}", pivot.args);
+                write!(f, "\n  Args: {:?}", pivot.args)?;
             }
         }
 
         if let Some(created) = &self.created_at {
-            let _ = write!(
-                message,
-                "\n\nCreated: {}.{:09}s",
-                created.seconds, created.nanos
-            );
+            write!(f, "\n\nCreated: {}.{:09}s", created.seconds, created.nanos)?;
         }
 
         if let Some(updated) = &self.updated_at {
-            let _ = write!(
-                message,
-                "\nUpdated: {}.{:09}s",
-                updated.seconds, updated.nanos
-            );
+            write!(f, "\nUpdated: {}.{:09}s", updated.seconds, updated.nanos)?;
         }
 
-        message
+        Ok(())
     }
 }
 

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -2,13 +2,16 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::Write as _;
 use turnkey_client::generated::GetTvcDeploymentRequest;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 
 use crate::client::fetch_tvc_app;
+use crate::commands::app_status::TimestampPayload;
 use crate::commands::display::{format_egress_enabled, yes_no};
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 
 /// Get the status of a deployment.
 #[derive(Debug, ClapArgs)]
@@ -20,7 +23,7 @@ pub struct Args {
 }
 
 /// Run the deploy status command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let request = GetTvcDeploymentRequest {
@@ -38,81 +41,141 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
         .tvc_deployment
         .ok_or_else(|| anyhow::anyhow!("deployment not found: {}", args.deploy_id))?;
 
-    let manifest = deployment
-        .manifest
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("manifest not found in deployment"))?;
-    let app = fetch_tvc_app(&auth, &deployment.app_id).await?;
+    // Exhaustive destructure (rather than `..`) so a new `TvcDeployment` field
+    // forces a compile error here and forces a deliberate decision about usage
+    let TvcDeployment {
+        id,
+        app_id,
+        manifest,
+        qos_version,
+        pivot_container,
+        created_at,
+        updated_at,
+        delete,
+        debug_mode,
+        organization_id: _,
+        manifest_set: _,
+        share_set: _,
+        manifest_approvals: _,
+    } = deployment;
 
-    shell_println!(ctx, "Deployment: {}", deployment.id)?;
-    shell_println!(ctx, "App ID: {}", deployment.app_id)?;
-    shell_println!(ctx, "{}", format_egress_enabled(app.enable_egress))?;
-    shell_println!(ctx, "Manifest ID: {}", manifest.id)?;
-    shell_println!(ctx, "QOS Version: {}", deployment.qos_version)?;
-    shell_println!(ctx, "{}", format_marked_for_deletion(&deployment))?;
+    let manifest = manifest.ok_or_else(|| anyhow::anyhow!("manifest not found in deployment"))?;
+    let app = fetch_tvc_app(&auth, &app_id).await?;
 
-    if let Some(pivot) = &deployment.pivot_container {
-        shell_println!(ctx)?;
-        shell_println!(ctx, "Pivot Container:")?;
-        shell_println!(ctx, "  URL: {}", pivot.container_url)?;
-        shell_println!(ctx, "  Path: {}", pivot.path)?;
-        if !pivot.args.is_empty() {
-            shell_println!(ctx, "  Args: {:?}", pivot.args)?;
-        }
-    }
-
-    if let Some(created) = &deployment.created_at {
-        shell_println!(ctx)?;
-        shell_println!(ctx, "Created: {}.{:0>9}s", created.seconds, created.nanos)?;
-    }
-
-    if let Some(updated) = &deployment.updated_at {
-        shell_println!(ctx, "Updated: {}.{:0>9}s", updated.seconds, updated.nanos)?;
-    }
-
-    Ok(())
+    Ok(Outcome::DeployStatus(DeploymentStatusReport {
+        deployment_id: id,
+        app_id,
+        egress_enabled: app.enable_egress,
+        manifest_id: manifest.id,
+        qos_version,
+        marked_for_deletion: delete,
+        debug_mode,
+        pivot_container: pivot_container.map(|pivot| PivotContainerSummary {
+            url: pivot.container_url,
+            path: pivot.path,
+            args: pivot.args,
+        }),
+        created_at: created_at.map(Into::into),
+        updated_at: updated_at.map(Into::into),
+    }))
 }
 
-fn format_marked_for_deletion(deployment: &TvcDeployment) -> String {
-    format!("Marked for deletion: {}", yes_no(deployment.delete))
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentStatusReport {
+    deployment_id: String,
+    app_id: String,
+    egress_enabled: bool,
+    manifest_id: String,
+    qos_version: String,
+    marked_for_deletion: bool,
+    debug_mode: bool,
+    pivot_container: Option<PivotContainerSummary>,
+    created_at: Option<TimestampPayload>,
+    updated_at: Option<TimestampPayload>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PivotContainerSummary {
+    url: String,
+    path: String,
+    args: Vec<String>,
+}
+
+impl Message for DeploymentStatusReport {
+    fn reason(&self) -> &'static str {
+        "deployment-status"
+    }
+
+    fn human_message(&self) -> String {
+        let mut message = format!(
+            r#"Deployment: {}
+App ID: {}
+{}
+Manifest ID: {}
+QOS Version: {}
+{}
+Debug Mode: {}"#,
+            self.deployment_id,
+            self.app_id,
+            format_egress_enabled(self.egress_enabled),
+            self.manifest_id,
+            self.qos_version,
+            format_marked_for_deletion(self.marked_for_deletion),
+            yes_no(self.debug_mode)
+        );
+
+        if let Some(pivot) = &self.pivot_container {
+            let _ = write!(
+                message,
+                r#"
+
+Pivot Container:
+  URL: {}
+  Path: {}"#,
+                pivot.url, pivot.path
+            );
+            if !pivot.args.is_empty() {
+                let _ = write!(message, "\n  Args: {:?}", pivot.args);
+            }
+        }
+
+        if let Some(created) = &self.created_at {
+            let _ = write!(
+                message,
+                "\n\nCreated: {}.{:09}s",
+                created.seconds, created.nanos
+            );
+        }
+
+        if let Some(updated) = &self.updated_at {
+            let _ = write!(
+                message,
+                "\nUpdated: {}.{:09}s",
+                updated.seconds, updated.nanos
+            );
+        }
+
+        message
+    }
+}
+
+fn format_marked_for_deletion(delete: bool) -> String {
+    format!("Marked for deletion: {}", yes_no(delete))
 }
 
 #[cfg(test)]
 mod tests {
     use super::format_marked_for_deletion;
-    use turnkey_client::generated::external::data::v1::TvcDeployment;
-
-    fn deployment(delete: bool) -> TvcDeployment {
-        TvcDeployment {
-            id: "deploy-123".to_string(),
-            organization_id: "org-123".to_string(),
-            app_id: "app-123".to_string(),
-            manifest_set: None,
-            share_set: None,
-            manifest: None,
-            manifest_approvals: vec![],
-            qos_version: "qos-v1".to_string(),
-            pivot_container: None,
-            debug_mode: false,
-            created_at: None,
-            updated_at: None,
-            delete,
-        }
-    }
 
     #[test]
     fn marked_for_deletion_formats_yes_when_delete_is_true() {
-        assert_eq!(
-            format_marked_for_deletion(&deployment(true)),
-            "Marked for deletion: yes"
-        );
+        assert_eq!(format_marked_for_deletion(true), "Marked for deletion: yes");
     }
 
     #[test]
     fn marked_for_deletion_formats_no_when_delete_is_false() {
-        assert_eq!(
-            format_marked_for_deletion(&deployment(false)),
-            "Marked for deletion: no"
-        );
+        assert_eq!(format_marked_for_deletion(false), "Marked for deletion: no");
     }
 }

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     client::build_client,
+    outcome::Outcome,
     output::{Message, StdCtx},
 };
 use anyhow::{Context, Result, anyhow, ensure};
@@ -29,9 +30,9 @@ pub struct Args {
     pub operator_encrypt_keys: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct QuorumKeyCreated {
+pub struct QuorumKeyCreated {
     quorum_key_id: String,
     quorum_public_key: String,
     share_ids: Vec<String>,
@@ -53,7 +54,7 @@ impl Message for QuorumKeyCreated {
 }
 
 /// Run the hosted quorum-key creation command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let operator_encrypt_keys = parse_operator_encrypt_keys(&args.operator_encrypt_keys)?;
     validate_operator_count(operator_encrypt_keys.len())?;
     validate_threshold(args.threshold, operator_encrypt_keys.len())?;
@@ -73,7 +74,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
         .map_err(|error| anyhow!("failed to create hosted TVC quorum key: {error}"))?;
     let output = validate_result(result.result, expected_share_count)?;
 
-    ctx.shell().emit(&output)
+    Ok(Outcome::KeysCreateQuorumKey(output))
 }
 
 fn parse_operator_encrypt_keys(input: &str) -> Result<Vec<String>> {

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -1,15 +1,12 @@
 //! Create a hosted quorum key from operator encryption public keys.
 
-use crate::{
-    client::build_client,
-    outcome::Outcome,
-    output::{Message, StdCtx},
-};
+use crate::{client::build_client, outcome::Outcome, output::StdCtx};
 use anyhow::{Context, Result, anyhow, ensure};
 use clap::Args as ClapArgs;
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
 use serde::Serialize;
 use std::collections::HashSet;
+use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcQuorumKeyIntent, CreateTvcQuorumKeyResult};
 
@@ -38,13 +35,10 @@ pub struct QuorumKeyCreated {
     share_ids: Vec<String>,
 }
 
-impl Message for QuorumKeyCreated {
-    fn reason(&self) -> &'static str {
-        "quorum-key-created"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for QuorumKeyCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             "Quorum Key ID: {}\nQuorum Public Key: {}\nShare IDs: {}",
             self.quorum_key_id,
             self.quorum_public_key,
@@ -323,15 +317,16 @@ mod tests {
             }
         );
         assert_eq!(
-            output.human_message(),
+            output.to_string(),
             "Quorum Key ID: quorum-key-id\nQuorum Public Key: quorum-public-key\nShare IDs: share-1, share-2"
         );
 
-        let json: Value = serde_json::from_str(&output.to_json_string()).unwrap();
+        // The payload serializes without a `reason`; the reason is the
+        // `Outcome`'s responsibility.
+        let json: Value = serde_json::to_value(&output).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
-                "reason": "quorum-key-created",
                 "quorumKeyId": "quorum-key-id",
                 "quorumPublicKey": "quorum-public-key",
                 "shareIds": ["share-1", "share-2"],

--- a/tvc/src/commands/keys/generate_local_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_local_quorum_key.rs
@@ -1,15 +1,16 @@
 //! Generate local quorum key command - generates and encrypts a quorum key from a given config.
 
 use crate::config::quorum_key::QuorumKeyConfig;
-use crate::output::StdCtx;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use crate::quorum_key_metadata::{
     EncryptedShareMetadata, QuorumKeyMetadata, decode_p256_public_key_hex,
 };
-use crate::shell_println;
 use crate::util::read_json_file;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use qos_p256::{P256Pair, P256Public};
+use serde::Serialize;
 use std::fs;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
@@ -40,7 +41,7 @@ struct OperatorPublicKey {
 struct PlaintextShares(Vec<Zeroizing<Vec<u8>>>);
 
 /// Run the quorum key generation command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let config: QuorumKeyConfig =
         read_json_file(&args.config_file, "quorum key config file").await?;
     config.validate()?;
@@ -65,16 +66,34 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
         )
     })?;
 
-    shell_println!(
-        ctx,
-        "Quorum key metadata written to: {}",
-        args.quorum_key_metadata_out.display()
-    )?;
+    Ok(Outcome::KeysGenerateQuorumKey(QuorumKeyGenerated {
+        quorum_key_public,
+        threshold: config.threshold,
+        metadata_path: args.quorum_key_metadata_out.display().to_string(),
+    }))
+}
 
-    shell_println!(ctx, "Quorum Public Key: {quorum_key_public}")?;
-    shell_println!(ctx, "Threshold: {}", config.threshold)?;
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumKeyGenerated {
+    quorum_key_public: String,
+    threshold: u32,
+    metadata_path: String,
+}
 
-    Ok(())
+impl Message for QuorumKeyGenerated {
+    fn reason(&self) -> &'static str {
+        "quorum-key-generated"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"Quorum key metadata written to: {}
+Quorum Public Key: {}
+Threshold: {}"#,
+            self.metadata_path, self.quorum_key_public, self.threshold
+        )
+    }
 }
 
 fn parse_operator_public_keys(operator_public_keys: &[String]) -> Result<Vec<OperatorPublicKey>> {

--- a/tvc/src/commands/keys/generate_local_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_local_quorum_key.rs
@@ -2,7 +2,7 @@
 
 use crate::config::quorum_key::QuorumKeyConfig;
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::quorum_key_metadata::{
     EncryptedShareMetadata, QuorumKeyMetadata, decode_p256_public_key_hex,
 };
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use qos_p256::{P256Pair, P256Public};
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::fs;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
@@ -81,13 +82,10 @@ pub struct QuorumKeyGenerated {
     metadata_path: String,
 }
 
-impl Message for QuorumKeyGenerated {
-    fn reason(&self) -> &'static str {
-        "quorum-key-generated"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for QuorumKeyGenerated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"Quorum key metadata written to: {}
 Quorum Public Key: {}
 Threshold: {}"#,

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -2,10 +2,11 @@
 
 use crate::config::quorum_key::QuorumKeyConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::output::StdCtx;
-use crate::shell_println;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use serde::Serialize;
 use std::path::PathBuf;
 
 /// Generate a template quorum key configuration file.
@@ -24,7 +25,7 @@ pub struct Args {
 }
 
 /// Run the quorum key init command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     if args.output.exists() {
         anyhow::bail!("File already exists: {}", args.output.display());
     }
@@ -37,25 +38,36 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     std::fs::write(&args.output, json)
         .with_context(|| format!("failed to write file: {}", args.output.display()))?;
 
-    shell_println!(
-        ctx,
-        "Created quorum key config template: {}",
-        args.output.display()
-    )?;
-    shell_println!(ctx)?;
-    // Constraints inherited from qos_crypto::shamir::shares_generate.
-    shell_println!(ctx, "Constraints (see qos_crypto/src/shamir.rs):")?;
-    shell_println!(ctx, "  shares    : 1..=255")?;
-    shell_println!(ctx, "  threshold : >= 2 and <= shares")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Edit the file to fill in your values, then run:")?;
-    shell_println!(
-        ctx,
-        "  tvc keys generate-local-quorum-key --config-file {}",
-        args.output.display()
-    )?;
+    Ok(Outcome::KeysInitQuorumKey(QuorumKeyConfigCreated {
+        path: args.output.display().to_string(),
+    }))
+}
 
-    Ok(())
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumKeyConfigCreated {
+    path: String,
+}
+
+impl Message for QuorumKeyConfigCreated {
+    fn reason(&self) -> &'static str {
+        "quorum-key-config-created"
+    }
+
+    fn human_message(&self) -> String {
+        // Constraints inherited from qos_crypto::shamir::shares_generate.
+        format!(
+            r#"Created quorum key config template: {}
+
+Constraints (see qos_crypto/src/shamir.rs):
+  shares    : 1..=255
+  threshold : >= 2 and <= shares
+
+Edit the file to fill in your values, then run:
+  tvc keys generate-local-quorum-key --config-file {}"#,
+            self.path, self.path
+        )
+    }
 }
 
 /// Load the operator public key from the active org's config.

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -3,10 +3,11 @@
 use crate::config::quorum_key::QuorumKeyConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 /// Generate a template quorum key configuration file.
@@ -49,14 +50,11 @@ pub struct QuorumKeyConfigCreated {
     path: String,
 }
 
-impl Message for QuorumKeyConfigCreated {
-    fn reason(&self) -> &'static str {
-        "quorum-key-config-created"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for QuorumKeyConfigCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // Constraints inherited from qos_crypto::shamir::shares_generate.
-        format!(
+        write!(
+            f,
             r#"Created quorum key config template: {}
 
 Constraints (see qos_crypto/src/shamir.rs):

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -2,7 +2,7 @@
 
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::pair::{HexSeed, Pair};
 use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
@@ -12,6 +12,7 @@ use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, QuorumMember, VersionedManifestEnvelope};
 use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
 
 /// Re-encrypt a share with an ephemeral key.
@@ -79,20 +80,19 @@ pub struct ReEncryptedShareGenerated {
     written_to: Option<String>,
 }
 
-impl Message for ReEncryptedShareGenerated {
-    fn reason(&self) -> &'static str {
-        "re-encrypted-share-generated"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for ReEncryptedShareGenerated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.share {
             // Preserve the previous human behavior: pretty-printed share JSON.
-            Some(share) => serde_json::to_string_pretty(share)
-                .expect("serializing re-encrypted share should not fail"),
+            Some(share) => {
+                let json = serde_json::to_string_pretty(share)
+                    .expect("serializing re-encrypted share should not fail");
+                f.write_str(&json)
+            }
             // File branch: the "Re-encrypted share written to: ..." narration
             // prints inline on stderr; the outcome is machine-only, so human
             // mode prints nothing here.
-            None => String::new(),
+            None => Ok(()),
         }
     }
 }
@@ -239,6 +239,7 @@ mod tests {
         ReEncryptedShareGenerated, ReEncryptedShareOutput, build_re_encrypted_share_output,
         ensure_quorum_key_matches_manifest, find_share_set_member,
     };
+    use crate::outcome::Outcome;
     use crate::output::Message;
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
@@ -563,7 +564,8 @@ mod tests {
     #[test]
     fn inline_branch_serializes_flattened_share_payload() {
         let value: serde_json::Value =
-            serde_json::from_str(&generated_inline().to_json_string()).unwrap();
+            serde_json::from_str(&Outcome::KeysReEncryptShare(generated_inline()).to_json_string())
+                .unwrap();
 
         assert_eq!(
             value,
@@ -585,8 +587,10 @@ mod tests {
 
     #[test]
     fn file_branch_serializes_written_to_path() {
-        let value: serde_json::Value =
-            serde_json::from_str(&generated_written_to().to_json_string()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(
+            &Outcome::KeysReEncryptShare(generated_written_to()).to_json_string(),
+        )
+        .unwrap();
 
         assert_eq!(
             value,
@@ -599,6 +603,6 @@ mod tests {
 
     #[test]
     fn file_branch_is_machine_only_in_human_mode() {
-        assert!(generated_written_to().human_message().is_empty());
+        assert!(generated_written_to().to_string().is_empty());
     }
 }

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -1,6 +1,7 @@
 //! Re-encrypt local share command.
 
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
+use crate::outcome::Outcome;
 use crate::output::{Message, StdCtx};
 use crate::pair::{HexSeed, Pair};
 use crate::provisioning::ProvisionBundle;
@@ -65,19 +66,39 @@ pub(crate) struct ReEncryptedShareOutput {
     pub(crate) share_approval: Approval,
 }
 
-impl Message for ReEncryptedShareOutput {
+/// Wide terminal outcome covering both output branches: the share payload
+/// inline (no `--re-encrypted-out`) or the path it was written to.
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReEncryptedShareGenerated {
+    /// Present when the share is returned inline (no `--re-encrypted-out`).
+    #[serde(flatten)]
+    share: Option<ReEncryptedShareOutput>,
+    /// Present when the share was written to a file via `--re-encrypted-out`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    written_to: Option<String>,
+}
+
+impl Message for ReEncryptedShareGenerated {
     fn reason(&self) -> &'static str {
         "re-encrypted-share-generated"
     }
 
     fn human_message(&self) -> String {
-        // Preserve the previous human behavior: pretty-printed share JSON.
-        serde_json::to_string_pretty(self).expect("serializing re-encrypted share should not fail")
+        match &self.share {
+            // Preserve the previous human behavior: pretty-printed share JSON.
+            Some(share) => serde_json::to_string_pretty(share)
+                .expect("serializing re-encrypted share should not fail"),
+            // File branch: the "Re-encrypted share written to: ..." narration
+            // prints inline on stderr; the outcome is machine-only, so human
+            // mode prints nothing here.
+            None => String::new(),
+        }
     }
 }
 
 /// Run the re-encrypt-local-share command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let operator_seed_source =
         LocalOperatorSeedSource::from_args(args.operator_seed, args.operator_seed_path)?;
 
@@ -102,7 +123,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     )
     .await?;
 
-    write_output(ctx, args.re_encrypted_out.as_deref(), &output).await
+    write_output(ctx, args.re_encrypted_out.as_deref(), output).await
 }
 
 async fn build_re_encrypted_share_output(
@@ -191,29 +212,34 @@ fn find_share_set_member(
 async fn write_output(
     ctx: &mut StdCtx,
     path: Option<&Path>,
-    output: &ReEncryptedShareOutput,
-) -> anyhow::Result<()> {
-    if let Some(path) = path {
-        let contents = serde_json::to_string_pretty(output)
+    output: ReEncryptedShareOutput,
+) -> anyhow::Result<Outcome> {
+    let generated = if let Some(path) = path {
+        let contents = serde_json::to_string_pretty(&output)
             .context("failed to serialize re-encrypted share")?;
         write_file(path, &contents).await?;
         shell_eprintln!(ctx, "Re-encrypted share written to: {}", path.display())?;
+        ReEncryptedShareGenerated {
+            share: None,
+            written_to: Some(path.display().to_string()),
+        }
     } else {
-        // Emit the share output as the machine-relevant payload. In human mode
-        // this prints pretty JSON exactly as before; in JSON mode it is wrapped
-        // in a stable `reason` envelope so the share survives suppression.
-        ctx.shell().emit(output)?;
-    }
+        ReEncryptedShareGenerated {
+            share: Some(output),
+            written_to: None,
+        }
+    };
 
-    Ok(())
+    Ok(Outcome::KeysReEncryptShare(generated))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ReEncryptedShareOutput, build_re_encrypted_share_output,
+        ReEncryptedShareGenerated, ReEncryptedShareOutput, build_re_encrypted_share_output,
         ensure_quorum_key_matches_manifest, find_share_set_member,
     };
+    use crate::output::Message;
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
     use crate::quorum_key_metadata::{EncryptedShareMetadata, QuorumKeyMetadata};
@@ -507,5 +533,72 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("does not match"));
+    }
+
+    fn generated_inline() -> ReEncryptedShareGenerated {
+        ReEncryptedShareGenerated {
+            share: Some(ReEncryptedShareOutput {
+                deployment_id: "deploy-123".to_string(),
+                ephemeral_public_key_hex: "04abcd".to_string(),
+                re_encrypted_share: "010203".to_string(),
+                share_approval: Approval {
+                    signature: vec![0xde, 0xad, 0xbe, 0xef],
+                    member: QuorumMember {
+                        alias: "operator-1".to_string(),
+                        pub_key: vec![0xaa, 0xbb, 0xcc],
+                    },
+                },
+            }),
+            written_to: None,
+        }
+    }
+
+    fn generated_written_to() -> ReEncryptedShareGenerated {
+        ReEncryptedShareGenerated {
+            share: None,
+            written_to: Some("re_encrypted_share.json".to_string()),
+        }
+    }
+
+    #[test]
+    fn inline_branch_serializes_flattened_share_payload() {
+        let value: serde_json::Value =
+            serde_json::from_str(&generated_inline().to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "reason": "re-encrypted-share-generated",
+                "deploymentId": "deploy-123",
+                "ephemeralPublicKeyHex": "04abcd",
+                "reEncryptedShare": "010203",
+                "shareApproval": {
+                    "signature": "deadbeef",
+                    "member": {
+                        "alias": "operator-1",
+                        "pubKey": "aabbcc",
+                    },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn file_branch_serializes_written_to_path() {
+        let value: serde_json::Value =
+            serde_json::from_str(&generated_written_to().to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "reason": "re-encrypted-share-generated",
+                "writtenTo": "re_encrypted_share.json",
+            })
+        );
+    }
+
+    #[test]
+    fn file_branch_is_machine_only_in_human_mode() {
+        assert!(generated_written_to().human_message().is_empty());
     }
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -5,12 +5,14 @@ use crate::config::turnkey::{
     StoredQosOperatorKey, dashboard_base_url, default_api_key_path, default_operator_key_path,
     default_org_dir,
 };
-use crate::output::StdCtx;
+use crate::outcome::Outcome;
+use crate::output::{Message, StdCtx};
 use crate::prompts::{self, error_required_in_non_interactive};
 use crate::{shell_eprintln, shell_print, shell_println};
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
+use serde::Serialize;
 use std::collections::BTreeSet;
 use std::io::BufRead;
 use tracing::debug;
@@ -60,7 +62,7 @@ struct LoginPlan {
     api_key_policy: ApiKeyPolicy,
 }
 
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     debug!(
         non_interactive = ctx.is_non_interactive(),
         org_arg_present = args.org.is_some(),
@@ -81,7 +83,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
 
 /// Permanently delete a saved login profile: its config entry and its API and
 /// operator key files on disk.
-pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<()> {
+pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<Outcome> {
     let is_non_interactive = ctx.is_non_interactive();
     debug!(
         non_interactive = is_non_interactive,
@@ -212,36 +214,17 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<()> {
     // succeeds, so a failure leaves the profile listed and the delete retryable.
     config.save().await?;
 
-    shell_println!(ctx, "Deleted login profile '{alias}' ({}).", removed.id)?;
-    if let Some(dir) = removed_dir {
-        shell_println!(ctx, "Removed key directory: {}", dir.display())?;
-    }
-
     // A local delete does not touch the dashboard-registered API key, and we
     // can't tell whether it is still there, so hedge with "may" and give steps.
     let dashboard_url = dashboard_base_url(&removed.api_base_url);
-    shell_println!(ctx)?;
-    shell_println!(
-        ctx,
-        "IMPORTANT: The API key may still be registered on the Turnkey dashboard."
-    )?;
-    shell_println!(
-        ctx,
-        "It will remain valid until it is manually removed. To remove it:"
-    )?;
-    shell_println!(
-        ctx,
-        "  1. Go to {dashboard_url}/dashboard/v2/users and click your user"
-    )?;
-    match api_public_key {
-        Some(public_key) => {
-            shell_println!(ctx, "  2. Delete the API key with public key:")?;
-            shell_println!(ctx, "       {public_key}")?;
-        }
-        None => shell_println!(ctx, "  2. Delete the API key associated with this profile")?,
-    }
 
-    Ok(())
+    Ok(Outcome::ProfileDelete(ProfileDeleted {
+        alias,
+        organization_id: removed.id,
+        removed_key_directory: removed_dir.map(|dir| dir.display().to_string()),
+        dashboard_url: dashboard_url.to_string(),
+        api_public_key,
+    }))
 }
 
 /// Resolve the alias of a configured profile to delete. Prompts interactively
@@ -319,7 +302,7 @@ fn build_login_plan_non_interactive(args: Args) -> Result<LoginPlan> {
     })
 }
 
-async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<()> {
+async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<Outcome> {
     let (alias, org_config) = match plan.org {
         OrgPlan::Existing(query) => {
             let alias = match find_org(&config, &query) {
@@ -374,7 +357,29 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url).await?;
     let operator_key = find_or_generate_operator_key(ctx, &alias, &org_config).await?;
 
-    print_success(ctx, &alias, &org_config, &api_key, &operator_key, &whoami)
+    // Operator key path now lives in the org's local operator record (the
+    // versioned registry), not on `OrgConfig` directly. Resolve it before the
+    // struct literal so `alias` is still available (the struct moves it).
+    let operator_key_path = org_config
+        .select_local_record(&alias)?
+        .key_path
+        .display()
+        .to_string();
+
+    Ok(Outcome::Login(LoggedIn {
+        organization_name: whoami.organization_name,
+        organization_id: whoami.organization_id,
+        username: whoami.username,
+        user_id: whoami.user_id,
+        alias,
+        api_public_key: api_key.public_key.clone(),
+        operator_public_key: operator_key.public_key.clone(),
+        config_file_path: crate::config::turnkey::config_file_path()?
+            .display()
+            .to_string(),
+        api_key_path: org_config.api_key_path.display().to_string(),
+        operator_key_path,
+    }))
 }
 
 fn prompt_for_org_plan(
@@ -636,45 +641,102 @@ async fn verify_credentials(
     })
 }
 
-fn print_success(
-    ctx: &mut StdCtx,
-    alias: &str,
-    org_config: &OrgConfig,
-    api_key: &StoredApiKey,
-    operator_key: &StoredQosOperatorKey,
-    whoami: &WhoamiResult,
-) -> Result<()> {
-    let local = org_config.select_local_record(alias)?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Successfully logged in!")?;
-    shell_println!(ctx)?;
-    shell_println!(
-        ctx,
-        "Organization: {} ({})",
-        whoami.organization_name,
-        whoami.organization_id
-    )?;
-    shell_println!(ctx, "User: {} ({})", whoami.username, whoami.user_id)?;
-    shell_println!(ctx, "Active Org: {alias}")?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Credentials")?;
-    shell_println!(ctx, "  API public key:        {}", api_key.public_key)?;
-    shell_println!(ctx, "  Operator public key:   {}", operator_key.public_key)?;
-    shell_println!(ctx)?;
-    shell_println!(ctx, "Saved to")?;
-    shell_println!(
-        ctx,
-        "  Config file:    {}",
-        crate::config::turnkey::config_file_path()?.display()
-    )?;
-    shell_println!(
-        ctx,
-        "  API key:        {}",
-        org_config.api_key_path.display()
-    )?;
-    shell_println!(ctx, "  Operator key:   {}", local.key_path.display())?;
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoggedIn {
+    organization_name: String,
+    organization_id: String,
+    username: String,
+    user_id: String,
+    alias: String,
+    api_public_key: String,
+    operator_public_key: String,
+    config_file_path: String,
+    api_key_path: String,
+    operator_key_path: String,
+}
 
-    Ok(())
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileDeleted {
+    alias: String,
+    organization_id: String,
+    removed_key_directory: Option<String>,
+    dashboard_url: String,
+    api_public_key: Option<String>,
+}
+
+impl Message for ProfileDeleted {
+    fn reason(&self) -> &'static str {
+        "profile-deleted"
+    }
+
+    fn human_message(&self) -> String {
+        let mut lines = vec![format!(
+            "Deleted login profile '{}' ({}).",
+            self.alias, self.organization_id
+        )];
+
+        if let Some(directory) = &self.removed_key_directory {
+            lines.push(format!("Removed key directory: {directory}"));
+        }
+
+        lines.extend([
+            String::new(),
+            "IMPORTANT: The API key may still be registered on the Turnkey dashboard.".to_string(),
+            "It will remain valid until it is manually removed. To remove it:".to_string(),
+            format!(
+                "  1. Go to {}/dashboard/v2/users and click your user",
+                self.dashboard_url
+            ),
+        ]);
+
+        match &self.api_public_key {
+            Some(public_key) => {
+                lines.push("  2. Delete the API key with public key:".to_string());
+                lines.push(format!("       {public_key}"));
+            }
+            None => lines.push("  2. Delete the API key associated with this profile".to_string()),
+        }
+
+        lines.join("\n")
+    }
+}
+
+impl Message for LoggedIn {
+    fn reason(&self) -> &'static str {
+        "logged-in"
+    }
+
+    fn human_message(&self) -> String {
+        format!(
+            r#"
+Successfully logged in!
+
+Organization: {} ({})
+User: {} ({})
+Active Org: {}
+
+Credentials
+  API public key:        {}
+  Operator public key:   {}
+
+Saved to
+  Config file:    {}
+  API key:        {}
+  Operator key:   {}"#,
+            self.organization_name,
+            self.organization_id,
+            self.username,
+            self.user_id,
+            self.alias,
+            self.api_public_key,
+            self.operator_public_key,
+            self.config_file_path,
+            self.api_key_path,
+            self.operator_key_path
+        )
+    }
 }
 
 #[cfg(test)]

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -6,7 +6,7 @@ use crate::config::turnkey::{
     default_org_dir,
 };
 use crate::outcome::Outcome;
-use crate::output::{Message, StdCtx};
+use crate::output::StdCtx;
 use crate::prompts::{self, error_required_in_non_interactive};
 use crate::{shell_eprintln, shell_print, shell_println};
 use anyhow::{Context, Result, anyhow, bail};
@@ -14,6 +14,7 @@ use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
 use serde::Serialize;
 use std::collections::BTreeSet;
+use std::fmt::{self, Display, Formatter};
 use std::io::BufRead;
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
@@ -267,8 +268,8 @@ struct ProfileChoice<'a> {
     is_active: bool,
 }
 
-impl std::fmt::Display for ProfileChoice<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ProfileChoice<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let suffix = if self.is_active { " (active)" } else { "" };
         write!(f, "{} ({}){suffix}", self.alias, self.org_id)
     }
@@ -449,8 +450,8 @@ enum OrgChoice {
     New,
 }
 
-impl std::fmt::Display for OrgChoice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for OrgChoice {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             OrgChoice::Existing { display, .. } => write!(f, "{display}"),
             OrgChoice::New => write!(f, "[new] Add a new organization"),
@@ -666,12 +667,8 @@ pub struct ProfileDeleted {
     api_public_key: Option<String>,
 }
 
-impl Message for ProfileDeleted {
-    fn reason(&self) -> &'static str {
-        "profile-deleted"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for ProfileDeleted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut lines = vec![format!(
             "Deleted login profile '{}' ({}).",
             self.alias, self.organization_id
@@ -699,17 +696,14 @@ impl Message for ProfileDeleted {
             None => lines.push("  2. Delete the API key associated with this profile".to_string()),
         }
 
-        lines.join("\n")
+        f.write_str(&lines.join("\n"))
     }
 }
 
-impl Message for LoggedIn {
-    fn reason(&self) -> &'static str {
-        "logged-in"
-    }
-
-    fn human_message(&self) -> String {
-        format!(
+impl Display for LoggedIn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
             r#"
 Successfully logged in!
 

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -1,10 +1,9 @@
 //! App configuration file format for `tvc app create`.
 
-use std::fmt::Display;
-
 use crate::prompts;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
 use thiserror::Error;
 
 pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
@@ -310,7 +309,7 @@ impl AppConfigValidationError {
 }
 
 impl Display for AppConfigValidationErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let s = self
             .0
             .iter()

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -327,7 +327,7 @@ mod tests {
     /// Build a `TvcManifest` from the fixture, optionally flipping debug mode on.
     fn manifest(debug_mode: bool) -> TvcManifest {
         let json = if debug_mode {
-            MANIFEST_JSON.replace("\"debugMode\": false", "\"debugMode\": true")
+            MANIFEST_JSON.replace(r#""debugMode": false"#, r#""debugMode": true"#)
         } else {
             MANIFEST_JSON.to_string()
         };

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -6,7 +6,7 @@ use crate::shell_println;
 use anyhow::{Context, Result, anyhow};
 use qos_core::protocol::services::boot::VersionedManifest;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use thiserror::Error;
 use turnkey_client::generated::{
@@ -298,7 +298,7 @@ impl DeployConfigValidationErrors {
 }
 
 impl Display for DeployConfigValidationErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let s = self
             .0
             .iter()

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -16,6 +16,7 @@ pub use qos_operator_key::StoredQosOperatorKey;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::path::PathBuf;
 use tracing::debug;
@@ -233,8 +234,8 @@ pub enum OperatorKind {
     Hosted,
 }
 
-impl std::fmt::Display for OperatorKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for OperatorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Local => "local".fmt(f),
             Self::Hosted => "hosted".fmt(f),

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -13,6 +13,7 @@ pub mod commands;
 pub mod config;
 pub(crate) mod local_operator_key;
 pub mod logging;
+pub mod outcome;
 pub mod output;
 pub mod pair;
 pub mod prompts;

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -10,6 +10,7 @@
 //! `reason` strings are an external, stable contract: kebab-case, named
 //! deliberately, never renamed after release.
 
+use crate::commands::deploy::approve::ApproveOutcome;
 use crate::commands::{app, deploy, keys, login};
 use crate::output::Message;
 use serde::{Serialize, Serializer};
@@ -22,7 +23,7 @@ use serde::{Serialize, Serializer};
 pub enum Outcome {
     Login(login::LoggedIn),
     ProfileDelete(login::ProfileDeleted),
-    DeployApprove(deploy::approve::ApproveOutcome),
+    DeployApprove(ApproveOutcome),
     DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus),
     DeployProvisioningDetails(deploy::provisioning_details::ProvisioningDetails),
     DeployPostShare(deploy::post_share::QuorumKeySharePosted),
@@ -81,23 +82,51 @@ impl Serialize for Outcome {
 }
 
 impl Message for Outcome {
+    /// The single source of truth for the reason vocabulary. Every terminal
+    /// reason string is a literal in  this one match, so uniqueness is auditable
+    /// at a glance (and, in a follow-up, enforceable by a proc-macro).
     fn reason(&self) -> &'static str {
-        with_message!(self, |msg| msg.reason())
+        match self {
+            Outcome::Login(_) => "logged-in",
+            Outcome::ProfileDelete(_) => "profile-deleted",
+            Outcome::DeployApprove(ApproveOutcome::Posted(_)) => "manifest-approval-posted",
+            Outcome::DeployApprove(ApproveOutcome::NotPosted(_)) => "manifest-approval-generated",
+            Outcome::DeployApprove(ApproveOutcome::DryRun(_)) => "manifest-approval-dry-run",
+            Outcome::DeployGetStatus(_) => "deployment-runtime-status",
+            Outcome::DeployProvisioningDetails(_) => "provisioning-details",
+            Outcome::DeployPostShare(_) => "quorum-key-share-posted",
+            Outcome::DeployStatus(_) => "deployment-status",
+            Outcome::DeployCreate(_) => "deployment-created",
+            Outcome::DeployInit(_) => "deployment-config-created",
+            Outcome::DeployDebugLogs(_) => "debug-logs-fetched",
+            Outcome::DeployDelete(_) => "deployment-deleted",
+            Outcome::DeployRestore(_) => "deployment-restored",
+            Outcome::AppStatus(_) => "app-status",
+            Outcome::AppList(_) => "apps-listed",
+            Outcome::AppCreate(_) => "app-created",
+            Outcome::AppInit(_) => "app-config-created",
+            Outcome::AppSetLiveDeploy(_) => "live-deployment-set",
+            Outcome::AppDelete(_) => "app-deleted",
+            Outcome::KeysCreateQuorumKey(_) => "quorum-key-created",
+            Outcome::KeysGenerateQuorumKey(_) => "quorum-key-generated",
+            Outcome::KeysInitQuorumKey(_) => "quorum-key-config-created",
+            Outcome::KeysReEncryptShare(_) => "re-encrypted-share-generated",
+        }
     }
 
     fn human_message(&self) -> String {
-        with_message!(self, |msg| msg.human_message())
-    }
-
-    fn to_json_string(&self) -> String {
-        with_message!(self, |msg| msg.to_json_string())
+        // Each inner payload renders itself via `Display`; the terminal outcome
+        // just delegates. An empty rendering means the outcome is machine-only.
+        with_message!(self, |msg| msg.to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::deploy::approve::ApproveOutcome;
+    use crate::commands::deploy::approve::{
+        ApprovalDryRun, ApprovalGenerated, ApprovalPosted, ApproveOutcome,
+    };
     use std::collections::HashSet;
 
     /// One zero-value instance per terminal shape, in `Outcome`'s declaration
@@ -108,15 +137,9 @@ mod tests {
         vec![
             Outcome::Login(login::LoggedIn::default()),
             Outcome::ProfileDelete(login::ProfileDeleted::default()),
-            Outcome::DeployApprove(ApproveOutcome::Posted(
-                deploy::approve::ApprovalPosted::default(),
-            )),
-            Outcome::DeployApprove(ApproveOutcome::NotPosted(
-                deploy::approve::ApprovalGenerated::default(),
-            )),
-            Outcome::DeployApprove(ApproveOutcome::DryRun(
-                deploy::approve::ApprovalDryRun::default(),
-            )),
+            Outcome::DeployApprove(ApproveOutcome::Posted(ApprovalPosted::default())),
+            Outcome::DeployApprove(ApproveOutcome::NotPosted(ApprovalGenerated::default())),
+            Outcome::DeployApprove(ApproveOutcome::DryRun(ApprovalDryRun::default())),
             Outcome::DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus::default()),
             Outcome::DeployProvisioningDetails(
                 deploy::provisioning_details::ProvisioningDetails::default(),

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -135,8 +135,12 @@ mod tests {
             Outcome::AppSetLiveDeploy(app::set_live_deploy::LiveDeploymentSet::default()),
             Outcome::AppDelete(app::delete::AppDeleted::default()),
             Outcome::KeysCreateQuorumKey(keys::create_quorum_key::QuorumKeyCreated::default()),
-            Outcome::KeysGenerateQuorumKey(keys::generate_local_quorum_key::QuorumKeyGenerated::default()),
-            Outcome::KeysInitQuorumKey(keys::init_local_quorum_key::QuorumKeyConfigCreated::default()),
+            Outcome::KeysGenerateQuorumKey(
+                keys::generate_local_quorum_key::QuorumKeyGenerated::default(),
+            ),
+            Outcome::KeysInitQuorumKey(
+                keys::init_local_quorum_key::QuorumKeyConfigCreated::default(),
+            ),
             Outcome::KeysReEncryptShare(
                 keys::re_encrypt_local_share::ReEncryptedShareGenerated::default(),
             ),

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -1,0 +1,177 @@
+//! The closed vocabulary of command outcomes.
+//!
+//! `Outcome` has exactly one variant per command, named after the command and
+//! ordered to mirror `cli.rs`'s subcommand tree, so the two can be diffed at a
+//! glance. Per-command message structs live in their own command modules; this
+//! enum only aggregates and delegates. A command with multiple terminal shapes
+//! (e.g. `deploy approve`) owns a command-local enum in its own module, and
+//! the top-level variant here wraps it.
+//!
+//! `reason` strings are an external, stable contract: kebab-case, named
+//! deliberately, never renamed after release.
+
+use crate::commands::{app, deploy, keys, login};
+use crate::output::Message;
+use serde::{Serialize, Serializer};
+
+/// One wide terminal outcome per command (the wide-event model).
+///
+/// Streaming messages (today: only `deploy debug-logs`'s per-line
+/// `debug-log-line`) are emitted inline by their command and are not part of
+/// this enum; the command still returns its terminal variant.
+pub enum Outcome {
+    Login(login::LoggedIn),
+    ProfileDelete(login::ProfileDeleted),
+    DeployApprove(deploy::approve::ApproveOutcome),
+    DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus),
+    DeployProvisioningDetails(deploy::provisioning_details::ProvisioningDetails),
+    DeployPostShare(deploy::post_share::QuorumKeySharePosted),
+    DeployStatus(deploy::status::DeploymentStatusReport),
+    DeployCreate(deploy::create::DeploymentCreated),
+    DeployInit(deploy::init::DeploymentConfigCreated),
+    DeployDebugLogs(deploy::debug_logs::DebugLogsFetched),
+    DeployDelete(deploy::delete::DeploymentDeleted),
+    DeployRestore(deploy::restore::DeploymentRestored),
+    AppStatus(app::status::AppStatusReport),
+    AppList(app::list::AppsListed),
+    AppCreate(app::create::AppCreated),
+    AppInit(app::init::AppConfigCreated),
+    AppSetLiveDeploy(app::set_live_deploy::LiveDeploymentSet),
+    AppDelete(app::delete::AppDeleted),
+    KeysCreateQuorumKey(keys::create_quorum_key::QuorumKeyCreated),
+    KeysGenerateQuorumKey(keys::generate_local_quorum_key::QuorumKeyGenerated),
+    KeysInitQuorumKey(keys::init_local_quorum_key::QuorumKeyConfigCreated),
+    KeysReEncryptShare(keys::re_encrypt_local_share::ReEncryptedShareGenerated),
+}
+
+/// Apply `$body` to the message carried by whichever variant `$self` is.
+macro_rules! with_message {
+    ($self:expr, |$msg:ident| $body:expr) => {
+        match $self {
+            Outcome::Login($msg) => $body,
+            Outcome::ProfileDelete($msg) => $body,
+            Outcome::DeployApprove($msg) => $body,
+            Outcome::DeployGetStatus($msg) => $body,
+            Outcome::DeployProvisioningDetails($msg) => $body,
+            Outcome::DeployPostShare($msg) => $body,
+            Outcome::DeployStatus($msg) => $body,
+            Outcome::DeployCreate($msg) => $body,
+            Outcome::DeployInit($msg) => $body,
+            Outcome::DeployDebugLogs($msg) => $body,
+            Outcome::DeployDelete($msg) => $body,
+            Outcome::DeployRestore($msg) => $body,
+            Outcome::AppStatus($msg) => $body,
+            Outcome::AppList($msg) => $body,
+            Outcome::AppCreate($msg) => $body,
+            Outcome::AppInit($msg) => $body,
+            Outcome::AppSetLiveDeploy($msg) => $body,
+            Outcome::AppDelete($msg) => $body,
+            Outcome::KeysCreateQuorumKey($msg) => $body,
+            Outcome::KeysGenerateQuorumKey($msg) => $body,
+            Outcome::KeysInitQuorumKey($msg) => $body,
+            Outcome::KeysReEncryptShare($msg) => $body,
+        }
+    };
+}
+
+impl Serialize for Outcome {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        with_message!(self, |msg| msg.serialize(serializer))
+    }
+}
+
+impl Message for Outcome {
+    fn reason(&self) -> &'static str {
+        with_message!(self, |msg| msg.reason())
+    }
+
+    fn human_message(&self) -> String {
+        with_message!(self, |msg| msg.human_message())
+    }
+
+    fn to_json_string(&self) -> String {
+        with_message!(self, |msg| msg.to_json_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::deploy::approve::ApproveOutcome;
+    use std::collections::HashSet;
+
+    /// One zero-value instance per terminal shape, in `Outcome`'s declaration
+    /// order (command-local shapes expanded in their own declaration order).
+    /// The registry tests only read reason strings, so `Default` fixtures
+    /// suffice; realistic payloads are exercised by each command's own tests.
+    fn all_terminal_shapes() -> Vec<Outcome> {
+        vec![
+            Outcome::Login(login::LoggedIn::default()),
+            Outcome::ProfileDelete(login::ProfileDeleted::default()),
+            Outcome::DeployApprove(ApproveOutcome::Posted(
+                deploy::approve::ApprovalPosted::default(),
+            )),
+            Outcome::DeployApprove(ApproveOutcome::NotPosted(
+                deploy::approve::ApprovalGenerated::default(),
+            )),
+            Outcome::DeployApprove(ApproveOutcome::DryRun(
+                deploy::approve::ApprovalDryRun::default(),
+            )),
+            Outcome::DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus::default()),
+            Outcome::DeployProvisioningDetails(
+                deploy::provisioning_details::ProvisioningDetails::default(),
+            ),
+            Outcome::DeployPostShare(deploy::post_share::QuorumKeySharePosted::default()),
+            Outcome::DeployStatus(deploy::status::DeploymentStatusReport::default()),
+            Outcome::DeployCreate(deploy::create::DeploymentCreated::default()),
+            Outcome::DeployInit(deploy::init::DeploymentConfigCreated::default()),
+            Outcome::DeployDebugLogs(deploy::debug_logs::DebugLogsFetched::default()),
+            Outcome::DeployDelete(deploy::delete::DeploymentDeleted::default()),
+            Outcome::DeployRestore(deploy::restore::DeploymentRestored::default()),
+            Outcome::AppStatus(app::status::AppStatusReport::default()),
+            Outcome::AppList(app::list::AppsListed::default()),
+            Outcome::AppCreate(app::create::AppCreated::default()),
+            Outcome::AppInit(app::init::AppConfigCreated::default()),
+            Outcome::AppSetLiveDeploy(app::set_live_deploy::LiveDeploymentSet::default()),
+            Outcome::AppDelete(app::delete::AppDeleted::default()),
+            Outcome::KeysCreateQuorumKey(keys::create_quorum_key::QuorumKeyCreated::default()),
+            Outcome::KeysGenerateQuorumKey(keys::generate_local_quorum_key::QuorumKeyGenerated::default()),
+            Outcome::KeysInitQuorumKey(keys::init_local_quorum_key::QuorumKeyConfigCreated::default()),
+            Outcome::KeysReEncryptShare(
+                keys::re_encrypt_local_share::ReEncryptedShareGenerated::default(),
+            ),
+        ]
+    }
+
+    /// Reasons that live outside `Outcome`: the `deploy debug-logs` streaming
+    /// message and the error envelope reasons from `output.rs`.
+    const NON_TERMINAL_REASONS: [&str; 3] =
+        ["debug-log-line", "command-error", "missing-required-input"];
+
+    // TODO - proc macro here
+    #[test]
+    fn all_reasons_are_unique() {
+        let mut reasons: Vec<&str> = all_terminal_shapes().iter().map(Message::reason).collect();
+        reasons.extend(NON_TERMINAL_REASONS);
+
+        let unique: HashSet<&str> = reasons.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            reasons.len(),
+            "duplicate reason strings in: {reasons:?}"
+        );
+    }
+
+    #[test]
+    fn reasons_are_kebab_case() {
+        for outcome in all_terminal_shapes() {
+            let reason = outcome.reason();
+            assert!(
+                reason
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "reason `{reason}` is not kebab-case"
+            );
+        }
+    }
+}

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -93,9 +93,20 @@ impl<W, W2> Shell<W, W2> {
 }
 
 impl<W: Write, W2: Write> Shell<W, W2> {
+    /// Emit a machine-consumable message: one JSON line in JSON mode, or the
+    /// message's `human_message()` in human mode.
+    ///
+    /// An empty `human_message()` means the outcome is machine-only; human
+    /// mode prints nothing (JSON mode still emits the message).
     pub fn emit<M: Message>(&mut self, message: &M) -> Result<()> {
         match self.message_format {
-            MessageFormat::Human => self.human().line(message.human_message()),
+            MessageFormat::Human => {
+                let text = message.human_message();
+                if text.is_empty() {
+                    return Ok(());
+                }
+                self.human().line(text)
+            }
             MessageFormat::Json => {
                 writeln!(self.stdout, "{}", message.to_json_string())?;
                 Ok(())
@@ -392,6 +403,44 @@ mod tests {
         shell.emit(&TestMessage { value: "ok" }).unwrap();
 
         assert_eq!(shell.into_stdout(), "value: ok\n".as_bytes());
+    }
+
+    #[derive(Serialize)]
+    struct MachineOnlyMessage {
+        value: &'static str,
+    }
+
+    impl Message for MachineOnlyMessage {
+        fn reason(&self) -> &'static str {
+            "machine-only-message"
+        }
+
+        fn human_message(&self) -> String {
+            String::new()
+        }
+    }
+
+    #[test]
+    fn shell_emit_human_skips_empty_human_message() {
+        let mut shell = TestShell::with_human_formatter();
+
+        shell.emit(&MachineOnlyMessage { value: "ok" }).unwrap();
+
+        let output = String::from_utf8(shell.into_stdout()).unwrap();
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn shell_emit_json_still_emits_message_with_empty_human_message() {
+        let mut shell = TestShell::with_json_formatter();
+
+        shell.emit(&MachineOnlyMessage { value: "ok" }).unwrap();
+
+        let output = String::from_utf8(shell.into_stdout()).unwrap();
+        assert_eq!(
+            output,
+            concat!(r#"{"reason":"machine-only-message","value":"ok"}"#, "\n")
+        );
     }
 
     #[test]

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use clap::ValueEnum;
 use serde::Serialize;
 use std::error::Error;
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Formatter};
 use std::io::{self, IsTerminal, Stderr, Stdout, Write};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -282,7 +282,7 @@ impl MissingRequiredInput {
 }
 
 impl Display for MissingRequiredInput {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
     }
 }

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -1,6 +1,7 @@
 use crate::util::read_file_to_string;
 use anyhow::anyhow;
 use qos_p256::P256Pair;
+use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
@@ -43,8 +44,8 @@ impl FromStr for HexSeed {
 }
 
 // The seed must never reach debug output, so the derive is off the table.
-impl std::fmt::Debug for HexSeed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for HexSeed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("HexSeed(..)")
     }
 }

--- a/tvc/tests/keys_generate_local_quorum_key.rs
+++ b/tvc/tests/keys_generate_local_quorum_key.rs
@@ -127,6 +127,51 @@ fn generate_local_quorum_key_rejects_invalid_config() {
 }
 
 #[test]
+fn generate_local_quorum_key_json_output_emits_structured_message() {
+    let temp = TempDir::new().unwrap();
+    let config_path = temp.path().join("quorum_key.json");
+    let metadata_path = temp.path().join("quorum_key_metadata.json");
+
+    let operator_public_keys = (0..2)
+        .map(|_| hex::encode(P256Pair::generate().unwrap().public_key().to_bytes()))
+        .collect::<Vec<_>>();
+
+    fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&json!({
+            "shares": 2,
+            "threshold": 2,
+            "operatorPublicKeys": operator_public_keys,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let assert = cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("--message-format=json")
+        .arg("keys")
+        .arg("generate-local-quorum-key")
+        .arg("--config-file")
+        .arg(&config_path)
+        .arg("--quorum-key-metadata-out")
+        .arg(&metadata_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Quorum Public Key:").not());
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected one JSON message, got {stdout:?}");
+
+    let message: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(message["reason"], "quorum-key-generated");
+    assert_eq!(message["threshold"], 2);
+    assert_eq!(message["metadataPath"], metadata_path.display().to_string());
+    assert!(message["quorumKeyPublic"].is_string());
+}
+
+#[test]
 fn keys_help_lists_local_quorum_key_commands_only() {
     cargo_bin_cmd!("tvc")
         .arg("keys")

--- a/tvc/tests/message_format.rs
+++ b/tvc/tests/message_format.rs
@@ -20,7 +20,7 @@ fn deploy_init_defaults_to_human_output() {
         .stdout(predicate::str::contains(
             "Created deployment config template:",
         ))
-        .stdout(predicate::str::contains("\"reason\"").not());
+        .stdout(predicate::str::contains(r#""reason""#).not());
 }
 
 #[test]
@@ -50,6 +50,65 @@ fn deploy_init_json_output_emits_structured_message() {
     assert_eq!(message["path"], output.display().to_string());
     assert_eq!(message["template"], true);
     assert_eq!(message["interactive"], false);
+    // camelCase payload keys are part of the contract (a blank template keeps
+    // the pull-secret placeholder, so needsPullSecret is true).
+    assert_eq!(message["fromDeployment"], false);
+    assert_eq!(message["needsPullSecret"], true);
+}
+
+#[test]
+fn app_init_json_output_emits_structured_message() {
+    let temp = TempDir::new().unwrap();
+    let output = temp.path().join("app.json");
+
+    let assert = cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .current_dir(temp.path())
+        .arg("--message-format=json")
+        .arg("app")
+        .arg("init")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created app config template:").not());
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected one JSON message, got {stdout:?}");
+
+    let message: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(message["reason"], "app-config-created");
+    assert_eq!(message["command"], "app init");
+    assert_eq!(message["path"], output.display().to_string());
+    assert_eq!(message["template"], true);
+    assert_eq!(message["interactive"], false);
+}
+
+#[test]
+fn keys_init_local_quorum_key_json_output_emits_structured_message() {
+    let temp = TempDir::new().unwrap();
+    let output = temp.path().join("quorum_key.json");
+
+    let assert = cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .current_dir(temp.path())
+        .arg("--message-format=json")
+        .arg("keys")
+        .arg("init-local-quorum-key")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created quorum key config template:").not());
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected one JSON message, got {stdout:?}");
+
+    let message: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(message["reason"], "quorum-key-config-created");
+    assert_eq!(message["path"], output.display().to_string());
 }
 
 #[test]

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -61,7 +61,7 @@ fn approve_walks_all_sections_with_yeses() {
     session.send_line("y").unwrap();
 
     session.exp_string("ALL SECTIONS APPROVED").unwrap();
-    session.exp_string("\"signature\"").unwrap();
+    session.exp_string(r#""signature""#).unwrap();
     session.exp_eof().unwrap();
 }
 


### PR DESCRIPTION
## TVC-116 (part 2): every command emits a typed Outcome

Builds on #170 (merged) and is rebased onto current `main` — including #190's `StdCtx` cleanup and the operator/hosted-key refactors (versioned operator registry, the `local_*` key-command renames, and `keys create-quorum-key`). Command entry points take `&mut StdCtx` and return a typed result that the CLI emits centrally.

### What this adds

Before this work, most commands succeeded **silently** in `--message-format=json` — e.g. `tvc app init --message-format=json` wrote the file, printed nothing, exited 0. Now every command emits a typed, tagged outcome.

- **`Outcome` enum** (`src/outcome.rs`): one variant per command, ordered to mirror the CLI tree. Every command's `run()` returns `Result<Outcome>`, so a command with no outcome doesn't compile. `cli.rs` emits it centrally, symmetric with the existing error path. On success the CLI fails open — if writing the outcome fails (e.g. a broken pipe into `jq`), it warns on stderr but still exits `0`, since the operation already succeeded.
- **Envelope/payload split**: per-command payload structs implement `Display` (human rendering) + `Serialize` (JSON fields) only. `Message` — the "emittable" trait — is implemented **solely** by the top-level envelopes: `Outcome` (terminal), `DebugLogLine` (streaming), and the error types. A bare payload therefore can't be emitted; it must be wrapped in an `Outcome`. `Outcome::reason()` is one explicit match — the single source of truth for the reason vocabulary (24 terminal reasons, plus the `debug-log-line` streaming reason and 2 error reasons).
- **Wide-event model**: success = exactly one tagged JSON line on stdout (`json.loads(stdout)` always works). Sole exception: `deploy debug-logs` streams NDJSON `debug-log-line` messages — which also fixes it previously printing *nothing* in JSON mode, including the log lines themselves.
- **`keys create-quorum-key`** (new on `main`) is wired into the `Outcome` model like every other command.
- **Contract fix**: `deployment-config-created` emits `fromDeployment`/`needsPullSecret` (camelCase).
- **Tests**: reason uniqueness + kebab-case checks; XOR-branch serialization tests for the multi-shape `deploy approve` payloads; and human-output goldens that lock the existing human rendering byte-for-byte. (Moving reason-uniqueness to compile-time enforcement via a proc-macro is tracked as a follow-up, TVC-207.)
- **Conventions**: message DTOs derive `Default` (4 `ActivityStatus`-bearing structs need manual impls — the generated enum lacks `Default` upstream); each file's tests live in its single `mod tests` (no `#[cfg(test)]` scatter in `src`).
- **Repo guidance**: `tvc/AGENTS.md` (with a `tvc/CLAUDE.md` symlink) codifies the conventions used here — raw string literals for multi-line output, prefer moving over cloning, exhaustive destructuring of generated types, and short `use` imports over fully-qualified paths.

> An earlier revision of this PR also added a `tvc schema` command (plus a `schemars` dependency and a schema-catalog snapshot test). That has been dropped — the approach was poorly fitted, and machine-readable self-onboarding is better served by a future `mcp serve`.

### Samples

```console
$ tvc app init --output app.json --message-format=json     # was silent before this PR
{"reason":"app-config-created","command":"app init","path":"app.json","template":true,"interactive":false}
```

```console
$ tvc deploy approve --deploy-id deploy-123 --operator-id operator-456 --dangerous-skip-interactive --message-format=json
{"reason":"manifest-approval-posted","approval":{"signature":"30440220...","member":{"alias":"operator-primary","pubKey":"04ab..."}},"manifestId":"manifest-789","operatorId":"operator-456","approvalIds":["approval-abc"],"quorumReached":true}
```

The posted outcome identifies the manifest and operator, returns the approval IDs created by the API, and reports whether the deployment's manifest-approval quorum is now satisfied. Without `--approval-out` it also includes the signed approval inline; with `--approval-out approval.json`, that payload is replaced by `"writtenTo":"approval.json"`.

## Reviews packet

For structured review: https://reviews.figitaki.dev/r/lYghULlT