### PR TITLE
Remove generics that aren't necessary

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI parsing and dispatch.
 
 use crate::commands;
-use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell};
+use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell, StdCtx};
 use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser};
 use std::io::Write;
 use std::process::ExitCode;
@@ -104,7 +104,7 @@ impl Cli {
 }
 
 impl Commands {
-    async fn run<W: Write>(self, ctx: &mut Ctx<W>) -> anyhow::Result<()> {
+    async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<()> {
         match self {
             Commands::Deploy { command } => match command {
                 DeployCommands::Approve(args) => commands::deploy::approve::run(ctx, args).await,

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -6,12 +6,11 @@ use crate::{
         app::{AppConfig, AppConfigValidationErrors, OperatorSetParams},
         turnkey::{self, StoredQosOperatorKey},
     },
-    output::Ctx,
+    output::StdCtx,
     prompts, shell_println,
 };
 use anyhow::{Context, Result, anyhow};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperatorSetParams};
@@ -40,7 +39,7 @@ struct Overrides {
     pub dangerous_enable_debug_mode_deployments: bool,
 }
 
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let config = if ctx.is_non_interactive() {
         build_app_config_non_interactive(&args).await?
     } else {
@@ -51,10 +50,7 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
     run_with_config(ctx, args, app_config).await
 }
 
-async fn build_app_config_interactive<W: Write>(
-    ctx: &mut Ctx<W>,
-    args: &Args,
-) -> Result<AppConfig> {
+async fn build_app_config_interactive(ctx: &mut StdCtx, args: &Args) -> Result<AppConfig> {
     let mut config = match read_app_config_file_bytes(&args.config_file).await {
         Ok(bytes) => parse_app_config(&bytes, &args.config_file)?,
         Err(_) => AppConfig::template(None),
@@ -108,11 +104,7 @@ fn invalid_app_config_error(path: &Path, errors: AppConfigValidationErrors) -> a
     anyhow!("invalid config file: {}: {}", path.display(), errors)
 }
 
-fn offer_to_save_app_config<W: Write>(
-    ctx: &mut Ctx<W>,
-    path: &Path,
-    config: &AppConfig,
-) -> Result<()> {
+fn offer_to_save_app_config(ctx: &mut StdCtx, path: &Path, config: &AppConfig) -> Result<()> {
     let save = prompts::confirm(&format!("Save filled config to {}?", path.display()), true)?;
     if save {
         let json = serde_json::to_string_pretty(config).context("failed to serialize config")?;
@@ -132,11 +124,7 @@ async fn load_saved_operator_public_key() -> Option<String> {
     Some(operator_key.public_key)
 }
 
-async fn run_with_config<W: Write>(
-    ctx: &mut Ctx<W>,
-    args: Args,
-    app_config: AppConfig,
-) -> Result<()> {
+async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) -> Result<()> {
     shell_println!(ctx, "Creating app '{}'...", app_config.name)?;
 
     let auth = build_client().await?;

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -1,11 +1,10 @@
 //! App delete command - marks an app and all deployments for deletion.
 
 use crate::client::build_client;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::DeleteTvcAppAndDeploymentsIntent;
 
@@ -19,7 +18,7 @@ pub struct Args {
 }
 
 /// Run the app delete command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcAppAndDeploymentsIntent {

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -2,12 +2,11 @@
 
 use crate::config::app::AppConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
 use crate::shell_println;
 use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::path::PathBuf;
 
 /// Generate a template app configuration file.
@@ -31,7 +30,7 @@ pub struct Args {
 }
 
 /// Run the app init command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -42,7 +41,7 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
     execute(ctx, args).await
 }
 
-async fn execute<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
     // Check if file already exists
     if args.output.exists() {
         bail!("File already exists: {}", args.output.display());

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -2,12 +2,11 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
-use std::io::Write;
 use turnkey_client::generated::GetTvcAppsRequest;
 use turnkey_client::generated::external::data::v1::TvcApp;
 
 use crate::commands::display::format_egress_enabled;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 
 const SEPARATOR_WIDTH: usize = 40;
@@ -22,7 +21,7 @@ pub struct Args {
 }
 
 /// Run the app list command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let response = auth
@@ -55,7 +54,7 @@ fn filter_by_name(apps: &mut Vec<TvcApp>, name: Option<&str>) {
     }
 }
 
-fn render_app<W: Write>(ctx: &mut Ctx<W>, app: &TvcApp) -> anyhow::Result<()> {
+fn render_app(ctx: &mut StdCtx, app: &TvcApp) -> anyhow::Result<()> {
     let live = app.live_deployment_id.as_deref().unwrap_or("(none)");
     let mut lines = vec![
         format!("Name: {}", app.name),

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -1,11 +1,10 @@
 //! App set-live-deploy command.
 
 use crate::client::build_client;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::UpdateTvcAppLiveDeploymentIntent;
 
@@ -19,7 +18,7 @@ pub struct Args {
 }
 
 /// Run the app set-live-deploy command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let auth = build_client().await?;
 
     let intent = UpdateTvcAppLiveDeploymentIntent {

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -2,13 +2,12 @@
 
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use turnkey_client::generated::GetAppStatusRequest;
 
 use crate::client::fetch_tvc_app;
 use crate::commands::app_status::{format_replica_status, sanitize_app_status};
 use crate::commands::display::format_egress_enabled;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 
 /// Get the live status of an app from the cluster.
@@ -21,7 +20,7 @@ pub struct Args {
 }
 
 /// Run the app status command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let request = GetAppStatusRequest {

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -2,7 +2,7 @@
 
 use crate::config::turnkey::Config;
 use crate::operator_key::{OperatorSeedSource, load_operator_pair};
-use crate::output::{Ctx, Message};
+use crate::output::{Message, StdCtx};
 use crate::pair::HexSeed;
 use crate::prompts;
 use crate::prompts::{bail_required_in_non_interactive, stdin_can_prompt};
@@ -17,7 +17,6 @@ use qos_core::protocol::services::boot::{
 use serde::Serialize;
 use std::collections::HashSet;
 use std::fmt::Write;
-use std::io::Write as IoWrite;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -120,7 +119,7 @@ struct ResolvedApproveInputs {
     post_target: Option<PostTarget>,
 }
 
-pub async fn run<W: IoWrite>(ctx: &mut Ctx<W>, mut args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, mut args: Args) -> anyhow::Result<()> {
     let operator_seed_source =
         OperatorSeedSource::from_args(args.operator_seed.take(), args.operator_seed_path.take())?;
 
@@ -133,8 +132,8 @@ pub async fn run<W: IoWrite>(ctx: &mut Ctx<W>, mut args: Args) -> anyhow::Result
     run_with_resolved_inputs(ctx, inputs).await
 }
 
-async fn build_inputs_interactive<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn build_inputs_interactive(
+    ctx: &mut StdCtx,
     args: Args,
     operator_seed_source: Option<OperatorSeedSource>,
 ) -> anyhow::Result<ResolvedApproveInputs> {
@@ -194,8 +193,8 @@ async fn build_inputs_interactive<W: IoWrite>(
     })
 }
 
-async fn build_inputs_non_interactive<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn build_inputs_non_interactive(
+    ctx: &mut StdCtx,
     args: Args,
     operator_seed_source: Option<OperatorSeedSource>,
 ) -> anyhow::Result<ResolvedApproveInputs> {
@@ -242,8 +241,8 @@ async fn build_inputs_non_interactive<W: IoWrite>(
     })
 }
 
-async fn run_with_resolved_inputs<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn run_with_resolved_inputs(
+    ctx: &mut StdCtx,
     inputs: ResolvedApproveInputs,
 ) -> anyhow::Result<()> {
     if inputs.dry_run {
@@ -271,8 +270,8 @@ async fn run_with_resolved_inputs<W: IoWrite>(
     Ok(())
 }
 
-async fn load_manifest<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn load_manifest(
+    ctx: &mut StdCtx,
     args: &Args,
 ) -> anyhow::Result<(VersionedManifest, Option<String>)> {
     match (&args.manifest, &args.deploy_id) {
@@ -285,8 +284,8 @@ async fn load_manifest<W: IoWrite>(
     }
 }
 
-async fn sign_and_output<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn sign_and_output(
+    ctx: &mut StdCtx,
     operator_seed_source: Option<OperatorSeedSource>,
     approval_out: Option<&Path>,
     manifest: &VersionedManifest,
@@ -346,8 +345,8 @@ async fn load_saved_operator_ids() -> anyhow::Result<Vec<String>> {
     Ok(config.get_last_operator_ids().unwrap_or_default())
 }
 
-async fn post_approval_to_api<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn post_approval_to_api(
+    ctx: &mut StdCtx,
     plan: PostApprovalPlan<'_>,
     approval: &Approval,
 ) -> anyhow::Result<()> {
@@ -469,10 +468,7 @@ async fn generate_approval(
 }
 
 /// Walk the user through each section of the manifest for approval.
-fn interactive_approve<W: IoWrite>(
-    ctx: &mut Ctx<W>,
-    manifest: &VersionedManifest,
-) -> anyhow::Result<()> {
+fn interactive_approve(ctx: &mut StdCtx, manifest: &VersionedManifest) -> anyhow::Result<()> {
     shell_println!(ctx, "\n========================================")?;
     shell_println!(ctx, "         MANIFEST APPROVAL")?;
     shell_println!(ctx, "========================================\n")?;
@@ -501,7 +497,7 @@ fn render_namespace(namespace: &Namespace) -> String {
     s
 }
 
-fn review_namespace<W: IoWrite>(ctx: &mut Ctx<W>, namespace: &Namespace) -> anyhow::Result<()> {
+fn review_namespace(ctx: &mut StdCtx, namespace: &Namespace) -> anyhow::Result<()> {
     shell_print!(ctx, "{}", render_namespace(namespace))?;
     prompts::confirm_or_bail("Approve namespace?", "approval")
 }
@@ -519,7 +515,7 @@ fn render_enclave(enclave: &NitroConfig) -> String {
     s
 }
 
-fn review_enclave<W: IoWrite>(ctx: &mut Ctx<W>, enclave: &NitroConfig) -> anyhow::Result<()> {
+fn review_enclave(ctx: &mut StdCtx, enclave: &NitroConfig) -> anyhow::Result<()> {
     shell_print!(ctx, "{}", render_enclave(enclave))?;
     prompts::confirm_or_bail("Approve enclave configuration?", "approval")
 }
@@ -542,7 +538,7 @@ fn render_pivot(manifest: &VersionedManifest) -> String {
     s
 }
 
-fn review_pivot<W: IoWrite>(ctx: &mut Ctx<W>, manifest: &VersionedManifest) -> anyhow::Result<()> {
+fn review_pivot(ctx: &mut StdCtx, manifest: &VersionedManifest) -> anyhow::Result<()> {
     shell_print!(ctx, "{}", render_pivot(manifest))?;
     prompts::confirm_or_bail("Approve pivot binary?", "approval")
 }
@@ -566,7 +562,7 @@ fn render_manifest_set(set: &ManifestSet) -> String {
     s
 }
 
-fn review_manifest_set<W: IoWrite>(ctx: &mut Ctx<W>, set: &ManifestSet) -> anyhow::Result<()> {
+fn review_manifest_set(ctx: &mut StdCtx, set: &ManifestSet) -> anyhow::Result<()> {
     shell_print!(ctx, "{}", render_manifest_set(set))?;
     prompts::confirm_or_bail("Approve manifest set?", "approval")
 }
@@ -582,7 +578,7 @@ fn render_share_set(set: &ShareSet) -> String {
     s
 }
 
-fn review_share_set<W: IoWrite>(ctx: &mut Ctx<W>, set: &ShareSet) -> anyhow::Result<()> {
+fn review_share_set(ctx: &mut StdCtx, set: &ShareSet) -> anyhow::Result<()> {
     shell_print!(ctx, "{}", render_share_set(set))?;
     prompts::confirm_or_bail("Approve share set?", "approval")
 }
@@ -596,8 +592,8 @@ async fn read_manifest_from_path(path: &Path) -> anyhow::Result<VersionedManifes
 
 /// Fetch manifest from Turnkey using GetTvcDeployment API.
 /// Returns the manifest and its Turnkey manifest_id.
-async fn fetch_manifest_from_deploy<W: IoWrite>(
-    ctx: &mut Ctx<W>,
+async fn fetch_manifest_from_deploy(
+    ctx: &mut StdCtx,
     deploy_id: &str,
 ) -> anyhow::Result<(VersionedManifest, String)> {
     shell_println!(ctx, "Fetching deployment {deploy_id}...")?;

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -4,13 +4,12 @@ use super::format_port_summary;
 use crate::client::{build_client, fetch_tvc_app};
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::prompts;
 use crate::pull_secret::encrypt_pivot_pull_secret;
 use crate::shell_println;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
@@ -147,7 +146,7 @@ struct ResolvedDeployInputs {
     pivot_pull_secret: Option<String>,
 }
 
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let inputs = if ctx.is_non_interactive() {
         build_inputs_non_interactive(args).await?
     } else {
@@ -157,10 +156,7 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
     run_with_resolved_inputs(ctx, inputs).await
 }
 
-async fn build_inputs_interactive<W: Write>(
-    ctx: &mut Ctx<W>,
-    args: Args,
-) -> Result<ResolvedDeployInputs> {
+async fn build_inputs_interactive(ctx: &mut StdCtx, args: Args) -> Result<ResolvedDeployInputs> {
     let Args {
         config_file: config_path,
         pivot_pull_secret,
@@ -313,8 +309,8 @@ fn invalid_deploy_config_error(errors: DeployConfigValidationErrors) -> anyhow::
 /// Ask the user whether to write the updated config back to disk.
 /// `file_loaded` distinguishes "saving over an existing file" from
 /// "creating a new file at this path" in the prompt wording.
-fn offer_to_save_config<W: Write>(
-    ctx: &mut Ctx<W>,
+fn offer_to_save_config(
+    ctx: &mut StdCtx,
     path: &Path,
     config: &DeployConfig,
     file_loaded: bool,
@@ -374,10 +370,7 @@ fn pin_image_url(image_url: &str, resolved_digest: &str) -> String {
     }
 }
 
-async fn run_with_resolved_inputs<W: Write>(
-    ctx: &mut Ctx<W>,
-    inputs: ResolvedDeployInputs,
-) -> Result<()> {
+async fn run_with_resolved_inputs(ctx: &mut StdCtx, inputs: ResolvedDeployInputs) -> Result<()> {
     let deploy_config = inputs.config;
 
     shell_println!(

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -1,6 +1,6 @@
 //! Deploy debug-logs command.
 
-use crate::output::Ctx;
+use crate::output::{Ctx, StdCtx};
 use crate::{shell_eprintln, shell_println};
 use anyhow::Context;
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -119,7 +119,7 @@ pub struct Args {
 }
 
 /// Run the `deploy debug-logs` command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let request = DebugLogQueryRequest {
@@ -171,8 +171,8 @@ impl DebugLogQueryRequest {
     }
 }
 
-async fn query_debug_logs<W: Write>(
-    ctx: &mut Ctx<W>,
+async fn query_debug_logs(
+    ctx: &mut StdCtx,
     client: &turnkey_client::TurnkeyClient<TurnkeyP256ApiKey>,
     request: DebugLogQueryRequest,
 ) -> anyhow::Result<()> {
@@ -325,9 +325,9 @@ impl DebugLogPrinter {
         }
     }
 
-    fn print_response<W: Write>(
+    fn print_response<W: Write, W2: Write>(
         &mut self,
-        ctx: &mut Ctx<W>,
+        ctx: &mut Ctx<W, W2>,
         response: &GetTvcDeploymentDebugLogsResponse,
     ) -> anyhow::Result<()> {
         for entry in &response.entries {
@@ -541,9 +541,7 @@ mod tests {
             ],
         };
         let mut printer = DebugLogPrinter::new(false, 1000, false);
-        let shell =
-            crate::output::Shell::from_write(Vec::new(), crate::output::MessageFormat::Human);
-        let mut ctx = Ctx::new(shell, false);
+        let mut ctx = Ctx::new(crate::output::EmptyShell::default(), false);
 
         printer.print_response(&mut ctx, &response).unwrap();
 

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -1,11 +1,10 @@
 //! Deploy delete command - marks a deployment for deletion.
 
 use crate::client::build_client;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::DeleteTvcDeploymentIntent;
 
@@ -19,7 +18,7 @@ pub struct Args {
 }
 
 /// Run the deploy delete command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcDeploymentIntent {

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use turnkey_client::generated::{
     GetAppStatusRequest,
     external::data::v1::{AppStatus, DeploymentStatus},
@@ -11,7 +10,7 @@ use turnkey_client::generated::{
 use crate::{
     client::{fetch_tvc_app, fetch_tvc_deployment},
     commands::display::format_egress_enabled,
-    output::Ctx,
+    output::StdCtx,
     shell_println,
 };
 
@@ -25,7 +24,7 @@ pub struct Args {
 }
 
 /// Run the deploy get-status command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let Args {
         deploy_id: deployment_id,
     } = args;

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -4,14 +4,13 @@ use super::PORT_GUIDANCE;
 use crate::{
     client::{build_client, fetch_tvc_deployment},
     config::{deploy::DeployConfig, turnkey},
-    output::{Ctx, Message},
+    output::{Message, StdCtx},
     prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty},
 };
 use anyhow::{Context, Result, bail};
 use chrono::Local;
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::io::Write;
 use std::path::PathBuf;
 
 pub(crate) const LONG_ABOUT: &str = r#"
@@ -46,7 +45,7 @@ pub struct Args {
 }
 
 /// Run the deploy init command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -57,7 +56,7 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
     execute(ctx, args).await
 }
 
-async fn execute<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+async fn execute(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let Args {
         output,
         from_deployment,

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -1,12 +1,11 @@
 //! Deploy post-share command.
 
 use crate::commands::keys::re_encrypt_share::ReEncryptedShareOutput;
-use crate::output::{Ctx, Message};
+use crate::output::{Message, StdCtx};
 use crate::util::read_json_file;
 use anyhow::Context;
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use std::io::Write;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{PostTvcQuorumKeyShareIntent, QuorumKeyShareApprovalBundle};
@@ -25,7 +24,7 @@ pub struct Args {
 }
 
 /// Run the deploy post-share command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let re_encrypted_share: ReEncryptedShareOutput =
         read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;
     let intent =

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -1,6 +1,6 @@
 //! Deploy provisioning-details command.
 
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::provisioning::{
     ProvisionBundle, extract_ephemeral_public_key_bytes, verify_provisioning_details,
 };
@@ -10,7 +10,6 @@ use anyhow::{Context, bail};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, VersionedManifestEnvelope};
 use qos_nsm::types::NsmDigest;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{
@@ -59,7 +58,7 @@ struct AttestationSummary {
 const SUMMARY_PCR_MAX_INDEX: usize = 17;
 
 /// Run the deploy provisioning-details command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let request = GetTvcDeploymentProvisioningDetailsRequest {
@@ -123,8 +122,8 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn write_provision_bundle<W: Write>(
-    ctx: &mut Ctx<W>,
+async fn write_provision_bundle(
+    ctx: &mut StdCtx,
     path: &Path,
     bundle: &ProvisionBundle,
 ) -> anyhow::Result<()> {
@@ -188,8 +187,8 @@ fn approval_summaries(approvals: &[Approval]) -> Vec<ApprovalSummary> {
         .collect()
 }
 
-fn print_summary<W: Write>(
-    ctx: &mut Ctx<W>,
+fn print_summary(
+    ctx: &mut StdCtx,
     deploy_id: &str,
     verification_status: &str,
     summary: &AttestationSummary,
@@ -257,8 +256,8 @@ fn print_summary<W: Write>(
     Ok(())
 }
 
-fn print_approval_summary_entries<W: Write>(
-    ctx: &mut Ctx<W>,
+fn print_approval_summary_entries(
+    ctx: &mut StdCtx,
     approvals: &[ApprovalSummary],
 ) -> anyhow::Result<()> {
     for approval in approvals {

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -2,11 +2,10 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::RestoreTvcDeploymentIntent;
 
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 
 /// Restore a deleted deployment.
@@ -19,7 +18,7 @@ pub struct Args {
 }
 
 /// Run the deploy restore command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let intent = RestoreTvcDeploymentIntent {

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -2,13 +2,12 @@
 
 use anyhow::Context;
 use clap::Args as ClapArgs;
-use std::io::Write;
 use turnkey_client::generated::GetTvcDeploymentRequest;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 
 use crate::client::fetch_tvc_app;
 use crate::commands::display::{format_egress_enabled, yes_no};
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 
 /// Get the status of a deployment.
@@ -21,7 +20,7 @@ pub struct Args {
 }
 
 /// Run the deploy status command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let auth = crate::client::build_client().await?;
 
     let request = GetTvcDeploymentRequest {

--- a/tvc/src/commands/keys/generate_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_quorum_key.rs
@@ -1,7 +1,7 @@
 //! Generate quorum key command - generates and encrypts a quorum key from a given config.
 
 use crate::config::quorum_key::QuorumKeyConfig;
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::quorum_key_metadata::{
     EncryptedShareMetadata, QuorumKeyMetadata, decode_p256_public_key_hex,
 };
@@ -11,7 +11,6 @@ use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
 use qos_p256::{P256Pair, P256Public};
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 use zeroize::Zeroizing;
 
@@ -41,7 +40,7 @@ struct OperatorPublicKey {
 struct PlaintextShares(Vec<Zeroizing<Vec<u8>>>);
 
 /// Run the quorum key generation command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     let config: QuorumKeyConfig =
         read_json_file(&args.config_file, "quorum key config file").await?;
     config.validate()?;

--- a/tvc/src/commands/keys/init_quorum_key.rs
+++ b/tvc/src/commands/keys/init_quorum_key.rs
@@ -2,11 +2,10 @@
 
 use crate::config::quorum_key::QuorumKeyConfig;
 use crate::config::turnkey::{Config, StoredQosOperatorKey};
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::shell_println;
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use std::io::Write;
 use std::path::PathBuf;
 
 /// Generate a template quorum key configuration file.
@@ -25,7 +24,7 @@ pub struct Args {
 }
 
 /// Run the quorum key init command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     if args.output.exists() {
         anyhow::bail!("File already exists: {}", args.output.display());
     }

--- a/tvc/src/commands/keys/re_encrypt_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_share.rs
@@ -1,7 +1,7 @@
 //! Re-encrypt share command.
 
 use crate::operator_key::{OperatorSeedSource, load_operator_pair};
-use crate::output::{Ctx, Message};
+use crate::output::{Message, StdCtx};
 use crate::pair::{HexSeed, Pair};
 use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
@@ -11,7 +11,6 @@ use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, QuorumMember, VersionedManifestEnvelope};
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Re-encrypt a share with an ephemeral key.
@@ -78,7 +77,7 @@ impl Message for ReEncryptedShareOutput {
 }
 
 /// Run the re-encrypt-share command.
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> anyhow::Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<()> {
     let operator_seed_source =
         OperatorSeedSource::from_args(args.operator_seed, args.operator_seed_path)?;
 
@@ -189,8 +188,8 @@ fn find_share_set_member(
         })
 }
 
-async fn write_output<W: Write>(
-    ctx: &mut Ctx<W>,
+async fn write_output(
+    ctx: &mut StdCtx,
     path: Option<&Path>,
     output: &ReEncryptedShareOutput,
 ) -> anyhow::Result<()> {

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -4,13 +4,13 @@ use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, OrgConfig, StoredApiKey, StoredQosOperatorKey,
     dashboard_base_url, default_api_key_path, default_operator_key_path, default_org_dir,
 };
-use crate::output::Ctx;
+use crate::output::StdCtx;
 use crate::prompts::{self, error_required_in_non_interactive};
 use crate::{shell_eprintln, shell_print, shell_println};
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
-use std::io::{BufRead, Write};
+use std::io::BufRead;
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
@@ -58,7 +58,7 @@ struct LoginPlan {
     api_key_policy: ApiKeyPolicy,
 }
 
-pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<()> {
     debug!(
         non_interactive = ctx.is_non_interactive(),
         org_arg_present = args.org.is_some(),
@@ -79,7 +79,7 @@ pub async fn run<W: Write>(ctx: &mut Ctx<W>, args: Args) -> Result<()> {
 
 /// Permanently delete a saved login profile: its config entry and its API and
 /// operator key files on disk.
-pub async fn run_delete<W: Write>(ctx: &mut Ctx<W>, args: DeleteArgs) -> Result<()> {
+pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<()> {
     let is_non_interactive = ctx.is_non_interactive();
     debug!(
         non_interactive = is_non_interactive,
@@ -272,8 +272,8 @@ impl std::fmt::Display for ProfileChoice<'_> {
     }
 }
 
-fn build_login_plan_interactive<W: Write>(
-    ctx: &mut Ctx<W>,
+fn build_login_plan_interactive(
+    ctx: &mut StdCtx,
     args: Args,
     config: &Config,
 ) -> Result<LoginPlan> {
@@ -300,11 +300,7 @@ fn build_login_plan_non_interactive(args: Args) -> Result<LoginPlan> {
     })
 }
 
-async fn execute_login<W: Write>(
-    ctx: &mut Ctx<W>,
-    mut config: Config,
-    plan: LoginPlan,
-) -> Result<()> {
+async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<()> {
     let (alias, org_config) = match plan.org {
         OrgPlan::Existing(query) => {
             let alias = match find_org(&config, &query) {
@@ -362,8 +358,8 @@ async fn execute_login<W: Write>(
     print_success(ctx, &alias, &org_config, &api_key, &operator_key, &whoami)
 }
 
-fn prompt_for_org_plan<W: Write>(
-    ctx: &mut Ctx<W>,
+fn prompt_for_org_plan(
+    ctx: &mut StdCtx,
     config: &Config,
     api_base_url_override: Option<&str>,
 ) -> Result<OrgPlan> {
@@ -402,8 +398,8 @@ fn prompt_for_org_plan<W: Write>(
     }
 }
 
-fn prompt_for_new_org_inputs<W: Write>(
-    ctx: &mut Ctx<W>,
+fn prompt_for_new_org_inputs(
+    ctx: &mut StdCtx,
     api_base_url_override: Option<&str>,
 ) -> Result<OrgPlan> {
     let dashboard_url = dashboard_base_url(api_base_url_override.unwrap_or(API_BASE_URL_PROD));
@@ -483,10 +479,7 @@ fn update_api_base_url_from_override(
     }
 }
 
-async fn generate_api_key<W: Write>(
-    ctx: &mut Ctx<W>,
-    org_config: &OrgConfig,
-) -> Result<StoredApiKey> {
+async fn generate_api_key(ctx: &mut StdCtx, org_config: &OrgConfig) -> Result<StoredApiKey> {
     debug!("generating new API key");
     shell_println!(ctx)?;
     shell_println!(ctx, "Generating API key...")?;
@@ -527,7 +520,7 @@ async fn generate_api_key<W: Write>(
     Ok(api_key)
 }
 
-fn wait_for_dashboard_registration<W: Write>(ctx: &mut Ctx<W>) -> Result<()> {
+fn wait_for_dashboard_registration(ctx: &mut StdCtx) -> Result<()> {
     shell_print!(ctx, "Press Enter when done...")?;
 
     let mut input = String::new();
@@ -535,8 +528,8 @@ fn wait_for_dashboard_registration<W: Write>(ctx: &mut Ctx<W>) -> Result<()> {
     Ok(())
 }
 
-async fn find_or_generate_operator_key<W: Write>(
-    ctx: &mut Ctx<W>,
+async fn find_or_generate_operator_key(
+    ctx: &mut StdCtx,
     org_config: &OrgConfig,
 ) -> Result<StoredQosOperatorKey> {
     debug!(operator_key_path = %org_config.operator_key_path.display(), "resolving operator key");
@@ -622,8 +615,8 @@ async fn verify_credentials(
     })
 }
 
-fn print_success<W: Write>(
-    ctx: &mut Ctx<W>,
+fn print_success(
+    ctx: &mut StdCtx,
     alias: &str,
     org_config: &OrgConfig,
     api_key: &StoredApiKey,

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -136,9 +136,9 @@ impl DeployConfig {
     /// Non-placeholder fields are preserved unchanged so partial edits work.
     ///
     /// `saved_app_id` is offered as the default for the App ID prompt when set.
-    pub fn fill_interactively<W: Write>(
+    pub fn fill_interactively<W: Write, W2: Write>(
         &mut self,
-        ctx: &mut Ctx<W>,
+        ctx: &mut Ctx<W, W2>,
         saved_app_id: Option<&str>,
     ) -> Result<()> {
         if self.app_id.starts_with("<FILL_IN") {
@@ -313,7 +313,7 @@ impl Display for DeployConfigValidationErrors {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::Shell;
+    use crate::output::EmptyShell;
     use turnkey_client::generated::external::data::v1::{
         TvcContainerSpec, TvcDeployment, TvcManifest,
     };
@@ -478,7 +478,7 @@ mod tests {
         config.expected_pivot_digest = "sha256:abc".into();
         config.pivot_container_encrypted_pull_secret = None;
 
-        let shell = Shell::from_write(Vec::new(), crate::output::MessageFormat::Human);
+        let shell = EmptyShell::default();
         let mut ctx = Ctx::new(shell, false);
         config.fill_interactively(&mut ctx, None).unwrap();
         assert_eq!(config.app_id, "app_xyz");

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -6,7 +6,7 @@ use clap::ValueEnum;
 use serde::Serialize;
 use std::error::Error;
 use std::fmt::{self, Display};
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Stderr, Stdout, Write};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum MessageFormat {
@@ -48,15 +48,15 @@ pub trait Message: Serialize {
     }
 }
 
-pub struct Shell<W: Write = Box<dyn Write + Send>> {
-    stdout: W,
-    stderr: W,
+pub struct Shell<Out = Stdout, Err = Stderr> {
+    stdout: Out,
+    stderr: Err,
     color: ColorChoice,
     use_color: bool,
     message_format: MessageFormat,
 }
 
-impl Shell<Box<dyn Write + Send>> {
+impl Shell {
     pub fn standard(message_format: MessageFormat, color: ColorChoice) -> Self {
         let use_color = match color {
             ColorChoice::Auto => io::stderr().is_terminal(),
@@ -65,8 +65,8 @@ impl Shell<Box<dyn Write + Send>> {
         };
 
         Self {
-            stdout: Box::new(io::stdout()),
-            stderr: Box::new(io::stderr()),
+            stdout: io::stdout(),
+            stderr: io::stderr(),
             color,
             use_color,
             message_format,
@@ -74,11 +74,25 @@ impl Shell<Box<dyn Write + Send>> {
     }
 }
 
-impl<W: Write> Shell<W> {
+impl<W, W2> Shell<W, W2> {
     pub fn message_format(&self) -> MessageFormat {
         self.message_format
     }
 
+    pub fn color(&self) -> ColorChoice {
+        self.color
+    }
+
+    fn style(&self, color: AnsiColor) -> Style {
+        if self.use_color {
+            Style::new().bold().fg_color(Some(Color::Ansi(color)))
+        } else {
+            Style::new()
+        }
+    }
+}
+
+impl<W: Write, W2: Write> Shell<W, W2> {
     pub fn emit<M: Message>(&mut self, message: &M) -> Result<()> {
         match self.message_format {
             MessageFormat::Human => self.human().line(message.human_message()),
@@ -95,20 +109,8 @@ impl<W: Write> Shell<W> {
     /// message format is [`MessageFormat::Human`] and is a silent no-op
     /// otherwise, so it must never carry machine-readable output — use
     /// [`Shell::emit`] for that.
-    pub fn human(&mut self) -> Human<'_, W> {
+    pub fn human(&mut self) -> Human<'_, W, W2> {
         Human(self)
-    }
-
-    pub fn color(&self) -> ColorChoice {
-        self.color
-    }
-
-    fn style(&self, color: AnsiColor) -> Style {
-        if self.use_color {
-            Style::new().bold().fg_color(Some(Color::Ansi(color)))
-        } else {
-            Style::new()
-        }
     }
 }
 
@@ -118,9 +120,9 @@ impl<W: Write> Shell<W> {
 /// is a silent no-op otherwise, so it is meant for
 /// human-facing output (progress, prompts, spacing) — never for
 /// machine-readable JSON output, which must go through [`Shell::emit`].
-pub struct Human<'a, W: Write>(&'a mut Shell<W>);
+pub struct Human<'a, W: Write, W2: Write>(&'a mut Shell<W, W2>);
 
-impl<W: Write> Human<'_, W> {
+impl<W: Write, W2: Write> Human<'_, W, W2> {
     pub fn line(&mut self, message: impl Display) -> Result<()> {
         if matches!(self.0.message_format, MessageFormat::Human) {
             writeln!(self.0.stdout, "{message}")?;
@@ -176,16 +178,18 @@ impl<W: Write> Human<'_, W> {
 }
 
 /// Bundles the `Shell` with cross-cutting CLI flags
-pub struct Ctx<W: Write = Box<dyn Write + Send>> {
-    shell: Shell<W>,
+pub struct Ctx<W, W2> {
+    shell: Shell<W, W2>,
     non_interactive: bool,
 }
 
-impl<W: Write> Ctx<W> {
+pub type StdCtx = Ctx<Stdout, Stderr>;
+
+impl<W: Write, W2: Write> Ctx<W, W2> {
     /// `non_interactive` is the raw `--non-interactive` flag; JSON output mode
     /// always forces non-interactive regardless of the flag, since a piped
     /// consumer can't answer prompts.
-    pub fn new(shell: Shell<W>, non_interactive: bool) -> Self {
+    pub fn new(shell: Shell<W, W2>, non_interactive: bool) -> Self {
         let non_interactive = non_interactive || shell.message_format().is_json();
         Self {
             shell,
@@ -193,7 +197,7 @@ impl<W: Write> Ctx<W> {
         }
     }
 
-    pub fn shell(&mut self) -> &mut Shell<W> {
+    pub fn shell(&mut self) -> &mut Shell<W, W2> {
         &mut self.shell
     }
 
@@ -307,18 +311,41 @@ impl Message for ErrorMessage {
 }
 
 #[cfg(test)]
+pub use tests::*;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde::Serialize;
+    use std::io::Empty;
 
-    impl Shell<Vec<u8>> {
-        pub fn from_write(stdout: Vec<u8>, message_format: MessageFormat) -> Self {
+    pub type TestShell = Shell<Vec<u8>, Vec<u8>>;
+    pub type EmptyShell = Shell<Empty, Empty>;
+
+    impl<W: Default, W2: Default> Default for Shell<W, W2> {
+        fn default() -> Self {
             Self {
-                stdout,
-                stderr: Vec::new(),
+                stdout: Default::default(),
+                stderr: Default::default(),
                 color: ColorChoice::Never,
                 use_color: false,
-                message_format,
+                message_format: MessageFormat::Human,
+            }
+        }
+    }
+
+    impl TestShell {
+        pub fn with_json_formatter() -> Self {
+            Self {
+                message_format: MessageFormat::Json,
+                ..Default::default()
+            }
+        }
+
+        pub fn with_human_formatter() -> Self {
+            Self {
+                message_format: MessageFormat::Human,
+                ..Default::default()
             }
         }
 
@@ -348,44 +375,42 @@ mod tests {
 
     #[test]
     fn shell_emit_json_flattens_reason_into_message() {
-        let mut shell = Shell::from_write(Vec::new(), MessageFormat::Json);
+        let mut shell = TestShell::with_json_formatter();
 
         shell.emit(&TestMessage { value: "ok" }).unwrap();
 
-        let output = String::from_utf8(shell.into_stdout()).unwrap();
-        assert_eq!(output, "{\"reason\":\"test-message\",\"value\":\"ok\"}\n");
+        assert_eq!(
+            shell.into_stdout(),
+            concat!(r#"{"reason":"test-message","value":"ok"}"#, "\n").as_bytes()
+        );
     }
 
     #[test]
     fn shell_emit_human_uses_human_message() {
-        let mut shell = Shell::from_write(Vec::new(), MessageFormat::Human);
+        let mut shell = TestShell::with_human_formatter();
 
         shell.emit(&TestMessage { value: "ok" }).unwrap();
 
-        let output = String::from_utf8(shell.into_stdout()).unwrap();
-        assert_eq!(output, "value: ok\n");
+        assert_eq!(shell.into_stdout(), "value: ok\n".as_bytes());
     }
 
     #[test]
     fn ctx_reflects_explicit_non_interactive_flag() {
-        let shell = Shell::from_write(Vec::new(), MessageFormat::Human);
-        let ctx = Ctx::new(shell, true);
+        let ctx = Ctx::new(TestShell::with_human_formatter(), true);
 
         assert!(ctx.is_non_interactive());
     }
 
     #[test]
     fn ctx_forces_non_interactive_in_json_mode_regardless_of_flag() {
-        let shell = Shell::from_write(Vec::new(), MessageFormat::Json);
-        let ctx = Ctx::new(shell, false);
+        let ctx = Ctx::new(TestShell::with_json_formatter(), false);
 
         assert!(ctx.is_non_interactive());
     }
 
     #[test]
     fn ctx_is_interactive_when_flag_unset_and_format_is_human() {
-        let shell = Shell::from_write(Vec::new(), MessageFormat::Human);
-        let ctx = Ctx::new(shell, false);
+        let ctx = Ctx::new(TestShell::with_human_formatter(), false);
 
         assert!(!ctx.is_non_interactive());
     }


### PR DESCRIPTION
I should have caught this on my initial review. I started by wanting to see how much of a pain my suggestion would be, then I ended up just taking on the pain myself. I made a couple other small changes like ~~adding the lint rule to Cargo.toml (still needs to be removed from main.rs and lib.rs) and~~ instead of fallibly converting byte arrays to strings in tests, I infallibly convert strings to byte arrays. I also messed around with some type aliases. 

My changes should be pretty straighforward. 

