### PR TITLE
tvc: generalize consensus activity submission

### DIFF
--- a/tvc/src/commands/consensus.rs
+++ b/tvc/src/commands/consensus.rs
@@ -2,11 +2,13 @@
 
 use crate::client::AuthenticatedClient;
 use anyhow::{Context, Result};
-use turnkey_client::TurnkeyClientError;
+use std::future::Future;
 use turnkey_client::generated::intent::Inner;
 use turnkey_client::generated::{
-    Activity, ApproveActivityIntent, GetOrganizationConfigsRequest, GetWhoamiRequest,
+    Activity, ActivityStatus, ActivityType, ApproveActivityIntent, GetActivitiesRequest,
+    GetOrganizationConfigsRequest, GetWhoamiRequest,
 };
+use turnkey_client::{ActivityResult, TurnkeyClientError};
 
 const VOTE_SELECTION_APPROVED: &str = "VOTE_SELECTION_APPROVED";
 
@@ -49,19 +51,70 @@ pub(crate) fn pending_consensus_result(activity: &PendingConsensusActivity<'_>) 
     Err(crate::exit::ExitError::consensus_needed().into())
 }
 
-/// Find a pending activity whose intent contents exactly match `intent`.
+/// Find a pending activity whose intent satisfies `matches_intent`.
 ///
 /// The submission timestamp lives in the request envelope (`timestampMs`),
-/// not in the intent, so intent equality identifies an operator re-running
+/// not in the intent, so intent matching identifies an operator re-running
 /// the same request even though the server fingerprints each raw request
 /// body differently.
-pub(crate) fn find_matching_pending_activity<'a>(
-    activities: &'a [Activity],
-    intent: &Inner,
-) -> Option<&'a Activity> {
-    activities
-        .iter()
-        .find(|activity| activity.intent.as_ref().and_then(|i| i.inner.as_ref()) == Some(intent))
+pub(crate) fn find_matching_pending_activity_by(
+    activities: &[Activity],
+    matches_intent: impl Fn(&Inner) -> bool,
+) -> Option<&Activity> {
+    activities.iter().find(|activity| {
+        activity
+            .intent
+            .as_ref()
+            .and_then(|intent| intent.inner.as_ref())
+            .is_some_and(&matches_intent)
+    })
+}
+
+pub(crate) enum ConsensusSubmission<T> {
+    Submitted(ActivityResult<T>),
+    ExistingActivityHandled,
+}
+
+pub(crate) async fn submit_with_consensus<T, MatchesIntent, Submit, SubmitFuture>(
+    auth: &AuthenticatedClient,
+    activity_type: ActivityType,
+    list_context: &'static str,
+    submit_context: &'static str,
+    matches_intent: MatchesIntent,
+    submit: Submit,
+) -> Result<ConsensusSubmission<T>>
+where
+    MatchesIntent: Fn(&Inner) -> bool,
+    Submit: FnOnce(u128) -> SubmitFuture,
+    SubmitFuture: Future<Output = std::result::Result<ActivityResult<T>, TurnkeyClientError>>,
+{
+    let pending = auth
+        .client
+        .get_activities(GetActivitiesRequest {
+            organization_id: auth.org_id.clone(),
+            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
+            pagination_options: None,
+            filter_by_type: vec![activity_type],
+        })
+        .await
+        .context(list_context)?;
+
+    if let Some(existing) = find_matching_pending_activity_by(&pending.activities, matches_intent) {
+        vote_on_existing_activity(auth, existing).await?;
+        return Ok(ConsensusSubmission::ExistingActivityHandled);
+    }
+
+    let result = submit(auth.client.current_timestamp()).await;
+    match result {
+        Ok(result) => Ok(ConsensusSubmission::Submitted(result)),
+        Err(error) => {
+            if let Some(activity) = pending_consensus_from_error(&error) {
+                pending_consensus_result(&activity)?;
+                unreachable!("pending_consensus_result always returns an error");
+            }
+            Err(error).context(submit_context)
+        }
+    }
 }
 
 /// Number of approval votes already recorded on an activity.
@@ -229,8 +282,9 @@ mod tests {
             pending_activity("match", Some(approvals_intent("manifest-a", "sig-a"))),
         ];
 
-        let found =
-            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+        let found = find_matching_pending_activity_by(&activities, |inner| {
+            inner == &approvals_intent("manifest-a", "sig-a")
+        });
 
         assert_eq!(found.map(|a| a.id.as_str()), Some("match"));
     }
@@ -242,8 +296,9 @@ mod tests {
             Some(approvals_intent("manifest-a", "another-operator-sig")),
         )];
 
-        let found =
-            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+        let found = find_matching_pending_activity_by(&activities, |inner| {
+            inner == &approvals_intent("manifest-a", "sig-a")
+        });
 
         assert!(found.is_none());
     }
@@ -252,8 +307,37 @@ mod tests {
     fn matcher_ignores_activities_without_intent() {
         let activities = vec![pending_activity("no-intent", None)];
 
-        let found =
-            find_matching_pending_activity(&activities, &approvals_intent("manifest-a", "sig-a"));
+        let found = find_matching_pending_activity_by(&activities, |inner| {
+            inner == &approvals_intent("manifest-a", "sig-a")
+        });
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn generic_matcher_finds_activity_with_matching_predicate() {
+        let activities = vec![
+            pending_activity("other", Some(approvals_intent("manifest-b", "sig-b"))),
+            pending_activity("match", Some(approvals_intent("manifest-a", "sig-a"))),
+        ];
+
+        let found = find_matching_pending_activity_by(&activities, |inner| {
+            inner == &approvals_intent("manifest-a", "sig-a")
+        });
+
+        assert_eq!(found.map(|a| a.id.as_str()), Some("match"));
+    }
+
+    #[test]
+    fn generic_matcher_ignores_activities_without_matching_predicate() {
+        let activities = vec![pending_activity(
+            "other",
+            Some(approvals_intent("manifest-a", "sig-a")),
+        )];
+
+        let found = find_matching_pending_activity_by(&activities, |inner| {
+            inner == &approvals_intent("manifest-a", "sig-b")
+        });
 
         assert!(found.is_none());
     }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -15,12 +15,11 @@ use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 use turnkey_client::generated::{
-    ActivityStatus, ActivityType, CreateTvcManifestApprovalsIntent, GetActivitiesRequest,
-    GetTvcDeploymentRequest, TvcManifestApproval, intent,
+    ActivityType, CreateTvcManifestApprovalsIntent, GetTvcDeploymentRequest, TvcManifestApproval,
+    intent,
 };
 
 const QUORUM_REACHED_MESSAGE: &str =
@@ -305,45 +304,22 @@ async fn post_approval_to_api(
         approvals: vec![tvc_approval],
     };
 
-    // Re-running this command after a consensus-needed response must vote on
-    // the existing pending activity instead of creating a duplicate one.
-    let pending = auth
-        .client
-        .get_activities(GetActivitiesRequest {
-            organization_id: auth.org_id.clone(),
-            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
-            pagination_options: None,
-            filter_by_type: vec![ActivityType::CreateTvcManifestApprovals],
-        })
-        .await
-        .context("failed to check for pending manifest approval activities")?;
-
     let intent_inner = intent::Inner::CreateTvcManifestApprovalsIntent(intent.clone());
-    if let Some(existing) = crate::commands::consensus::find_matching_pending_activity(
-        &pending.activities,
-        &intent_inner,
-    ) {
-        return crate::commands::consensus::vote_on_existing_activity(&auth, existing).await;
-    }
-
-    let timestamp_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("system time before unix epoch")?
-        .as_millis();
-
-    let result = match auth
-        .client
-        .create_tvc_manifest_approvals(auth.org_id.clone(), timestamp_ms, intent)
-        .await
+    let result = match crate::commands::consensus::submit_with_consensus(
+        &auth,
+        ActivityType::CreateTvcManifestApprovals,
+        "failed to check for pending manifest approval activities",
+        "failed to post manifest approval",
+        |pending_intent| pending_intent == &intent_inner,
+        |timestamp_ms| {
+            auth.client
+                .create_tvc_manifest_approvals(auth.org_id.clone(), timestamp_ms, intent)
+        },
+    )
+    .await?
     {
-        Ok(result) => result,
-        Err(error) => {
-            if let Some(activity) = crate::commands::consensus::pending_consensus_from_error(&error)
-            {
-                return crate::commands::consensus::pending_consensus_result(&activity);
-            }
-            return Err(error).context("failed to post manifest approval");
-        }
+        crate::commands::consensus::ConsensusSubmission::Submitted(result) => result,
+        crate::commands::consensus::ConsensusSubmission::ExistingActivityHandled => return Ok(()),
     };
 
     println!();

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -9,11 +9,9 @@ use crate::pull_secret::encrypt_pivot_pull_secret;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
 use turnkey_client::generated::{
-    ActivityStatus, ActivityType, CreateTvcDeploymentIntent, GetActivitiesRequest,
-    ValidateTvcImageRequest, intent,
+    ActivityType, CreateTvcDeploymentIntent, ValidateTvcImageRequest, intent,
 };
 
 pub(crate) const LONG_ABOUT: &str = r#"
@@ -410,45 +408,22 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
         pivot_container_encrypted_pull_secret,
     );
 
-    // Re-running this command after a consensus-needed response must vote on
-    // the existing pending activity instead of creating a duplicate one.
-    let pending = auth
-        .client
-        .get_activities(GetActivitiesRequest {
-            organization_id: auth.org_id.clone(),
-            filter_by_status: vec![ActivityStatus::ConsensusNeeded],
-            pagination_options: None,
-            filter_by_type: vec![ActivityType::CreateTvcDeployment],
-        })
-        .await
-        .context("failed to check for pending deployment activities")?;
-
     let intent_inner = intent::Inner::CreateTvcDeploymentIntent(intent.clone());
-    if let Some(existing) = crate::commands::consensus::find_matching_pending_activity(
-        &pending.activities,
-        &intent_inner,
-    ) {
-        return crate::commands::consensus::vote_on_existing_activity(&auth, existing).await;
-    }
-
-    let timestamp_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("system time before unix epoch")?
-        .as_millis();
-
-    let result = match auth
-        .client
-        .create_tvc_deployment(auth.org_id, timestamp_ms, intent)
-        .await
+    let result = match crate::commands::consensus::submit_with_consensus(
+        &auth,
+        ActivityType::CreateTvcDeployment,
+        "failed to check for pending deployment activities",
+        "failed to create TVC deployment",
+        |pending_intent| pending_intent == &intent_inner,
+        |timestamp_ms| {
+            auth.client
+                .create_tvc_deployment(auth.org_id.clone(), timestamp_ms, intent)
+        },
+    )
+    .await?
     {
-        Ok(result) => result,
-        Err(error) => {
-            if let Some(activity) = crate::commands::consensus::pending_consensus_from_error(&error)
-            {
-                return crate::commands::consensus::pending_consensus_result(&activity);
-            }
-            return Err(error).context("failed to create TVC deployment");
-        }
+        crate::commands::consensus::ConsensusSubmission::Submitted(result) => result,
+        crate::commands::consensus::ConsensusSubmission::ExistingActivityHandled => return Ok(()),
     };
 
     println!();

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -1,10 +1,9 @@
 //! Deploy delete command - marks a deployment for deletion.
 
 use crate::client::build_client;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args as ClapArgs;
-use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::generated::DeleteTvcDeploymentIntent;
+use turnkey_client::generated::{ActivityType, DeleteTvcDeploymentIntent, intent};
 
 /// Delete a TVC deployment by marking it for deletion.
 #[derive(Debug, ClapArgs)]
@@ -23,16 +22,23 @@ pub async fn run(args: Args) -> Result<()> {
         deployment_id: args.deploy_id.clone(),
     };
 
-    let timestamp_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("system time before unix epoch")?
-        .as_millis();
-
-    let result = auth
-        .client
-        .delete_tvc_deployment(auth.org_id, timestamp_ms, intent)
-        .await
-        .context("failed to delete TVC deployment")?;
+    let intent_inner = intent::Inner::DeleteTvcDeploymentIntent(intent.clone());
+    let result = match crate::commands::consensus::submit_with_consensus(
+        &auth,
+        ActivityType::DeleteTvcDeployment,
+        "failed to check for pending deployment delete activities",
+        "failed to delete TVC deployment",
+        |pending_intent| pending_intent == &intent_inner,
+        |timestamp_ms| {
+            auth.client
+                .delete_tvc_deployment(auth.org_id.clone(), timestamp_ms, intent)
+        },
+    )
+    .await?
+    {
+        crate::commands::consensus::ConsensusSubmission::Submitted(result) => result,
+        crate::commands::consensus::ConsensusSubmission::ExistingActivityHandled => return Ok(()),
+    };
 
     println!();
     println!("Deployment delete accepted; deployment is marked for deletion.");

--- a/tvc/tests/deploy_delete.rs
+++ b/tvc/tests/deploy_delete.rs
@@ -1,6 +1,33 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use tempfile::TempDir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ORG_ID: &str = "org-test";
+const DEPLOY_ID: &str = "11111111-1111-1111-1111-111111111111";
+const EXISTING_ACTIVITY_ID: &str = "activity-existing-delete";
+const EXISTING_FINGERPRINT: &str = "fp-existing-delete";
+
+fn generated_api_key() -> (String, String) {
+    let stamper = TurnkeyP256ApiKey::generate();
+    (
+        hex::encode(stamper.compressed_public_key()),
+        hex::encode(stamper.private_key()),
+    )
+}
+
+fn authed_tvc_cmd(server: &MockServer) -> assert_cmd::Command {
+    let (public_key, private_key) = generated_api_key();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear()
+        .env("TVC_ORG_ID", ORG_ID)
+        .env("TVC_API_BASE_URL", server.uri())
+        .env("TVC_API_KEY_PUBLIC", public_key)
+        .env("TVC_API_KEY_PRIVATE", private_key);
+    cmd
+}
 
 fn deploy_delete_cmd() -> (TempDir, assert_cmd::Command) {
     let temp = TempDir::new().unwrap();
@@ -32,4 +59,76 @@ fn deploy_delete_requires_deploy_id() {
             "the following required arguments were not provided",
         ))
         .stderr(predicate::str::contains("--deploy-id <DEPLOY_ID>"));
+}
+
+#[tokio::test]
+async fn deploy_delete_votes_on_existing_matching_activity() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_activities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activities": [
+                {
+                    "id": EXISTING_ACTIVITY_ID,
+                    "organizationId": ORG_ID,
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT",
+                    "fingerprint": EXISTING_FINGERPRINT,
+                    "intent": {
+                        "deleteTvcDeploymentIntent": {
+                            "deploymentId": DEPLOY_ID
+                        }
+                    },
+                    "votes": []
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "organizationId": ORG_ID,
+            "organizationName": "Test Org",
+            "userId": "user-current",
+            "username": "root-user"
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": EXISTING_ACTIVITY_ID,
+                "organizationId": ORG_ID,
+                "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "type": "ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT",
+                "fingerprint": EXISTING_FINGERPRINT
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/delete_tvc_deployment"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    authed_tvc_cmd(&server)
+        .arg("deploy")
+        .arg("delete")
+        .arg("--deploy-id")
+        .arg(DEPLOY_ID)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("already pending"))
+        .stdout(predicate::str::contains(EXISTING_ACTIVITY_ID))
+        .stdout(predicate::str::contains(EXISTING_FINGERPRINT))
+        .stdout(predicate::str::contains("Vote recorded"));
 }


### PR DESCRIPTION
## Summary

This is a shape-review PR stacked on #192. It factors the TVC consensus-needed flow into a reusable helper that activity-submitting commands can call instead of hand-rolling pending-activity lookup, dedup voting, and pending-consensus handling.

## Design

- Add `submit_with_consensus` in `tvc/src/commands/consensus.rs`.
- The helper takes an `ActivityType`, list/submit error contexts, a generic intent-matching predicate, and a submit closure.
- It checks `get_activities(CONSENSUS_NEEDED, activity_type)` before submitting.
- If a matching activity already exists, it uses the existing `vote_on_existing_activity` path, including the already-voted check and vote-progress messaging.
- If the fresh submit returns `ActivityPendingConsensus`, it prints the existing pending-consensus message and returns the dedicated exit-code-2 error.

## Migrated in this draft

- `tvc deploy create`: behavior remains identical to #192.
- `tvc deploy approve`: behavior remains identical to #192.
- `tvc deploy delete`: migrated as a small additional activity-submitting command to demonstrate the generic shape.

## Left for follow-up

This intentionally does not migrate every TVC command. If the shape looks right, the remaining activity-submitting commands can move over incrementally in smaller follow-up PRs.

## Verification

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p tvc -p turnkey_client`
- `git diff --check`

All passed locally. Rustc emitted sandbox hard-link incremental-cache warnings only.