### PR TITLE
tvc: surface consensus-needed clearly (non-zero exit, no duplicate activities)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,7 @@ dependencies = [
  "turnkey_client",
  "turnkey_enclave_encrypt",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -124,6 +124,12 @@ pub enum TurnkeyClientError {
     #[error("This activity ({0}) requires extra approvals")]
     ActivityRequiresApproval(String),
 
+    #[error("This activity ({activity_id}) is pending consensus")]
+    ActivityPendingConsensus {
+        activity_id: String,
+        fingerprint: String,
+    },
+
     #[error("Maximum number of attempts reached (after {0} retries)")]
     ExceededRetries(usize),
 
@@ -330,7 +336,13 @@ impl<S: Stamp> TurnkeyClient<S> {
                 ActivityStatus::Failed => {
                     return Err(TurnkeyClientError::ActivityFailed(activity.failure));
                 }
-                ActivityStatus::ConsensusNeeded | ActivityStatus::AuthenticatorsNeeded => {
+                ActivityStatus::ConsensusNeeded => {
+                    return Err(TurnkeyClientError::ActivityPendingConsensus {
+                        activity_id: activity.id,
+                        fingerprint: activity.fingerprint,
+                    });
+                }
+                ActivityStatus::AuthenticatorsNeeded => {
                     return Err(TurnkeyClientError::ActivityRequiresApproval(activity.id));
                 }
                 ActivityStatus::Unspecified
@@ -670,8 +682,12 @@ mod test {
             .await;
 
         match result.unwrap_err() {
-            TurnkeyClientError::ActivityRequiresApproval(activity_id) => {
+            TurnkeyClientError::ActivityPendingConsensus {
+                activity_id,
+                fingerprint,
+            } => {
                 assert_eq!(activity_id, "some-activity-id");
+                assert_eq!(fingerprint, "fingerprint");
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -45,3 +45,4 @@ predicates = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 rexpect = { workspace = true }
 tempfile = { workspace = true }
+wiremock = { workspace = true }

--- a/tvc/src/commands/consensus.rs
+++ b/tvc/src/commands/consensus.rs
@@ -1,0 +1,43 @@
+//! Helpers for activity responses that were accepted but still need quorum.
+
+use anyhow::Result;
+use turnkey_client::TurnkeyClientError;
+
+pub(crate) struct PendingConsensusActivity<'a> {
+    pub activity_id: &'a str,
+    pub fingerprint: &'a str,
+}
+
+pub(crate) fn pending_consensus_from_error(
+    error: &TurnkeyClientError,
+) -> Option<PendingConsensusActivity<'_>> {
+    match error {
+        TurnkeyClientError::ActivityPendingConsensus {
+            activity_id,
+            fingerprint,
+        } => Some(PendingConsensusActivity {
+            activity_id,
+            fingerprint,
+        }),
+        _ => None,
+    }
+}
+
+pub(crate) fn print_pending_consensus(activity: &PendingConsensusActivity<'_>) {
+    println!();
+    println!("Consensus needed. The activity was created successfully but is pending quorum.");
+    println!();
+    println!("Activity ID: {}", activity.activity_id);
+    println!("Fingerprint: {}", activity.fingerprint);
+    println!();
+    println!("Next steps:");
+    println!(
+        "  - Ask another quorum member to run `tvc activity approve --fingerprint {}`",
+        activity.fingerprint
+    );
+}
+
+pub(crate) fn pending_consensus_result(activity: &PendingConsensusActivity<'_>) -> Result<()> {
+    print_pending_consensus(activity);
+    Err(crate::exit::ExitError::consensus_needed().into())
+}

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -309,11 +309,20 @@ async fn post_approval_to_api(
         .context("system time before unix epoch")?
         .as_millis();
 
-    let result = auth
+    let result = match auth
         .client
         .create_tvc_manifest_approvals(auth.org_id.clone(), timestamp_ms, intent)
         .await
-        .context("failed to post manifest approval")?;
+    {
+        Ok(result) => result,
+        Err(error) => {
+            if let Some(activity) = crate::commands::consensus::pending_consensus_from_error(&error)
+            {
+                return crate::commands::consensus::pending_consensus_result(&activity);
+            }
+            return Err(error).context("failed to post manifest approval");
+        }
+    };
 
     println!();
     println!("Approval posted successfully!");

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -412,11 +412,20 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
         .context("system time before unix epoch")?
         .as_millis();
 
-    let result = auth
+    let result = match auth
         .client
         .create_tvc_deployment(auth.org_id, timestamp_ms, intent)
         .await
-        .context("failed to create TVC deployment")?;
+    {
+        Ok(result) => result,
+        Err(error) => {
+            if let Some(activity) = crate::commands::consensus::pending_consensus_from_error(&error)
+            {
+                return crate::commands::consensus::pending_consensus_result(&activity);
+            }
+            return Err(error).context("failed to create TVC deployment");
+        }
+    };
 
     println!();
     println!("Deployment created successfully!");

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -7,6 +7,7 @@
 pub mod app;
 pub mod app_status;
 pub mod confirmation;
+pub(crate) mod consensus;
 pub mod deploy;
 pub mod display;
 pub mod keys;

--- a/tvc/src/exit.rs
+++ b/tvc/src/exit.rs
@@ -1,0 +1,25 @@
+//! CLI exit-code helpers.
+
+use thiserror::Error;
+
+pub const CONSENSUS_NEEDED_EXIT_CODE: i32 = 2;
+
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct ExitError {
+    code: i32,
+    message: String,
+}
+
+impl ExitError {
+    pub fn consensus_needed() -> Self {
+        Self {
+            code: CONSENSUS_NEEDED_EXIT_CODE,
+            message: "activity is pending consensus".to_string(),
+        }
+    }
+
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+}

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod exit;
 pub mod logging;
 pub(crate) mod operator_key;
 pub mod pair;

--- a/tvc/src/main.rs
+++ b/tvc/src/main.rs
@@ -2,9 +2,16 @@ use tracing::debug;
 use tvc::cli::Cli;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     tvc::logging::init();
     debug!(version = env!("CARGO_PKG_VERSION"), "starting tvc");
 
-    Cli::run().await
+    if let Err(error) = Cli::run().await {
+        if let Some(exit_error) = error.downcast_ref::<tvc::exit::ExitError>() {
+            std::process::exit(exit_error.code());
+        }
+
+        eprintln!("Error: {error:#}");
+        std::process::exit(1);
+    }
 }

--- a/tvc/tests/deploy_consensus.rs
+++ b/tvc/tests/deploy_consensus.rs
@@ -1,0 +1,147 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::NamedTempFile;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ENV_ORG_ID: &str = "TVC_ORG_ID";
+const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
+const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
+const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const ORG_ID: &str = "org-test";
+const APP_ID: &str = "11111111-1111-1111-1111-111111111111";
+const ACTIVITY_ID: &str = "activity-pending";
+const FINGERPRINT: &str = "activity-fingerprint";
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+fn authed_tvc_cmd(server: &MockServer) -> assert_cmd::Command {
+    let (public_key, private_key) = generated_api_key();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .env(ENV_ORG_ID, ORG_ID)
+        .env(ENV_API_BASE_URL, server.uri())
+        .env(ENV_API_KEY_PUBLIC, public_key)
+        .env(ENV_API_KEY_PRIVATE, private_key);
+    cmd
+}
+
+async fn mount_tvc_app_lookup(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/get_tvc_app"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tvcApp": {
+                "id": APP_ID,
+                "organizationId": ORG_ID,
+                "name": "test app",
+                "quorumPublicKey": "quorum-public-key",
+                "publicDomain": "example.com"
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+fn consensus_needed_activity(activity_type: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "activity": {
+            "type": activity_type,
+            "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+            "id": ACTIVITY_ID,
+            "organizationId": ORG_ID,
+            "fingerprint": FINGERPRINT
+        }
+    }))
+}
+
+#[tokio::test]
+async fn deploy_create_reports_consensus_needed_without_generic_failure() {
+    let server = MockServer::start().await;
+    mount_tvc_app_lookup(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/validate_tvc_image"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resolvedImageDigest": "sha256:resolved"
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_deployment"))
+        .respond_with(consensus_needed_activity(
+            "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+        ))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("--non-interactive")
+        .arg("deploy")
+        .arg("create")
+        .arg("--app-id")
+        .arg(APP_ID)
+        .arg("--qos-version")
+        .arg("0.12.1")
+        .arg("--pivot-image-url")
+        .arg("ghcr.io/team/app:latest")
+        .arg("--expected-pivot-digest")
+        .arg("sha256:resolved")
+        .arg("--pivot-path")
+        .arg("/app")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Consensus needed"))
+        .stdout(predicate::str::contains(ACTIVITY_ID))
+        .stdout(predicate::str::contains(FINGERPRINT))
+        .stdout(predicate::str::contains(
+            "tvc activity approve --fingerprint",
+        ))
+        .stderr(predicate::str::contains("failed to create TVC deployment").not());
+}
+
+#[tokio::test]
+async fn deploy_approve_reports_consensus_needed_without_generic_failure() {
+    let server = MockServer::start().await;
+    let approval_out = NamedTempFile::new().unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_manifest_approvals"))
+        .respond_with(consensus_needed_activity(
+            "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS",
+        ))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("--non-interactive")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--manifest-id")
+        .arg("22222222-2222-2222-2222-222222222222")
+        .arg("--operator-id")
+        .arg("33333333-3333-3333-3333-333333333333")
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--dangerous-skip-interactive")
+        .arg("--approval-out")
+        .arg(approval_out.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Consensus needed"))
+        .stdout(predicate::str::contains(ACTIVITY_ID))
+        .stdout(predicate::str::contains(FINGERPRINT))
+        .stdout(predicate::str::contains(
+            "tvc activity approve --fingerprint",
+        ))
+        .stderr(predicate::str::contains("failed to post manifest approval").not());
+}


### PR DESCRIPTION
Part 2 of 3 for TVC-183 (consensus-needed handling in the tvc CLI).

## Problem

In orgs requiring root-quorum consensus, `tvc deploy create` / `tvc deploy approve` submit an activity and the server returns HTTP 200 with `ACTIVITY_STATUS_CONSENSUS_NEEDED` — a normal response, not an error. But the generated client maps ConsensusNeeded to `Err(ActivityRequiresApproval(id))` and the CLI wraps that as a fatal generic error (`failed to create TVC deployment` / `failed to post manifest approval`). Operators read this as a failure and re-run; each run stamps a fresh `timestampMs`, the server fingerprint is `sha256(raw body)`, so every retry creates a **duplicate activity**.

## Changes

### `turnkey_client`
- New error variant `TurnkeyClientError::ActivityPendingConsensus { activity_id, fingerprint }` returned for `ACTIVITY_STATUS_CONSENSUS_NEEDED`. It carries the activity **fingerprint**, which is what quorum members need to vote (`ApproveActivityIntent { fingerprint }`).
- `ActivityRequiresApproval(activity_id)` is kept as-is and still returned for `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED`, so existing consumers matching that variant keep compiling.
- **Semver note:** adding a variant to the (non-`#[non_exhaustive]`) `TurnkeyClientError` enum is technically breaking for exhaustive matches without a wildcard arm; in practice consumers match specific variants with a catch-all. Consumers relying on `ActivityRequiresApproval` for consensus flows must migrate to the new variant.

### `tvc` CLI
- `deploy create` and `deploy approve` no longer print a generic failure for consensus-needed. They print a clear pending-consensus message: the activity was created successfully, its **activity ID** and **fingerprint**, and the command another quorum member should run (`tvc activity approve --fingerprint <fp>` — subcommand ships in the stacked follow-up PR).
- **Exit-code semantics:** the CLI exits with dedicated code **2** (`tvc::exit::CONSENSUS_NEEDED_EXIT_CODE`) — non-zero because the operation is not complete, but distinct from `1` (generic error) so scripts/CI can tell "pending consensus" apart from a real failure.

## Test coverage
- `client`: unit test asserting ConsensusNeeded maps to `ActivityPendingConsensus` with both id and fingerprint (authenticators-needed test unchanged).
- `tvc/tests/deploy_consensus.rs` (new, wiremock-based): `deploy create` and `deploy approve` against a mock API returning consensus-needed — asserts exit code 2, pending-consensus message with activity id + fingerprint + approval instruction, and that the old generic failure text is absent.

## Verification
- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p tvc -p turnkey_client` ✅ (25 client + 127 tvc unit + all integration tests)
- `git diff --check` ✅