### PR TITLE
tvc: add `tvc policy init` to provision TVC operator policies (no root quorum)

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -105,6 +105,11 @@ impl Cli {
                     commands::keys::re_encrypt_share::run(args).await
                 }
             },
+            Commands::Policy { command } => match command {
+                PolicyCommands::Init(args) => {
+                    commands::policy::init::run(args, non_interactive).await
+                }
+            },
             Commands::Login(args) => commands::login::run(args, non_interactive).await,
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(delete_args) => {
@@ -139,6 +144,11 @@ enum Commands {
         #[command(subcommand)]
         command: KeysCommands,
     },
+    /// Manage TVC org policies.
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommands,
+    },
 }
 
 impl Commands {
@@ -151,6 +161,7 @@ impl Commands {
             Commands::Deploy { command } => command.name(),
             Commands::App { command } => command.name(),
             Commands::Keys { command } => command.name(),
+            Commands::Policy { command } => command.name(),
         }
     }
 }
@@ -234,6 +245,12 @@ enum KeysCommands {
     ReEncryptShare(commands::keys::re_encrypt_share::Args),
 }
 
+#[derive(Debug, Subcommand)]
+enum PolicyCommands {
+    /// Provision TVC org policies for designated users.
+    Init(commands::policy::init::Args),
+}
+
 impl AppCommands {
     fn name(&self) -> &'static str {
         match self {
@@ -253,6 +270,14 @@ impl KeysCommands {
             KeysCommands::GenerateQuorumKey(_) => "keys generate-quorum-key",
             KeysCommands::InitQuorumKey(_) => "keys init-quorum-key",
             KeysCommands::ReEncryptShare(_) => "keys re-encrypt-share",
+        }
+    }
+}
+
+impl PolicyCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            PolicyCommands::Init(_) => "policy init",
         }
     }
 }

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod deploy;
 pub mod display;
 pub mod keys;
 pub mod login;
+pub mod policy;

--- a/tvc/src/commands/policy/init.rs
+++ b/tvc/src/commands/policy/init.rs
@@ -1,0 +1,454 @@
+//! Policy init command - provisions org policies for TVC resources.
+
+use crate::client::build_client;
+use crate::prompts;
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+use turnkey_client::TurnkeyClientError;
+use turnkey_client::generated::{
+    CreatePoliciesIntent, CreatePolicyIntentV3, CreateUserTagIntent, immutable::common::v1::Effect,
+};
+
+const CREATED_TAG_ID_PLACEHOLDER: &str = "<created tag ID from create_user_tag>";
+
+/// Provision TVC org policies for designated users.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = LONG_ABOUT)]
+pub struct Args {
+    /// Comma-separated TVC policy resources to allow.
+    #[arg(
+        long,
+        value_name = "LIST",
+        value_delimiter = ',',
+        default_value = "TVC_APP,TVC_DEPLOYMENT,TVC_OPERATOR,TVC_QUORUM_KEY"
+    )]
+    resources: Vec<TvcResource>,
+
+    /// Number of tagged/designated approvals required.
+    #[arg(long, default_value_t = 1)]
+    threshold: u32,
+
+    /// Create a user tag with this name and attach --user-ids before creating the policy.
+    #[arg(long, value_name = "NAME")]
+    tag_name: Option<String>,
+
+    /// Reuse an existing user tag UUID instead of creating one.
+    #[arg(long, value_name = "UUID")]
+    tag_id: Option<String>,
+
+    /// Comma-separated user UUIDs for tag creation or tagless policy consensus.
+    #[arg(long, value_name = "UUID,...", value_delimiter = ',')]
+    user_ids: Vec<String>,
+
+    /// Policy name. Defaults to tvc-operators-<resources>-threshold-<N>.
+    #[arg(long, value_name = "NAME")]
+    policy_name: Option<String>,
+
+    /// Optional policy notes.
+    #[arg(long)]
+    notes: Option<String>,
+
+    /// Print the generated policy and planned API calls without submitting anything.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub(crate) const LONG_ABOUT: &str = r#"
+Provision an organization policy that allows designated users to perform TVC
+actions without root-quorum consensus.
+
+The generated policy always includes both a TVC resource condition and a
+consensus expression. This command never creates a policy that targets every org
+user.
+
+Modes:
+  Tag mode with a new tag:
+    tvc policy init --tag-name "TVC Operators" --user-ids <UUID,...>
+
+  Tag mode with an existing tag:
+    tvc policy init --tag-id <TAG_UUID>
+
+  Tagless mode by user ID:
+    tvc policy init --user-ids <UUID,...>
+
+If your org root quorum is greater than one, creating the tag or policy may
+return pending consensus. In that case, root-quorum members must approve the
+printed activity ID before provisioning can continue."#;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TvcResource {
+    App,
+    Deployment,
+    Operator,
+    QuorumKey,
+}
+
+impl TvcResource {
+    pub fn all() -> Vec<Self> {
+        vec![Self::App, Self::Deployment, Self::Operator, Self::QuorumKey]
+    }
+
+    fn as_policy_value(self) -> &'static str {
+        match self {
+            Self::App => "TVC_APP",
+            Self::Deployment => "TVC_DEPLOYMENT",
+            Self::Operator => "TVC_OPERATOR",
+            Self::QuorumKey => "TVC_QUORUM_KEY",
+        }
+    }
+
+    fn default_name_part(self) -> &'static str {
+        match self {
+            Self::App => "tvc-app",
+            Self::Deployment => "tvc-deployment",
+            Self::Operator => "tvc-operator",
+            Self::QuorumKey => "tvc-quorum-key",
+        }
+    }
+}
+
+impl FromStr for TvcResource {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value.trim() {
+            "TVC_APP" => Ok(Self::App),
+            "TVC_DEPLOYMENT" => Ok(Self::Deployment),
+            "TVC_OPERATOR" => Ok(Self::Operator),
+            "TVC_QUORUM_KEY" => Ok(Self::QuorumKey),
+            other => Err(format!("invalid TVC policy resource: {other}")),
+        }
+    }
+}
+
+impl fmt::Display for TvcResource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_policy_value())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PolicySubject {
+    Tag { tag_id: String },
+    UserIds(Vec<String>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GeneratedPolicy {
+    pub policy_name: String,
+    pub effect: &'static str,
+    pub condition: String,
+    pub consensus: String,
+    pub notes: String,
+}
+
+enum Mode {
+    NewTag {
+        tag_name: String,
+        user_ids: Vec<String>,
+    },
+    ExistingTag {
+        tag_id: String,
+    },
+    UserIds(Vec<String>),
+}
+
+pub async fn run(args: Args, is_non_interactive: bool) -> Result<()> {
+    let mode = resolve_mode(&args)?;
+    let subject = match &mode {
+        Mode::NewTag { .. } => PolicySubject::Tag {
+            tag_id: CREATED_TAG_ID_PLACEHOLDER.to_string(),
+        },
+        Mode::ExistingTag { tag_id } => PolicySubject::Tag {
+            tag_id: tag_id.clone(),
+        },
+        Mode::UserIds(user_ids) => PolicySubject::UserIds(user_ids.clone()),
+    };
+    let preview = build_policy(
+        args.policy_name.clone(),
+        &args.resources,
+        args.threshold,
+        subject,
+        args.notes.clone(),
+    )?;
+
+    print_plan(&preview, &mode, args.dry_run)?;
+    if args.dry_run {
+        return Ok(());
+    }
+
+    if !is_non_interactive && prompts::stdin_can_prompt() {
+        prompts::confirm_or_bail("Create this TVC policy?", "policy provisioning")?;
+    }
+
+    let auth = build_client().await?;
+
+    let tag_id = match mode {
+        Mode::NewTag { tag_name, user_ids } => {
+            println!("Creating user tag '{tag_name}'...");
+            let result = auth
+                .client
+                .create_user_tag(
+                    auth.org_id.clone(),
+                    timestamp_ms()?,
+                    CreateUserTagIntent {
+                        user_tag_name: tag_name,
+                        user_ids,
+                    },
+                )
+                .await;
+            match result {
+                Ok(result) => {
+                    println!("Created user tag: {}", result.result.user_tag_id);
+                    result.result.user_tag_id
+                }
+                Err(TurnkeyClientError::ActivityRequiresApproval(activity_id)) => {
+                    exit_pending_consensus("create_user_tag", &activity_id);
+                }
+                Err(err) => return Err(anyhow!(err).context("failed to create user tag")),
+            }
+        }
+        Mode::ExistingTag { tag_id } => tag_id,
+        Mode::UserIds(_) => CREATED_TAG_ID_PLACEHOLDER.to_string(),
+    };
+
+    let subject = match &tag_id[..] {
+        CREATED_TAG_ID_PLACEHOLDER => match resolve_mode(&args)? {
+            Mode::UserIds(user_ids) => PolicySubject::UserIds(user_ids),
+            _ => unreachable!("placeholder tag ID is only used for dry-run and tagless mode"),
+        },
+        _ => PolicySubject::Tag { tag_id },
+    };
+    let policy = build_policy(
+        args.policy_name,
+        &args.resources,
+        args.threshold,
+        subject,
+        args.notes,
+    )?;
+
+    println!("Creating TVC policy '{}'...", policy.policy_name);
+    let result = auth
+        .client
+        .create_policies(
+            auth.org_id,
+            timestamp_ms()?,
+            CreatePoliciesIntent {
+                policies: vec![policy.clone().into_create_policy_intent()],
+            },
+        )
+        .await;
+
+    match result {
+        Ok(result) => {
+            println!("TVC policy created successfully.");
+            println!("Policy IDs: {}", result.result.policy_ids.join(", "));
+            Ok(())
+        }
+        Err(TurnkeyClientError::ActivityRequiresApproval(activity_id)) => {
+            exit_pending_consensus("create_policies", &activity_id);
+        }
+        Err(err) => Err(anyhow!(err).context("failed to create policies")),
+    }
+}
+
+pub fn build_policy(
+    policy_name: Option<String>,
+    resources: &[TvcResource],
+    threshold: u32,
+    subject: PolicySubject,
+    notes: Option<String>,
+) -> Result<GeneratedPolicy> {
+    if resources.is_empty() {
+        bail!("at least one TVC policy resource is required");
+    }
+    if threshold == 0 {
+        bail!("--threshold must be at least 1");
+    }
+
+    let consensus = build_consensus(threshold, subject)?;
+    if consensus.trim().is_empty() {
+        bail!("internal error: generated policy consensus cannot be empty");
+    }
+
+    Ok(GeneratedPolicy {
+        policy_name: policy_name.unwrap_or_else(|| default_policy_name(resources, threshold)),
+        effect: "EFFECT_ALLOW",
+        condition: build_condition(resources),
+        consensus,
+        notes: notes.unwrap_or_default(),
+    })
+}
+
+impl GeneratedPolicy {
+    fn into_create_policy_intent(self) -> CreatePolicyIntentV3 {
+        CreatePolicyIntentV3 {
+            policy_name: self.policy_name,
+            effect: Effect::Allow,
+            condition: Some(self.condition),
+            consensus: Some(self.consensus),
+            notes: self.notes,
+        }
+    }
+}
+
+fn resolve_mode(args: &Args) -> Result<Mode> {
+    let user_ids = normalize_user_ids(&args.user_ids)?;
+    let has_user_ids = !user_ids.is_empty();
+    let has_tag_name = args.tag_name.as_ref().is_some_and(|v| !v.trim().is_empty());
+    let has_tag_id = args.tag_id.as_ref().is_some_and(|v| !v.trim().is_empty());
+
+    match (has_tag_id, has_tag_name, has_user_ids) {
+        (true, false, false) => Ok(Mode::ExistingTag {
+            tag_id: args.tag_id.clone().unwrap(),
+        }),
+        (false, true, true) => Ok(Mode::NewTag {
+            tag_name: args.tag_name.clone().unwrap(),
+            user_ids,
+        }),
+        (false, false, true) => Ok(Mode::UserIds(user_ids)),
+        _ => bail!(
+            "provide --tag-id, or provide --user-ids with --tag-name for tag mode, or --user-ids alone for tagless mode"
+        ),
+    }
+}
+
+fn normalize_user_ids(user_ids: &[String]) -> Result<Vec<String>> {
+    let mut normalized = Vec::new();
+    for user_id in user_ids {
+        let trimmed = user_id.trim();
+        if trimmed.is_empty() {
+            bail!("--user-ids cannot contain empty values");
+        }
+        normalized.push(trimmed.to_string());
+    }
+    Ok(normalized)
+}
+
+fn build_condition(resources: &[TvcResource]) -> String {
+    if resources.len() == 1 {
+        return format!("activity.resource == '{}'", resources[0].as_policy_value());
+    }
+
+    format!(
+        "activity.resource in [{}]",
+        resources
+            .iter()
+            .map(|resource| format!("'{}'", resource.as_policy_value()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn build_consensus(threshold: u32, subject: PolicySubject) -> Result<String> {
+    match subject {
+        PolicySubject::Tag { tag_id } => {
+            if tag_id.trim().is_empty() {
+                bail!("tag ID cannot be empty");
+            }
+            if threshold == 1 {
+                Ok(format!(
+                    "approvers.any(user, user.tags.contains('{tag_id}'))"
+                ))
+            } else {
+                Ok(format!(
+                    "approvers.filter(user, user.tags.contains('{tag_id}')).count() >= {threshold}"
+                ))
+            }
+        }
+        PolicySubject::UserIds(user_ids) => {
+            let user_ids = normalize_user_ids(&user_ids)?;
+            if user_ids.is_empty() {
+                bail!("at least one --user-ids value is required for tagless mode");
+            }
+            let list = format_string_list(&user_ids);
+            if threshold == 1 {
+                if user_ids.len() == 1 {
+                    Ok(format!("approvers.any(user, user.id == '{}')", user_ids[0]))
+                } else {
+                    Ok(format!("approvers.any(user, user.id in {list})"))
+                }
+            } else {
+                Ok(format!(
+                    "approvers.filter(user, user.id in {list}).count() >= {threshold}"
+                ))
+            }
+        }
+    }
+}
+
+fn format_string_list(values: &[String]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(|value| format!("'{value}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn default_policy_name(resources: &[TvcResource], threshold: u32) -> String {
+    let resource_part = if resources == TvcResource::all().as_slice() {
+        "all-resources".to_string()
+    } else {
+        resources
+            .iter()
+            .map(|resource| resource.default_name_part())
+            .collect::<Vec<_>>()
+            .join("-")
+    };
+
+    format!("tvc-operators-{resource_part}-threshold-{threshold}")
+}
+
+fn print_plan(policy: &GeneratedPolicy, mode: &Mode, dry_run: bool) -> Result<()> {
+    if dry_run {
+        println!("Dry run: no API calls will be submitted.");
+    }
+    println!("Generated TVC policy:");
+    println!("{}", serde_json::to_string_pretty(policy)?);
+    println!();
+    println!("Planned API calls:");
+    match mode {
+        Mode::NewTag { tag_name, user_ids } => {
+            println!(
+                "1. create_user_tag: name='{tag_name}', user_ids=[{}]",
+                user_ids.join(", ")
+            );
+            println!("2. create_policies: 1 EFFECT_ALLOW policy for TVC resources");
+        }
+        Mode::ExistingTag { tag_id } => {
+            println!("1. create_policies: 1 EFFECT_ALLOW policy using tag '{tag_id}'");
+        }
+        Mode::UserIds(user_ids) => {
+            println!(
+                "1. create_policies: 1 EFFECT_ALLOW policy using user_ids=[{}]",
+                user_ids.join(", ")
+            );
+        }
+    }
+    println!();
+    Ok(())
+}
+
+fn timestamp_ms() -> Result<u128> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system time before unix epoch")?
+        .as_millis())
+}
+
+fn exit_pending_consensus(activity_name: &str, activity_id: &str) -> ! {
+    eprintln!("Provisioning activity is pending root-quorum consensus.");
+    eprintln!("Activity: {activity_name}");
+    eprintln!("Activity ID: {activity_id}");
+    eprintln!(
+        "Ask the required root-quorum members to approve this activity, then rerun `tvc policy init` if the remaining provisioning step has not yet run."
+    );
+    std::process::exit(2);
+}

--- a/tvc/src/commands/policy/mod.rs
+++ b/tvc/src/commands/policy/mod.rs
@@ -1,0 +1,3 @@
+//! Policy commands.
+
+pub mod init;

--- a/tvc/tests/policy_init.rs
+++ b/tvc/tests/policy_init.rs
@@ -1,0 +1,181 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::TempDir;
+use tvc::commands::policy::init::{PolicySubject, TvcResource, build_policy};
+
+fn tvc_cmd() -> (TempDir, assert_cmd::Command) {
+    let temp = TempDir::new().unwrap();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear().env("HOME", temp.path());
+    (temp, cmd)
+}
+
+#[test]
+fn all_resources_default_uses_in_condition_and_tag_single_approval() {
+    let policy = build_policy(
+        None,
+        &TvcResource::all(),
+        1,
+        PolicySubject::Tag {
+            tag_id: "tag_123".to_string(),
+        },
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        policy.policy_name,
+        "tvc-operators-all-resources-threshold-1"
+    );
+    assert_eq!(
+        policy.condition,
+        "activity.resource in ['TVC_APP', 'TVC_DEPLOYMENT', 'TVC_OPERATOR', 'TVC_QUORUM_KEY']"
+    );
+    assert_eq!(
+        policy.consensus,
+        "approvers.any(user, user.tags.contains('tag_123'))"
+    );
+    assert_eq!(policy.notes, "");
+}
+
+#[test]
+fn single_resource_uses_equality_condition() {
+    let policy = build_policy(
+        Some("custom-policy".to_string()),
+        &[TvcResource::Deployment],
+        2,
+        PolicySubject::Tag {
+            tag_id: "tag_abc".to_string(),
+        },
+        Some("operators can deploy".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(policy.policy_name, "custom-policy");
+    assert_eq!(policy.condition, "activity.resource == 'TVC_DEPLOYMENT'");
+    assert_eq!(
+        policy.consensus,
+        "approvers.filter(user, user.tags.contains('tag_abc')).count() >= 2"
+    );
+    assert_eq!(policy.notes, "operators can deploy");
+}
+
+#[test]
+fn resource_subset_preserves_requested_order_in_membership_condition() {
+    let policy = build_policy(
+        None,
+        &[TvcResource::Operator, TvcResource::Deployment],
+        1,
+        PolicySubject::UserIds(vec!["user_1".to_string(), "user_2".to_string()]),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        policy.policy_name,
+        "tvc-operators-tvc-operator-tvc-deployment-threshold-1"
+    );
+    assert_eq!(
+        policy.condition,
+        "activity.resource in ['TVC_OPERATOR', 'TVC_DEPLOYMENT']"
+    );
+    assert_eq!(
+        policy.consensus,
+        "approvers.any(user, user.id in ['user_1', 'user_2'])"
+    );
+}
+
+#[test]
+fn user_id_threshold_consensus_uses_filter_count() {
+    let policy = build_policy(
+        None,
+        &[TvcResource::App],
+        2,
+        PolicySubject::UserIds(vec!["user_1".to_string(), "user_2".to_string()]),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        policy.consensus,
+        "approvers.filter(user, user.id in ['user_1', 'user_2']).count() >= 2"
+    );
+}
+
+#[test]
+fn threshold_must_be_at_least_one() {
+    let err = build_policy(
+        None,
+        &[TvcResource::App],
+        0,
+        PolicySubject::UserIds(vec!["user_1".to_string()]),
+        None,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("--threshold must be at least 1"));
+}
+
+#[test]
+fn dry_run_prints_policy_json_and_planned_calls_without_auth() {
+    let (_temp, mut cmd) = tvc_cmd();
+
+    cmd.args([
+        "policy",
+        "init",
+        "--dry-run",
+        "--tag-name",
+        "TVC Operators",
+        "--user-ids",
+        "user_1,user_2",
+        "--resources",
+        "TVC_DEPLOYMENT,TVC_OPERATOR",
+        "--threshold",
+        "2",
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("Planned API calls:"))
+    .stdout(predicate::str::contains("1. create_user_tag"))
+    .stdout(predicate::str::contains("2. create_policies"))
+    .stdout(predicate::str::contains("\"effect\": \"EFFECT_ALLOW\""))
+    .stdout(predicate::str::contains(
+        "activity.resource in ['TVC_DEPLOYMENT', 'TVC_OPERATOR']",
+    ))
+    .stdout(predicate::str::contains(
+        "approvers.filter(user, user.tags.contains('<created tag ID from create_user_tag>')).count() >= 2",
+    ))
+    .stderr(predicate::str::contains("No active organization").not());
+}
+
+#[test]
+fn rejects_unknown_resource_name() {
+    let (_temp, mut cmd) = tvc_cmd();
+
+    cmd.args([
+        "policy",
+        "init",
+        "--dry-run",
+        "--user-ids",
+        "user_1",
+        "--resources",
+        "TVC_DEPLOYMENT,BAD_RESOURCE",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains(
+        "invalid TVC policy resource: BAD_RESOURCE",
+    ));
+}
+
+#[test]
+fn requires_user_source() {
+    let (_temp, mut cmd) = tvc_cmd();
+
+    cmd.args(["policy", "init", "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "provide --tag-id, or provide --user-ids with --tag-name for tag mode, or --user-ids alone for tagless mode",
+        ));
+}


### PR DESCRIPTION
## Context

Adds a `tvc policy init` subcommand for provisioning organization policies that let designated users perform TVC actions through Turnkey policies instead of requiring root-quorum consensus for every TVC operation.

The command supports selecting the covered TVC policy resources with `--resources`: `TVC_APP`, `TVC_DEPLOYMENT`, `TVC_OPERATOR`, and `TVC_QUORUM_KEY`. It prints the generated policy before submission and supports `--dry-run` to show the exact policy JSON and planned API calls without authenticating or submitting.

## Policy shapes

Resource conditions:

- One resource: `activity.resource == 'TVC_DEPLOYMENT'`
- Multiple resources: `activity.resource in ['TVC_APP', 'TVC_DEPLOYMENT', 'TVC_OPERATOR', 'TVC_QUORUM_KEY']`

Tag mode:

- New tag: `--tag-name <NAME> --user-ids <UUID,...>` first submits `create_user_tag`, then uses the returned tag UUID.
- Existing tag: `--tag-id <UUID>` skips tag creation and uses that tag UUID.
- Threshold 1: `approvers.any(user, user.tags.contains('<TAG_ID>'))`
- Threshold >= 2: `approvers.filter(user, user.tags.contains('<TAG_ID>')).count() >= <N>`

Tagless user-ID mode:

- `--user-ids <UUID,...>` without tag flags submits only `create_policies`.
- Threshold 1, one user: `approvers.any(user, user.id == '<USER_ID>')`
- Threshold 1, multiple users: `approvers.any(user, user.id in ['<ID1>', '<ID2>'])`
- Threshold >= 2: `approvers.filter(user, user.id in ['<ID1>', '<ID2>']).count() >= <N>`

## Safety

The command never generates a policy without a consensus expression. `build_policy` rejects empty resources, threshold `0`, empty tag IDs, and empty tagless user lists before producing a policy. Dry-run and interactive output always include the full generated policy JSON.

## Pending consensus caveat

If the org root quorum threshold is greater than one, the provisioning `create_user_tag` or `create_policies` activity can return pending consensus. Current `main` maps that to `TurnkeyClientError::ActivityRequiresApproval(activity_id)`. This command handles that variant by printing the pending activity ID and root-quorum approval instructions, then exits non-zero without reporting the provisioning as a hard failure.

## Tests

- Added pure generator coverage for default all-resource condition, single-resource equality, multi-resource subsets, tag consensus, tagless user-ID consensus, and threshold validation.
- Added CLI coverage for `--dry-run` output, bad resource validation, and missing user source validation.
- Verified with:
  - `cargo fmt -- --check`
  - `cargo clippy --all-targets --all-features -- -D warnings`
  - `cargo test -p tvc`
  - `git diff --check`
