### PR TITLE
tvc: zero-pad deploy status timestamp nanos

### DIFF
--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -72,7 +72,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         );
 
         if let Some(updated) = &deployment_status.last_updated_time {
-            println!("Last Updated: {}.{:09}s", updated.seconds, updated.nanos);
+            println!("Last Updated: {}.{:0>9}s", updated.seconds, updated.nanos);
         }
     } else {
         println!("Live Status: unavailable");

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -61,11 +61,11 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
 
     if let Some(created) = &deployment.created_at {
         println!();
-        println!("Created: {}.{:09}s", created.seconds, created.nanos);
+        println!("Created: {}.{:0>9}s", created.seconds, created.nanos);
     }
 
     if let Some(updated) = &deployment.updated_at {
-        println!("Updated: {}.{:09}s", updated.seconds, updated.nanos);
+        println!("Updated: {}.{:0>9}s", updated.seconds, updated.nanos);
     }
 
     Ok(())


### PR DESCRIPTION
`tvc deploy status` / `get-status` printed timestamps with the nanos field space-padded, leaving a ragged gap before the trailing `s`:

```
Created: 1783454734.0        s
```

The `Timestamp` `seconds`/`nanos` fields are `String`s, and Rust ignores the `0` zero-fill flag for string types — so `{:09}` left-aligned and space-padded. Switch to `{:0>9}` (fill `0`, right-align) so it reads `1783454734.000000000s`, matching the already-correct `app/status.rs`.

Closes TVC-164.