### PR TITLE
fix(tvc): correct deploy create next-steps hints

### DIFF
--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -429,11 +429,11 @@ async fn run_with_resolved_inputs(inputs: ResolvedDeployInputs) -> Result<()> {
     println!();
     println!("Next steps:");
     println!(
-        "  - Run `WIP: tvc deploy status {}` to check deployment status",
+        "  - Run `tvc deploy status --deploy-id {}` to check deployment status",
         result.result.deployment_id
     );
     println!(
-        "  - Run `tvc deploy approve --deploy-id {}` to approve the manifest",
+        "  - Run `tvc deploy approve --deploy-id {} --operator-id <operator-id>` to approve the manifest",
         result.result.deployment_id
     );
 


### PR DESCRIPTION
Fixes the "Next steps" block printed by `tvc deploy create`:

- add `--operator-id <operator-id>` to the approve hint
- drop the misleading `WIP:` prefix from the status hint
- use the `--deploy-id` flag form (`deploy status` takes no positional arg)

Closes TVC-124.