### PR TITLE
tvc: vote on existing pending activity + tvc activity subcommands

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -64,6 +64,11 @@ impl Cli {
         let non_interactive = args.non_interactive;
 
         match args.command {
+            Commands::Activity { command } => match command {
+                ActivityCommands::List(args) => commands::activity::list::run(args).await,
+                ActivityCommands::Approve(args) => commands::activity::approve::run(args).await,
+                ActivityCommands::Reject(args) => commands::activity::reject::run(args).await,
+            },
             Commands::Deploy { command } => match command {
                 DeployCommands::Approve(args) => {
                     commands::deploy::approve::run(args, non_interactive).await
@@ -119,6 +124,11 @@ impl Cli {
 enum Commands {
     /// Authenticate with Turnkey.
     Login(commands::login::Args),
+    /// Inspect and vote on activities pending consensus.
+    Activity {
+        #[command(subcommand)]
+        command: ActivityCommands,
+    },
     /// Manage saved login profiles.
     Profile {
         #[command(subcommand)]
@@ -148,9 +158,30 @@ impl Commands {
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(_) => "profile delete",
             },
+            Commands::Activity { command } => command.name(),
             Commands::Deploy { command } => command.name(),
             Commands::App { command } => command.name(),
             Commands::Keys { command } => command.name(),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum ActivityCommands {
+    /// List activities, pending consensus by default.
+    List(commands::activity::list::Args),
+    /// Approve (vote on) an activity by fingerprint.
+    Approve(commands::activity::approve::Args),
+    /// Reject (vote against) an activity by fingerprint.
+    Reject(commands::activity::reject::Args),
+}
+
+impl ActivityCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            ActivityCommands::List(_) => "activity list",
+            ActivityCommands::Approve(_) => "activity approve",
+            ActivityCommands::Reject(_) => "activity reject",
         }
     }
 }

--- a/tvc/src/commands/activity/approve.rs
+++ b/tvc/src/commands/activity/approve.rs
@@ -1,0 +1,78 @@
+//! Activity approve command - vote to approve a pending activity by fingerprint.
+
+use crate::client::build_client;
+use crate::commands::consensus;
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use turnkey_client::TurnkeyClientError;
+use turnkey_client::generated::{ActivityStatus, ApproveActivityIntent, GetActivitiesRequest};
+
+/// Approve (vote on) an activity pending consensus.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Fingerprint of the activity to approve (see `tvc activity list`).
+    #[arg(long, env = "TVC_ACTIVITY_FINGERPRINT")]
+    pub fingerprint: String,
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let auth = build_client().await?;
+
+    // If the target activity is still pending and the current user already
+    // approved it, don't submit a second vote.
+    let pending = auth
+        .client
+        .get_activities(GetActivitiesRequest {
+            organization_id: auth.org_id.clone(),
+            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
+            pagination_options: None,
+            filter_by_type: vec![],
+        })
+        .await
+        .context("failed to list pending activities")?;
+
+    if let Some(activity) = pending
+        .activities
+        .iter()
+        .find(|activity| activity.fingerprint == args.fingerprint)
+    {
+        let user_id = consensus::current_user_id(&auth).await?;
+        if consensus::user_already_approved(activity, &user_id) {
+            println!("Activity ID: {}", activity.id);
+            consensus::print_already_approved(&auth, activity).await;
+            return Ok(());
+        }
+    }
+
+    let timestamp_ms = auth.client.current_timestamp();
+
+    let result = auth
+        .client
+        .approve_activity(
+            auth.org_id.clone(),
+            timestamp_ms,
+            ApproveActivityIntent {
+                fingerprint: args.fingerprint.clone(),
+            },
+        )
+        .await;
+
+    match result {
+        Ok(activity) => {
+            println!("Approval submitted. Activity {} completed.", activity.id);
+            Ok(())
+        }
+        Err(TurnkeyClientError::ActivityPendingConsensus {
+            activity_id,
+            fingerprint,
+        }) => {
+            println!("Vote recorded. Activity {activity_id} is still pending quorum.");
+            println!(
+                "Other quorum members can vote with `tvc activity approve --fingerprint {fingerprint}`."
+            );
+            Ok(())
+        }
+        Err(error) => Err(error).context("failed to approve activity"),
+    }
+}

--- a/tvc/src/commands/activity/list.rs
+++ b/tvc/src/commands/activity/list.rs
@@ -1,0 +1,147 @@
+//! Activity list command - list activities for the org, pending consensus by default.
+
+use crate::client::build_client;
+use anyhow::{Context, Result, anyhow};
+use clap::{Args as ClapArgs, ValueEnum};
+use turnkey_client::generated::external::data::v1::Timestamp;
+use turnkey_client::generated::{ActivityStatus, ActivityType, GetActivitiesRequest};
+
+/// List activities for the organization. Defaults to activities pending consensus.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Filter by activity status (repeatable). Defaults to consensus-needed.
+    #[arg(long = "status", value_enum, value_name = "STATUS")]
+    pub statuses: Vec<StatusFilter>,
+
+    /// Filter by activity type, e.g. ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT (repeatable).
+    #[arg(long = "activity-type", value_name = "TYPE")]
+    pub activity_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum StatusFilter {
+    Created,
+    Pending,
+    ConsensusNeeded,
+    Completed,
+    Failed,
+    Rejected,
+}
+
+impl From<StatusFilter> for ActivityStatus {
+    fn from(filter: StatusFilter) -> Self {
+        match filter {
+            StatusFilter::Created => ActivityStatus::Created,
+            StatusFilter::Pending => ActivityStatus::Pending,
+            StatusFilter::ConsensusNeeded => ActivityStatus::ConsensusNeeded,
+            StatusFilter::Completed => ActivityStatus::Completed,
+            StatusFilter::Failed => ActivityStatus::Failed,
+            StatusFilter::Rejected => ActivityStatus::Rejected,
+        }
+    }
+}
+
+fn parse_activity_types(raw: &[String]) -> Result<Vec<ActivityType>> {
+    raw.iter()
+        .map(|name| {
+            ActivityType::from_str_name(name).ok_or_else(|| {
+                anyhow!(
+                    "unknown activity type: {name} (expected an ACTIVITY_TYPE_* name, \
+                     e.g. ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT)"
+                )
+            })
+        })
+        .collect()
+}
+
+fn format_created_at(created_at: Option<&Timestamp>) -> String {
+    created_at
+        .and_then(|ts| ts.seconds.parse::<i64>().ok())
+        .and_then(|seconds| chrono::DateTime::from_timestamp(seconds, 0))
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let filter_by_type = parse_activity_types(&args.activity_types)?;
+
+    let filter_by_status: Vec<ActivityStatus> = if args.statuses.is_empty() {
+        vec![ActivityStatus::ConsensusNeeded]
+    } else {
+        args.statuses.into_iter().map(Into::into).collect()
+    };
+
+    let auth = build_client().await?;
+
+    let response = auth
+        .client
+        .get_activities(GetActivitiesRequest {
+            organization_id: auth.org_id.clone(),
+            filter_by_status,
+            pagination_options: None,
+            filter_by_type,
+        })
+        .await
+        .context("failed to list activities")?;
+
+    if response.activities.is_empty() {
+        println!("No matching activities found.");
+        return Ok(());
+    }
+
+    for activity in &response.activities {
+        println!("Activity ID: {}", activity.id);
+        println!("  Type: {}", activity.r#type.as_str_name());
+        println!("  Status: {}", activity.status.as_str_name());
+        println!("  Fingerprint: {}", activity.fingerprint);
+        println!(
+            "  Created: {}",
+            format_created_at(activity.created_at.as_ref())
+        );
+        println!();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_activity_types_accepts_known_names() {
+        let parsed = parse_activity_types(&[
+            "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT".to_string(),
+            "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                ActivityType::CreateTvcDeployment,
+                ActivityType::CreateTvcManifestApprovals
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_activity_types_rejects_unknown_names() {
+        let error = parse_activity_types(&["NOT_A_REAL_ACTIVITY_TYPE".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("NOT_A_REAL_ACTIVITY_TYPE"));
+    }
+
+    #[test]
+    fn format_created_at_renders_rfc3339() {
+        let formatted = format_created_at(Some(&Timestamp {
+            seconds: "1752570000".to_string(),
+            nanos: "0".to_string(),
+        }));
+        assert!(formatted.starts_with("2025-07-15"), "{formatted}");
+    }
+
+    #[test]
+    fn format_created_at_falls_back_for_missing_timestamp() {
+        assert_eq!(format_created_at(None), "-");
+    }
+}

--- a/tvc/src/commands/activity/mod.rs
+++ b/tvc/src/commands/activity/mod.rs
@@ -1,0 +1,5 @@
+//! Activity commands: inspect and vote on activities pending consensus.
+
+pub mod approve;
+pub mod list;
+pub mod reject;

--- a/tvc/src/commands/activity/reject.rs
+++ b/tvc/src/commands/activity/reject.rs
@@ -1,0 +1,58 @@
+//! Activity reject command - vote to reject a pending activity by fingerprint.
+
+use crate::client::build_client;
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use turnkey_client::TurnkeyClientError;
+use turnkey_client::generated::RejectActivityIntent;
+
+/// Reject (vote against) an activity pending consensus.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Fingerprint of the activity to reject (see `tvc activity list`).
+    #[arg(long, env = "TVC_ACTIVITY_FINGERPRINT")]
+    pub fingerprint: String,
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let auth = build_client().await?;
+    let timestamp_ms = auth.client.current_timestamp();
+
+    let result = auth
+        .client
+        .reject_activity(
+            auth.org_id.clone(),
+            timestamp_ms,
+            RejectActivityIntent {
+                fingerprint: args.fingerprint.clone(),
+            },
+        )
+        .await;
+
+    match result {
+        Ok(activity) => {
+            println!(
+                "Rejection submitted for activity {} (fingerprint {}).",
+                activity.id, args.fingerprint
+            );
+            Ok(())
+        }
+        // A completed rejection flips the activity to ACTIVITY_STATUS_REJECTED,
+        // which the client's polling loop reports as an unexpected status.
+        Err(TurnkeyClientError::UnexpectedActivityStatus(status))
+            if status == "ACTIVITY_STATUS_REJECTED" =>
+        {
+            println!(
+                "Rejection submitted for activity with fingerprint {}. The activity is now rejected.",
+                args.fingerprint
+            );
+            Ok(())
+        }
+        Err(TurnkeyClientError::ActivityPendingConsensus { activity_id, .. }) => {
+            println!("Rejection vote recorded. Activity {activity_id} is still pending quorum.");
+            Ok(())
+        }
+        Err(error) => Err(error).context("failed to reject activity"),
+    }
+}

--- a/tvc/src/commands/consensus.rs
+++ b/tvc/src/commands/consensus.rs
@@ -1,7 +1,14 @@
 //! Helpers for activity responses that were accepted but still need quorum.
 
-use anyhow::Result;
+use crate::client::AuthenticatedClient;
+use anyhow::{Context, Result};
 use turnkey_client::TurnkeyClientError;
+use turnkey_client::generated::intent::Inner;
+use turnkey_client::generated::{
+    Activity, ApproveActivityIntent, GetOrganizationConfigsRequest, GetWhoamiRequest,
+};
+
+const VOTE_SELECTION_APPROVED: &str = "VOTE_SELECTION_APPROVED";
 
 pub(crate) struct PendingConsensusActivity<'a> {
     pub activity_id: &'a str,
@@ -40,4 +47,254 @@ pub(crate) fn print_pending_consensus(activity: &PendingConsensusActivity<'_>) {
 pub(crate) fn pending_consensus_result(activity: &PendingConsensusActivity<'_>) -> Result<()> {
     print_pending_consensus(activity);
     Err(crate::exit::ExitError::consensus_needed().into())
+}
+
+/// Find a pending activity whose intent contents exactly match `intent`.
+///
+/// The submission timestamp lives in the request envelope (`timestampMs`),
+/// not in the intent, so intent equality identifies an operator re-running
+/// the same request even though the server fingerprints each raw request
+/// body differently.
+pub(crate) fn find_matching_pending_activity<'a>(
+    activities: &'a [Activity],
+    intent: &Inner,
+) -> Option<&'a Activity> {
+    activities
+        .iter()
+        .find(|activity| activity.intent.as_ref().and_then(|i| i.inner.as_ref()) == Some(intent))
+}
+
+/// Number of approval votes already recorded on an activity.
+pub(crate) fn approval_vote_count(activity: &Activity) -> usize {
+    activity
+        .votes
+        .iter()
+        .filter(|vote| vote.selection == VOTE_SELECTION_APPROVED)
+        .count()
+}
+
+/// Whether `user_id` has already recorded an approval vote on the activity.
+pub(crate) fn user_already_approved(activity: &Activity, user_id: &str) -> bool {
+    activity
+        .votes
+        .iter()
+        .any(|vote| vote.user_id == user_id && vote.selection == VOTE_SELECTION_APPROVED)
+}
+
+/// Resolve the authenticated user's ID via the whoami endpoint.
+pub(crate) async fn current_user_id(auth: &AuthenticatedClient) -> Result<String> {
+    let whoami = auth
+        .client
+        .get_whoami(GetWhoamiRequest {
+            organization_id: auth.org_id.clone(),
+        })
+        .await
+        .context("failed to resolve current user")?;
+    Ok(whoami.user_id)
+}
+
+/// Best-effort lookup of the org's root quorum threshold for progress display.
+async fn root_quorum_threshold(auth: &AuthenticatedClient) -> Option<i32> {
+    auth.client
+        .get_organization_configs(GetOrganizationConfigsRequest {
+            organization_id: auth.org_id.clone(),
+        })
+        .await
+        .ok()?
+        .configs?
+        .quorum
+        .map(|quorum| quorum.threshold)
+}
+
+/// Print the "already approved" message with vote progress.
+pub(crate) async fn print_already_approved(auth: &AuthenticatedClient, activity: &Activity) {
+    let approvals = approval_vote_count(activity);
+    let progress = match root_quorum_threshold(auth).await {
+        Some(threshold) if threshold > 0 => {
+            format!("{approvals} of {threshold} approval votes so far")
+        }
+        _ => format!("{approvals} approval vote(s) so far"),
+    };
+    println!(
+        "You have already approved this activity; waiting on other quorum members — {progress}."
+    );
+}
+
+/// Vote (approve) on an existing pending activity instead of creating a
+/// duplicate one.
+///
+/// Returns `Ok(())` when the vote completed quorum. When the activity is
+/// still pending quorum after the vote, prints "vote recorded" and returns
+/// the dedicated consensus-needed exit error (code 2) because the overall
+/// operation is not complete yet.
+pub(crate) async fn vote_on_existing_activity(
+    auth: &AuthenticatedClient,
+    existing: &Activity,
+) -> Result<()> {
+    println!();
+    println!(
+        "An identical request is already pending consensus; voting on it instead of creating a duplicate activity."
+    );
+    println!();
+    println!("Activity ID: {}", existing.id);
+    println!("Fingerprint: {}", existing.fingerprint);
+
+    let user_id = current_user_id(auth).await?;
+    if user_already_approved(existing, &user_id) {
+        println!();
+        print_already_approved(auth, existing).await;
+        return Ok(());
+    }
+
+    let timestamp_ms = auth.client.current_timestamp();
+    let result = auth
+        .client
+        .approve_activity(
+            auth.org_id.clone(),
+            timestamp_ms,
+            ApproveActivityIntent {
+                fingerprint: existing.fingerprint.clone(),
+            },
+        )
+        .await;
+
+    match result {
+        Ok(activity) => {
+            println!();
+            println!(
+                "Approval vote submitted: quorum reached and activity {} completed.",
+                activity.id
+            );
+            Ok(())
+        }
+        Err(TurnkeyClientError::ActivityPendingConsensus {
+            activity_id,
+            fingerprint,
+        }) => {
+            println!();
+            println!("Vote recorded. Activity {activity_id} is still pending quorum.");
+            println!();
+            println!("Next steps:");
+            println!(
+                "  - Ask another quorum member to run `tvc activity approve --fingerprint {fingerprint}`"
+            );
+            Err(crate::exit::ExitError::consensus_needed().into())
+        }
+        Err(error) => Err(error).context("failed to vote on existing pending activity"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use turnkey_client::generated::intent::Inner;
+    use turnkey_client::generated::{
+        Activity, ActivityStatus, ActivityType, CreateTvcManifestApprovalsIntent, Intent,
+        TvcManifestApproval,
+    };
+
+    fn approvals_intent(manifest_id: &str, signature: &str) -> Inner {
+        Inner::CreateTvcManifestApprovalsIntent(CreateTvcManifestApprovalsIntent {
+            manifest_id: manifest_id.to_string(),
+            approvals: vec![TvcManifestApproval {
+                operator_id: "operator-1".to_string(),
+                signature: signature.to_string(),
+            }],
+        })
+    }
+
+    fn pending_activity(id: &str, intent: Option<Inner>) -> Activity {
+        Activity {
+            id: id.to_string(),
+            organization_id: "org-test".to_string(),
+            status: ActivityStatus::ConsensusNeeded,
+            r#type: ActivityType::CreateTvcManifestApprovals,
+            intent: intent.map(|inner| Intent { inner: Some(inner) }),
+            result: None,
+            votes: vec![],
+            app_proofs: vec![],
+            fingerprint: format!("fp-{id}"),
+            can_approve: true,
+            can_reject: true,
+            created_at: None,
+            updated_at: None,
+            failure: None,
+        }
+    }
+
+    #[test]
+    fn matcher_finds_activity_with_identical_intent() {
+        let activities = vec![
+            pending_activity("other", Some(approvals_intent("manifest-b", "sig-b"))),
+            pending_activity("match", Some(approvals_intent("manifest-a", "sig-a"))),
+        ];
+
+        let found =
+            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+
+        assert_eq!(found.map(|a| a.id.as_str()), Some("match"));
+    }
+
+    #[test]
+    fn matcher_rejects_activity_with_different_intent_contents() {
+        let activities = vec![pending_activity(
+            "other",
+            Some(approvals_intent("manifest-a", "another-operator-sig")),
+        )];
+
+        let found =
+            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn matcher_ignores_activities_without_intent() {
+        let activities = vec![pending_activity("no-intent", None)];
+
+        let found =
+            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+
+        assert!(found.is_none());
+    }
+
+    fn vote(user_id: &str, selection: &str) -> turnkey_client::generated::Vote {
+        turnkey_client::generated::Vote {
+            id: format!("vote-{user_id}"),
+            user_id: user_id.to_string(),
+            user: None,
+            activity_id: "activity-1".to_string(),
+            selection: selection.to_string(),
+            message: "{}".to_string(),
+            public_key: "public-key".to_string(),
+            signature: "signature".to_string(),
+            scheme: "SIGNATURE_SCHEME_TK_API_P256".to_string(),
+            created_at: None,
+        }
+    }
+
+    #[test]
+    fn approval_vote_count_only_counts_approvals() {
+        let mut activity = pending_activity("counted", None);
+        activity.votes = vec![
+            vote("user-1", VOTE_SELECTION_APPROVED),
+            vote("user-2", "VOTE_SELECTION_REJECTED"),
+            vote("user-3", VOTE_SELECTION_APPROVED),
+        ];
+
+        assert_eq!(approval_vote_count(&activity), 2);
+    }
+
+    #[test]
+    fn user_already_approved_matches_only_approvals_by_that_user() {
+        let mut activity = pending_activity("voted", None);
+        activity.votes = vec![
+            vote("user-1", VOTE_SELECTION_APPROVED),
+            vote("user-2", "VOTE_SELECTION_REJECTED"),
+        ];
+
+        assert!(user_already_approved(&activity, "user-1"));
+        assert!(!user_already_approved(&activity, "user-2"));
+        assert!(!user_already_approved(&activity, "user-3"));
+    }
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -19,7 +19,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 use turnkey_client::generated::{
-    CreateTvcManifestApprovalsIntent, GetTvcDeploymentRequest, TvcManifestApproval,
+    ActivityStatus, ActivityType, CreateTvcManifestApprovalsIntent, GetActivitiesRequest,
+    GetTvcDeploymentRequest, TvcManifestApproval, intent,
 };
 
 const QUORUM_REACHED_MESSAGE: &str =
@@ -303,6 +304,27 @@ async fn post_approval_to_api(
         manifest_id: plan.manifest_id.into(),
         approvals: vec![tvc_approval],
     };
+
+    // Re-running this command after a consensus-needed response must vote on
+    // the existing pending activity instead of creating a duplicate one.
+    let pending = auth
+        .client
+        .get_activities(GetActivitiesRequest {
+            organization_id: auth.org_id.clone(),
+            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
+            pagination_options: None,
+            filter_by_type: vec![ActivityType::CreateTvcManifestApprovals],
+        })
+        .await
+        .context("failed to check for pending manifest approval activities")?;
+
+    let intent_inner = intent::Inner::CreateTvcManifestApprovalsIntent(intent.clone());
+    if let Some(existing) = crate::commands::consensus::find_matching_pending_activity(
+        &pending.activities,
+        &intent_inner,
+    ) {
+        return crate::commands::consensus::vote_on_existing_activity(&auth, existing).await;
+    }
 
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -11,7 +11,10 @@ use clap::Args as ClapArgs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
-use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
+use turnkey_client::generated::{
+    ActivityStatus, ActivityType, CreateTvcDeploymentIntent, GetActivitiesRequest,
+    ValidateTvcImageRequest, intent,
+};
 
 pub(crate) const LONG_ABOUT: &str = r#"
 Create a new TVC deployment.
@@ -406,6 +409,27 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
         pinned_image_url,
         pivot_container_encrypted_pull_secret,
     );
+
+    // Re-running this command after a consensus-needed response must vote on
+    // the existing pending activity instead of creating a duplicate one.
+    let pending = auth
+        .client
+        .get_activities(GetActivitiesRequest {
+            organization_id: auth.org_id.clone(),
+            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
+            pagination_options: None,
+            filter_by_type: vec![ActivityType::CreateTvcDeployment],
+        })
+        .await
+        .context("failed to check for pending deployment activities")?;
+
+    let intent_inner = intent::Inner::CreateTvcDeploymentIntent(intent.clone());
+    if let Some(existing) = crate::commands::consensus::find_matching_pending_activity(
+        &pending.activities,
+        &intent_inner,
+    ) {
+        return crate::commands::consensus::vote_on_existing_activity(&auth, existing).await;
+    }
 
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -4,6 +4,7 @@
 //! - An `Args` struct deriving `clap::Args`
 //! - A `run(args, config) -> anyhow::Result<()>` function
 
+pub mod activity;
 pub mod app;
 pub mod app_status;
 pub mod confirmation;

--- a/tvc/tests/activity.rs
+++ b/tvc/tests/activity.rs
@@ -1,0 +1,314 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ENV_ORG_ID: &str = "TVC_ORG_ID";
+const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
+const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
+const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const ORG_ID: &str = "org-test";
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+fn authed_tvc_cmd(server: &MockServer) -> assert_cmd::Command {
+    let (public_key, private_key) = generated_api_key();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .env(ENV_ORG_ID, ORG_ID)
+        .env(ENV_API_BASE_URL, server.uri())
+        .env(ENV_API_KEY_PUBLIC, public_key)
+        .env(ENV_API_KEY_PRIVATE, private_key);
+    cmd
+}
+
+#[test]
+fn activity_help_lists_subcommands() {
+    cargo_bin_cmd!("tvc")
+        .arg("activity")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("approve"))
+        .stdout(predicate::str::contains("reject"));
+}
+
+#[test]
+fn activity_approve_requires_fingerprint() {
+    cargo_bin_cmd!("tvc")
+        .arg("activity")
+        .arg("approve")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--fingerprint"));
+}
+
+#[test]
+fn activity_reject_requires_fingerprint() {
+    cargo_bin_cmd!("tvc")
+        .arg("activity")
+        .arg("reject")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--fingerprint"));
+}
+
+#[test]
+fn activity_list_rejects_unknown_activity_type() {
+    cargo_bin_cmd!("tvc")
+        .arg("activity")
+        .arg("list")
+        .arg("--activity-type")
+        .arg("NOT_A_REAL_ACTIVITY_TYPE")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("NOT_A_REAL_ACTIVITY_TYPE"));
+}
+
+#[tokio::test]
+async fn activity_list_shows_pending_activities() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activities": [
+                {
+                    "id": "activity-1",
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                    "fingerprint": "fp-1",
+                    "createdAt": { "seconds": "1752570000", "nanos": "0" }
+                },
+                {
+                    "id": "activity-2",
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS",
+                    "fingerprint": "fp-2"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("activity-1"))
+        .stdout(predicate::str::contains("fp-1"))
+        .stdout(predicate::str::contains(
+            "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+        ))
+        .stdout(predicate::str::contains("ACTIVITY_STATUS_CONSENSUS_NEEDED"))
+        .stdout(predicate::str::contains("2025-07-15"))
+        .stdout(predicate::str::contains("activity-2"))
+        .stdout(predicate::str::contains("fp-2"));
+}
+
+#[tokio::test]
+async fn activity_list_reports_when_nothing_matches() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "activities": [] })),
+        )
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No matching activities"));
+}
+
+async fn mount_no_pending_activities(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "activities": [] })),
+        )
+        .mount(server)
+        .await;
+}
+
+async fn mount_whoami(server: &MockServer, user_id: &str) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "organizationId": ORG_ID,
+            "organizationName": "Test Org",
+            "userId": user_id,
+            "username": "root-user"
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn activity_approve_skips_when_user_already_voted() {
+    let server = MockServer::start().await;
+    mount_whoami(&server, "user-current").await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activities": [
+                {
+                    "id": "activity-1",
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                    "fingerprint": "fp-1",
+                    "votes": [
+                        {
+                            "id": "vote-1",
+                            "userId": "user-current",
+                            "activityId": "activity-1",
+                            "selection": "VOTE_SELECTION_APPROVED",
+                            "message": "{}",
+                            "publicKey": "public-key",
+                            "signature": "signature",
+                            "scheme": "SIGNATURE_SCHEME_TK_API_P256"
+                        }
+                    ]
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/get_organization_configs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "configs": {
+                "features": [],
+                "quorum": { "threshold": 2, "userIds": ["u1", "u2"] }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // Already voted: no new approval may be submitted.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("approve")
+        .arg("--fingerprint")
+        .arg("fp-1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already approved"))
+        .stdout(predicate::str::contains("1 of 2"));
+}
+
+#[tokio::test]
+async fn activity_approve_reports_vote_recorded_when_quorum_still_pending() {
+    let server = MockServer::start().await;
+    mount_no_pending_activities(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "activity-1",
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": "fp-1"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("approve")
+        .arg("--fingerprint")
+        .arg("fp-1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Vote recorded"))
+        .stdout(predicate::str::contains("still pending quorum"));
+}
+
+#[tokio::test]
+async fn activity_approve_reports_completion_when_quorum_reached() {
+    let server = MockServer::start().await;
+    mount_no_pending_activities(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "activity-1",
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": "fp-1"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("approve")
+        .arg("--fingerprint")
+        .arg("fp-1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Approval submitted"))
+        .stdout(predicate::str::contains("activity-1"))
+        .stdout(predicate::str::contains("completed"));
+}
+
+#[tokio::test]
+async fn activity_reject_reports_rejection() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/reject_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "activity-1",
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_REJECTED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": "fp-1"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("activity")
+        .arg("reject")
+        .arg("--fingerprint")
+        .arg("fp-1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rejection submitted"))
+        .stdout(predicate::str::contains("fp-1"));
+}

--- a/tvc/tests/deploy_consensus.rs
+++ b/tvc/tests/deploy_consensus.rs
@@ -49,6 +49,16 @@ async fn mount_tvc_app_lookup(server: &MockServer) {
         .await;
 }
 
+async fn mount_no_pending_activities(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "activities": [] })),
+        )
+        .mount(server)
+        .await;
+}
+
 fn consensus_needed_activity(activity_type: &str) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(serde_json::json!({
         "activity": {
@@ -65,6 +75,7 @@ fn consensus_needed_activity(activity_type: &str) -> ResponseTemplate {
 async fn deploy_create_reports_consensus_needed_without_generic_failure() {
     let server = MockServer::start().await;
     mount_tvc_app_lookup(&server).await;
+    mount_no_pending_activities(&server).await;
 
     Mock::given(method("POST"))
         .and(path("/public/v1/query/validate_tvc_image"))
@@ -110,6 +121,7 @@ async fn deploy_create_reports_consensus_needed_without_generic_failure() {
 #[tokio::test]
 async fn deploy_approve_reports_consensus_needed_without_generic_failure() {
     let server = MockServer::start().await;
+    mount_no_pending_activities(&server).await;
     let approval_out = NamedTempFile::new().unwrap();
 
     Mock::given(method("POST"))

--- a/tvc/tests/deploy_dedup.rs
+++ b/tvc/tests/deploy_dedup.rs
@@ -1,0 +1,423 @@
+//! Pre-submit dedup: `tvc deploy create` and `tvc deploy approve` must vote
+//! on an existing pending activity with an identical intent instead of
+//! creating a duplicate.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ENV_ORG_ID: &str = "TVC_ORG_ID";
+const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
+const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
+const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const ORG_ID: &str = "org-test";
+const APP_ID: &str = "11111111-1111-1111-1111-111111111111";
+const EXISTING_ACTIVITY_ID: &str = "activity-existing";
+const EXISTING_FINGERPRINT: &str = "fp-existing";
+const CURRENT_USER_ID: &str = "user-current";
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+fn authed_tvc_cmd(server: &MockServer) -> assert_cmd::Command {
+    let (public_key, private_key) = generated_api_key();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .env(ENV_ORG_ID, ORG_ID)
+        .env(ENV_API_BASE_URL, server.uri())
+        .env(ENV_API_KEY_PUBLIC, public_key)
+        .env(ENV_API_KEY_PRIVATE, private_key);
+    cmd
+}
+
+async fn mount_tvc_app_lookup(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/get_tvc_app"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tvcApp": {
+                "id": APP_ID,
+                "organizationId": ORG_ID,
+                "name": "test app",
+                "quorumPublicKey": "quorum-public-key",
+                "publicDomain": "example.com"
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_image_validation(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/validate_tvc_image"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "resolvedImageDigest": "sha256:resolved"
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Intent JSON matching exactly what the CLI builds from `create_args`.
+fn matching_intent_json(app_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "createTvcDeploymentIntent": {
+            "appId": app_id,
+            "qosVersion": "0.12.1",
+            "pivotContainerImageUrl": "ghcr.io/team/app:latest@sha256:resolved",
+            "pivotPath": "/app",
+            "pivotArgs": [],
+            "expectedPivotDigest": "sha256:resolved",
+            "debugMode": false,
+            "healthCheckType": "TVC_HEALTH_CHECK_TYPE_HTTP",
+            "healthCheckPort": 3000,
+            "publicIngressPort": 3000
+        }
+    })
+}
+
+async fn mount_whoami(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "organizationId": ORG_ID,
+            "organizationName": "Test Org",
+            "userId": CURRENT_USER_ID,
+            "username": "root-user"
+        })))
+        .mount(server)
+        .await;
+}
+
+fn approval_vote(user_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("vote-{user_id}"),
+        "userId": user_id,
+        "activityId": EXISTING_ACTIVITY_ID,
+        "selection": "VOTE_SELECTION_APPROVED",
+        "message": "{}",
+        "publicKey": "public-key",
+        "signature": "signature",
+        "scheme": "SIGNATURE_SCHEME_TK_API_P256"
+    })
+}
+
+async fn mount_pending_activities_with_votes(
+    server: &MockServer,
+    intent: serde_json::Value,
+    votes: Vec<serde_json::Value>,
+) {
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activities": [
+                {
+                    "id": EXISTING_ACTIVITY_ID,
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                    "fingerprint": EXISTING_FINGERPRINT,
+                    "intent": intent,
+                    "votes": votes
+                }
+            ]
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_pending_activities(server: &MockServer, intent: serde_json::Value) {
+    mount_pending_activities_with_votes(server, intent, vec![]).await;
+}
+
+fn create_args(cmd: &mut assert_cmd::Command) -> &mut assert_cmd::Command {
+    cmd.arg("--non-interactive")
+        .arg("deploy")
+        .arg("create")
+        .arg("--app-id")
+        .arg(APP_ID)
+        .arg("--qos-version")
+        .arg("0.12.1")
+        .arg("--pivot-image-url")
+        .arg("ghcr.io/team/app:latest")
+        .arg("--expected-pivot-digest")
+        .arg("sha256:resolved")
+        .arg("--pivot-path")
+        .arg("/app")
+}
+
+#[tokio::test]
+async fn deploy_create_votes_on_existing_matching_activity() {
+    let server = MockServer::start().await;
+    mount_tvc_app_lookup(&server).await;
+    mount_image_validation(&server).await;
+    mount_whoami(&server).await;
+    mount_pending_activities(&server, matching_intent_json(APP_ID)).await;
+
+    // Voting on the existing activity; quorum still not reached afterwards.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": EXISTING_ACTIVITY_ID,
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": EXISTING_FINGERPRINT
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // The dedup path must NOT create a new activity.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_deployment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let mut cmd = authed_tvc_cmd(&server);
+    create_args(&mut cmd)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("already pending"))
+        .stdout(predicate::str::contains(EXISTING_ACTIVITY_ID))
+        .stdout(predicate::str::contains(EXISTING_FINGERPRINT))
+        .stdout(predicate::str::contains("Vote recorded"))
+        .stdout(predicate::str::contains("still pending quorum"));
+}
+
+#[tokio::test]
+async fn deploy_create_vote_completing_quorum_succeeds() {
+    let server = MockServer::start().await;
+    mount_tvc_app_lookup(&server).await;
+    mount_image_validation(&server).await;
+    mount_whoami(&server).await;
+    mount_pending_activities(&server, matching_intent_json(APP_ID)).await;
+
+    // Voting on the existing activity completes quorum.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": EXISTING_ACTIVITY_ID,
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": EXISTING_FINGERPRINT
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_deployment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let mut cmd = authed_tvc_cmd(&server);
+    create_args(&mut cmd)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already pending"))
+        .stdout(predicate::str::contains("quorum reached"));
+}
+
+#[tokio::test]
+async fn deploy_create_skips_vote_when_user_already_approved() {
+    let server = MockServer::start().await;
+    mount_tvc_app_lookup(&server).await;
+    mount_image_validation(&server).await;
+    mount_whoami(&server).await;
+    // The current user already approved the pending activity; one other
+    // quorum member also approved.
+    mount_pending_activities_with_votes(
+        &server,
+        matching_intent_json(APP_ID),
+        vec![approval_vote(CURRENT_USER_ID), approval_vote("user-other")],
+    )
+    .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/get_organization_configs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "configs": {
+                "features": [],
+                "quorum": { "threshold": 3, "userIds": ["u1", "u2", "u3"] }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // No new vote and no new activity may be submitted.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_deployment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let mut cmd = authed_tvc_cmd(&server);
+    create_args(&mut cmd)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already approved"))
+        .stdout(predicate::str::contains(EXISTING_ACTIVITY_ID))
+        .stdout(predicate::str::contains("2 of 3"));
+}
+
+/// Generate the (deterministic) operator approval offline so the test knows
+/// the exact signature the CLI will post, then serve a pending activity with
+/// that same intent.
+fn captured_manifest_approval_signature() -> String {
+    let approval_out = tempfile::NamedTempFile::new().unwrap();
+    cargo_bin_cmd!("tvc")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--dangerous-skip-interactive")
+        .arg("--skip-post")
+        .arg("--approval-out")
+        .arg(approval_out.path())
+        .assert()
+        .success();
+
+    let approval: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(approval_out.path()).unwrap()).unwrap();
+    approval["signature"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn deploy_approve_votes_on_existing_matching_activity() {
+    const MANIFEST_ID: &str = "22222222-2222-2222-2222-222222222222";
+    const OPERATOR_ID: &str = "33333333-3333-3333-3333-333333333333";
+
+    let signature = captured_manifest_approval_signature();
+
+    let server = MockServer::start().await;
+    mount_whoami(&server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activities": [
+                {
+                    "id": EXISTING_ACTIVITY_ID,
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS",
+                    "fingerprint": EXISTING_FINGERPRINT,
+                    "intent": {
+                        "createTvcManifestApprovalsIntent": {
+                            "manifestId": MANIFEST_ID,
+                            "approvals": [
+                                { "operatorId": OPERATOR_ID, "signature": signature }
+                            ]
+                        }
+                    }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": EXISTING_ACTIVITY_ID,
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS",
+                "fingerprint": EXISTING_FINGERPRINT
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // The dedup path must NOT post a duplicate manifest-approvals activity.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_manifest_approvals"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("--non-interactive")
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--manifest-id")
+        .arg(MANIFEST_ID)
+        .arg("--operator-id")
+        .arg(OPERATOR_ID)
+        .arg("--operator-seed")
+        .arg("fixtures/seed.hex")
+        .arg("--dangerous-skip-interactive")
+        .arg("--approval-out")
+        .arg(tempfile::NamedTempFile::new().unwrap().path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("already pending"))
+        .stdout(predicate::str::contains(EXISTING_ACTIVITY_ID))
+        .stdout(predicate::str::contains("Vote recorded"))
+        .stdout(predicate::str::contains("still pending quorum"));
+}
+
+#[tokio::test]
+async fn deploy_create_proceeds_when_no_pending_activity_matches() {
+    let server = MockServer::start().await;
+    mount_tvc_app_lookup(&server).await;
+    mount_image_validation(&server).await;
+    // Pending activity exists but for a different app: no dedup match.
+    mount_pending_activities(
+        &server,
+        matching_intent_json("99999999-9999-9999-9999-999999999999"),
+    )
+    .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_tvc_deployment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "activity-new",
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "type": "ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT",
+                "fingerprint": "fp-new"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cmd = authed_tvc_cmd(&server);
+    create_args(&mut cmd)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Consensus needed"))
+        .stdout(predicate::str::contains("activity-new"))
+        .stdout(predicate::str::contains("fp-new"));
+}


### PR DESCRIPTION
Part 3 of 3 for TVC-183. Stacked on #191 (base = `zeke/tvc-183-consensus-needed-cli`) so this PR shows only its own diff.

## Problem

#191 stops the CLI from mislabeling `ACTIVITY_STATUS_CONSENSUS_NEEDED` as a failure, but an operator who re-runs `tvc deploy create` / `tvc deploy approve` would still create a duplicate activity (each run stamps a fresh `timestampMs`, so the server fingerprint differs). There is also no way to vote on a pending activity from the CLI.

## Changes

### Pre-submit dedup in `deploy create` / `deploy approve`
Before submitting a new activity, the CLI queries `get_activities` filtered by `CONSENSUS_NEEDED` + the matching activity type (`CREATE_TVC_DEPLOYMENT` / `CREATE_TVC_MANIFEST_APPROVALS`) and compares **intent contents** client-side (the generated intent types derive `PartialEq`; the timestamp lives in the request envelope, not the intent, so intent equality identifies a re-run of the same request). When an identical request is already pending:
- **Already voted?** The CLI resolves the current user via `whoami` and inspects the activity's `votes`. If the user already approved, it does NOT submit another vote — it prints "you have already approved this activity; waiting on other quorum members — X of Y approval votes so far" (Y = root quorum threshold via `get_organization_configs`, best-effort) and exits cleanly (0).
- **Not voted yet:** it submits an approval vote via `approve_activity(ApproveActivityIntent { fingerprint })` instead of creating a duplicate.

### New `tvc activity` subcommand group
- `tvc activity list` — id, fingerprint, type, status, created time; defaults to consensus-needed, with `--status` (repeatable, value-enum) and `--activity-type` (repeatable, `ACTIVITY_TYPE_*` names) filters.
- `tvc activity approve --fingerprint <fp>` — votes on a pending activity; performs the same already-voted check first.
- `tvc activity reject --fingerprint <fp>` — votes against a pending activity. A completed rejection flips the activity to `ACTIVITY_STATUS_REJECTED`, which the client's polling loop surfaces as `UnexpectedActivityStatus`; the CLI maps that to a success message.

### Exit-code semantics (documented decision)
`approve_activity` itself routes through `process_activity`, so a vote that does not complete quorum also returns the consensus-needed condition. Handling is consistent by *operation*:
- `tvc activity approve` / `reject`: the vote **is** the operation — exit **0** when the vote is recorded, even if quorum is still pending.
- `deploy create` / `deploy approve` dedup path: the deployment operation is still incomplete after the vote — keep exit **2** (same dedicated code as #191) when quorum remains pending; exit 0 when the vote completes quorum. Already-voted (nothing to do) exits 0.

## Test coverage
- Unit tests: intent matcher (match / different contents / missing intent), `approval_vote_count`, `user_already_approved`, activity-type parsing, created-at formatting.
- `tvc/tests/activity.rs` (wiremock): subcommand help + required-arg parsing, list output (fields + empty case + unknown type rejection), approve → vote recorded / quorum completed / **already-voted skip (no second vote submitted, "1 of 2")**, reject.
- `tvc/tests/deploy_dedup.rs` (wiremock): create votes on matching pending activity (exit 2, no create call), vote completing quorum (exit 0), **already-approved skip (no vote, no create, "2 of 3")**, passthrough when nothing matches, and the manifest-approvals dedup path end-to-end using the operator's deterministic P256 signature captured from a `--skip-post` run.

## Verification
- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ (exit 0)
- `cargo test -p tvc -p turnkey_client` ✅ (256 tests, 0 failures)
- `git diff --check` ✅