### PR TITLE
feat(tvc): validate app-id at deploy create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,7 @@ dependencies = [
  "turnkey_api_key_stamper",
  "turnkey_client",
  "turnkey_enclave_encrypt",
+ "uuid",
  "zeroize",
 ]
 
@@ -4288,6 +4289,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ qos_p256 = { version = "0.12.1", default-features = false }
 base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 bs58 = { version = "0.5.0", features = ["std", "check"], default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
+uuid = { version = "1.13.1", default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
 serde_bytes = { version = "0.11", default-features = false }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
+uuid = { workspace = true }
 zeroize = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -1,7 +1,7 @@
 //! Deploy create command - creates a deployment from a config file or CLI flags.
 
 use super::format_port_summary;
-use crate::client::build_client;
+use crate::client::{build_client, fetch_tvc_app};
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
 use crate::prompts;
@@ -372,6 +372,9 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
 
     let auth = build_client().await?;
 
+    // validate that the app exists
+    fetch_tvc_app(&auth, &deploy_config.app_id).await?;
+
     let pivot_container_encrypted_pull_secret = match inputs.pivot_pull_secret.as_ref() {
         Some(pull_secret) => Some(encrypt_pivot_pull_secret(pull_secret, &auth.api_base_url)?),
         None => deploy_config.pivot_container_encrypted_pull_secret.clone(),
@@ -443,6 +446,10 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    // App IDs are validated as UUIDs, so test fixtures must use well-formed ones.
+    const FLAG_APP_ID: &str = "11111111-1111-1111-1111-111111111111";
+    const FILE_APP_ID: &str = "22222222-2222-2222-2222-222222222222";
+
     #[test]
     fn pin_image_url_appends_digest_to_tagged_reference() {
         let pinned = pin_image_url("ghcr.io/team/app:latest", "sha256:abc123");
@@ -457,7 +464,7 @@ mod tests {
 
     fn all_required_flags() -> Args {
         let overrides = Overrides {
-            app_id: Some("flag-app-id".into()),
+            app_id: Some(FLAG_APP_ID.into()),
             qos_version: Some("flag-qos".into()),
             pivot_image_url: Some("flag-image".into()),
             expected_pivot_digest: Some("flag-digest".into()),
@@ -473,7 +480,7 @@ mod tests {
 
     fn file_config() -> DeployConfig {
         let mut c = DeployConfig::template(None);
-        c.app_id = "file-app-id".into();
+        c.app_id = FILE_APP_ID.into();
         c.qos_version = "file-qos".into();
         c.pivot_container_image_url = "file-image".into();
         c.pivot_path = "file-path".into();
@@ -520,7 +527,7 @@ mod tests {
     fn flag_overrides_file_value() {
         let file = write_config(&file_config());
         let overrides = Overrides {
-            app_id: Some("flag-app-id".into()),
+            app_id: Some(FLAG_APP_ID.into()),
             ..Default::default()
         };
         let args = Args {
@@ -529,7 +536,7 @@ mod tests {
             ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, "flag-app-id");
+        assert_eq!(resolved.app_id, FLAG_APP_ID);
         // Untouched fields keep their file values.
         assert_eq!(resolved.qos_version, "file-qos");
         assert_eq!(resolved.health_check_port, 4000);
@@ -543,7 +550,7 @@ mod tests {
             ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, "file-app-id");
+        assert_eq!(resolved.app_id, FILE_APP_ID);
         assert_eq!(resolved.qos_version, "file-qos");
         assert_eq!(resolved.health_check_port, 4000);
     }
@@ -552,7 +559,7 @@ mod tests {
     fn no_file_uses_flag_only_with_template_defaults() {
         let resolved = run_resolve(&all_required_flags()).unwrap();
         // Required fields come from flags.
-        assert_eq!(resolved.app_id, "flag-app-id");
+        assert_eq!(resolved.app_id, FLAG_APP_ID);
         assert_eq!(resolved.qos_version, "flag-qos");
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");
@@ -759,7 +766,7 @@ mod tests {
         };
 
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, "flag-app-id");
+        assert_eq!(resolved.app_id, FLAG_APP_ID);
         assert_eq!(resolved.qos_version, "flag-qos");
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -10,6 +10,7 @@ use turnkey_client::generated::{
     external::data::v1::{TvcContainerSpec, TvcDeployment},
     immutable::common::v1::TvcHealthCheckType,
 };
+use uuid::Uuid;
 
 /// Sentinel written by `tvc deploy init` to remind the user to either remove
 /// the field (public image) or replace it with an encrypted pull secret
@@ -207,6 +208,10 @@ impl DeployConfig {
                 field: "app_id",
                 placeholder: self.app_id.clone(),
             });
+        } else if Uuid::try_parse(&self.app_id).is_err() {
+            errors.push(DeployConfigValidationError::InvalidAppId {
+                value: self.app_id.clone(),
+            });
         }
         if self.qos_version.starts_with("<FILL_IN") {
             errors.push(DeployConfigValidationError::Placeholder {
@@ -249,6 +254,8 @@ pub enum DeployConfigValidationError {
         field: &'static str,
         placeholder: String,
     },
+    #[error("app_id is not a valid UUID: {value}")]
+    InvalidAppId { value: String },
     #[error(
         "pivotContainerEncryptedPullSecret contains placeholder value {placeholder}; pass \
          --pivot-pull-secret <PATH> or remove pivotContainerEncryptedPullSecret for public images"
@@ -474,12 +481,62 @@ mod tests {
     #[test]
     fn fully_filled_config_has_no_placeholders() {
         let mut config = DeployConfig::template(None);
-        config.app_id = "app_123".into();
+        config.app_id = "651b573c-861b-4f10-a478-cbcfe0c226af".into();
         config.qos_version = "0.6.1".into();
         config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
         config.pivot_path = "/bin/pivot".into();
         config.expected_pivot_digest = "sha256:abc".into();
         config.pivot_container_encrypted_pull_secret = None;
         assert!(!config.has_placeholders());
+    }
+
+    /// Build a config with every required field filled by a valid (non-placeholder)
+    /// value, so `validate()` returns `Ok` unless a test perturbs one field.
+    fn valid_config() -> DeployConfig {
+        let mut config = DeployConfig::template(None);
+        config.app_id = "651b573c-861b-4f10-a478-cbcfe0c226af".into();
+        config.qos_version = "0.6.1".into();
+        config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
+        config.pivot_path = "/bin/pivot".into();
+        config.expected_pivot_digest = "sha256:abc".into();
+        config.pivot_container_encrypted_pull_secret = None;
+        config
+    }
+
+    #[test]
+    fn validate_rejects_non_uuid_app_id() {
+        let mut config = valid_config();
+        config.app_id = "not-a-uuid".into();
+        let errors = config.validate().unwrap_err();
+        assert!(errors.to_string().contains("not a valid UUID"), "{errors}");
+        // A malformed app_id is a hard error, so interactive mode bails instead
+        // of prompting the user to "fill in" an already-present value.
+        assert!(errors.has_non_placeholder_error());
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_uuid() {
+        // Turnkey resource IDs come in both UUID v4 and v7 forms; accept either.
+        for app_id in [
+            "651b573c-861b-4f10-a478-cbcfe0c226af", // v4
+            "019660f7-801d-75d8-a40e-e4f69944b711", // v7
+        ] {
+            let mut config = valid_config();
+            config.app_id = app_id.into();
+            assert!(config.validate().is_ok(), "should accept {app_id}");
+        }
+    }
+
+    /// The placeholder branch takes precedence over the UUID check, so an
+    /// unfilled `<FILL_IN_APP_ID>` is reported as a placeholder (which interactive
+    /// mode prompts to fill), not as an "invalid UUID" hard error.
+    #[test]
+    fn validate_reports_placeholder_app_id_as_placeholder() {
+        let config = DeployConfig::template(None);
+        let errors = config.validate().unwrap_err();
+        let msg = errors.to_string();
+        assert!(msg.contains("placeholder"), "{msg}");
+        assert!(!msg.contains("not a valid UUID"), "{msg}");
+        assert!(!errors.has_non_placeholder_error());
     }
 }


### PR DESCRIPTION
## Summary

Validate `app-id` at `tvc deploy create` so a leftover placeholder or a wrong/nonexistent app UUID fails fast instead of creating a deployment that can't be approved.

## What it does

- Rejects a malformed `app-id` (not a well-formed UUID) before sending, in `DeployConfig::validate()`. Accepts any UUID version since Turnkey IDs mix v4 and v7.
- Verifies the app exists via `get_tvc_app` before creating the deployment; errors with `app not found: <id>`.

The `<FILL_IN_APP_ID>` placeholder was already rejected by `validate()`. Server-side validation lives in `tkhq/mono` and is out of scope here.

Closes [ENG-4459](https://linear.app/turnkey/issue/ENG-4459/validate-app-id-at-tvc-deploy-create-reject-placeholder-nonexistent)
