### PR TITLE
tvc: validate org ID on login, document --api-base-url, add AGENTS.md

### DIFF
--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -1,0 +1,200 @@
+# TVC CLI — Agent Guide
+
+This document teaches an AI coding agent (Claude Code, Cursor, similar) how to
+drive the `tvc` CLI end-to-end on behalf of a human. It is a runnable playbook,
+not a reference manual — for exhaustive flag listings run `tvc <command> --help`.
+
+## 1. What TVC is
+
+`tvc` is the CLI for **Turnkey Verifiable Cloud (TVC)** — a platform that runs
+your code inside AWS Nitro Enclaves with cryptographic remote attestation.
+`tvc` is how you (or the agent driving on your behalf) authenticate, create
+applications, deploy them, approve deployment manifests, and inspect live
+deployment state.
+
+Concepts and dashboard docs live at
+<https://docs.turnkey.com/features/verifiable-cloud/overview>.
+
+## 2. Prerequisites
+
+Before running any `tvc` command, confirm all of the following:
+
+1. The user has a **Turnkey account** and belongs to at least one organization.
+2. You know the **organization ID** — a UUID like `01234567-89ab-cdef-0123-456789abcdef`. It is on the Turnkey dashboard **home page** (click-to-copy). Do NOT read an ID off a deployment or app detail page — that's a different UUID.
+3. The user has (or can create) **Turnkey API credentials** for that org. `tvc login` will generate a keypair for you and walk the user through registering the public key on the dashboard.
+4. The `tvc` binary is installed. Preferred: `cargo install tvc`. Verify with `tvc --version`.
+
+If any of these are missing, stop and ask the user rather than guessing.
+
+## 3. First-time setup: `tvc login`
+
+Run `tvc login` interactively (do NOT pass `--non-interactive` on first setup —
+the flow needs to prompt for the org ID and pause for dashboard registration).
+
+```bash
+tvc login
+```
+
+The flow:
+
+1. If no orgs are configured yet, `tvc` prints the dashboard URL and prompts:
+   - **Organization ID** — paste the UUID from the dashboard home page.
+   - **Organization alias** — a short local name (default: `default`). This is what you'll pass to `--org` later.
+2. `tvc` generates a P-256 API keypair and prints the public key.
+3. `tvc` prompts you to add that public key to the dashboard: **Users → your user → New API Key → Advanced Settings → Generate API key via CLI → paste public key → Continue → Approve.** Press Enter when done.
+4. `tvc` calls the Turnkey `whoami` endpoint to **verify** the org ID and credentials. If verification fails, no config is written and the error tells you which org ID failed.
+5. On success, `tvc` writes:
+   - `~/.config/turnkey/tvc.config.toml` — org registry and active org
+   - `~/.config/turnkey/orgs/<alias>/api_key.json` — the P-256 API keypair
+   - `~/.config/turnkey/orgs/<alias>/operator.json` — the operator (QOS) keypair used to approve deployment manifests
+
+After that, subsequent `tvc` commands read those files automatically.
+
+### CI / non-interactive use
+
+For CI, skip `tvc login` and set these three env vars instead — they authenticate
+directly without touching disk:
+
+| Env var | Value |
+|---|---|
+| `TVC_ORG_ID` | the Turnkey organization UUID |
+| `TVC_API_KEY_PUBLIC` | hex-encoded compressed P-256 public key |
+| `TVC_API_KEY_PRIVATE` | hex-encoded P-256 private key |
+
+Setting some but not all three is rejected. When set, env vars take precedence
+over any local config file.
+
+## 4. Common workflows
+
+All commands below are real subcommands. Cross-check names with
+`tvc --help` and `tvc <group> --help` if you're unsure.
+
+### Create an app
+
+An **app** is the long-lived container for a family of deployments. It owns the
+quorum key and the set of operators that can approve manifests.
+
+```bash
+# Generate a template config
+tvc app init --output my-app.json
+
+# Edit my-app.json to fill in name, quorumPublicKey, operator keys, etc.
+# The user typically needs to hand-edit this — do NOT guess these values.
+# Pass --interactive to app init to be prompted for each field instead.
+
+# Create the app on Turnkey
+tvc app create --config-file my-app.json
+```
+
+### List apps
+
+```bash
+tvc app list                     # all apps in the active org
+tvc app list --name my-app       # filter by name
+```
+
+### App live status
+
+```bash
+tvc app status --app-id <APP_UUID>
+```
+
+Returns the currently live deployment's runtime state from the cluster.
+
+### Create a deployment
+
+```bash
+# Generate a template deploy config
+tvc deploy init --output my-deploy.json
+
+# Edit my-deploy.json (appId, pivotContainerImageUrl, expectedPivotDigest, etc.)
+
+# Create the deployment
+tvc deploy create --config-file my-deploy.json
+```
+
+`tvc deploy create --help` documents each flag override (`--app-id`,
+`--qos-version`, `--pivot-image-url`, `--expected-pivot-digest`, etc.).
+
+### Approve a deployment
+
+Operators approve the QOS manifest before it goes live. The recommended flow
+fetches the manifest and manifest ID automatically via `GetTvcDeployment`:
+
+```bash
+tvc deploy approve \
+  --deploy-id <DEPLOYMENT_UUID> \
+  --operator-id <OPERATOR_UUID>
+```
+
+Passing `--dangerous-skip-interactive` bypasses the section-by-section
+confirmation prompts. Only do that when the human explicitly asked for it.
+
+### Check deployment status
+
+Two commands with different scopes — pick the right one:
+
+- `tvc deploy status --deploy-id <ID>` — deployment record status (config, manifest, approvals).
+- `tvc deploy get-status --deploy-id <ID>` — **live** runtime status polled from the cluster.
+
+### Tail debug logs
+
+Debug logs require debug mode at **both** the app level (created with
+`--dangerous-enable-debug-mode-deployments`) **and** the deployment level
+(created with `--dangerous-deploy-debug-mode`). Non-debug deployments cannot
+expose logs retroactively.
+
+```bash
+tvc deploy debug-logs --deploy-id <DEPLOYMENT_UUID>              # one-shot
+tvc deploy debug-logs --deploy-id <DEPLOYMENT_UUID> --poll       # follow
+```
+
+### Set the live deployment
+
+```bash
+tvc app set-live-deploy --app-id <APP_UUID> --deploy-id <DEPLOYMENT_UUID>
+```
+
+### Deletion
+
+```bash
+tvc deploy delete --deploy-id <DEPLOYMENT_UUID>
+tvc app delete --app-id <APP_UUID>          # also deletes all its deployments
+```
+
+## 5. Configuration overrides
+
+Global flags exist on `tvc` itself:
+
+- `--non-interactive` (or `TVC_NON_INTERACTIVE=true`) — disables all prompts and fails fast on missing input. Set this whenever you're driving `tvc` from a script or another agent.
+- `--message-format json` — emits newline-delimited JSON. Implies `--non-interactive`. Prefer this for machine-readable output when parsing the CLI's response.
+- `--color auto|always|never` — ANSI color control.
+
+Environment / URL overrides:
+
+- `--api-base-url <URL>` (or `TVC_API_BASE_URL`) — override the Turnkey API endpoint. Defaults to `https://api.turnkey.com`. Available on `tvc login`; also honored by env-var auth in CI. Only needed for non-prod Turnkey environments.
+- `TVC_ORG` — default value for `--org` on `tvc login`.
+- Per-command env vars (`TVC_APP_ID`, `TVC_DEPLOY_ID`, `TVC_OPERATOR_ID`, `TVC_MANIFEST_ID`, `TVC_DEPLOY_CONFIG`, `TVC_APP_CONFIG`, …) — check each command's `--help` for its supported vars and precedence.
+
+Precedence (highest wins): CLI flag > env var > config file value > built-in default.
+
+## 6. Where things live
+
+- **Config file:** `~/.config/turnkey/tvc.config.toml`
+- **Per-org keys:** `~/.config/turnkey/orgs/<alias>/api_key.json` and `.../operator.json`
+- **Reference apps and deploy configs:** <https://github.com/tkhq/tvc-examples>
+- **Product docs and concepts:** <https://docs.turnkey.com/features/verifiable-cloud/overview>
+- **Quickstart guide:** <https://docs.turnkey.com/getting-started/verifiable-cloud-quickstart>
+- **Source of truth for command surface:** `tvc/src/commands/` in the `tkhq/rust-sdk` repo. If a command isn't there, it doesn't exist — don't invent flags.
+
+## 7. Common gotchas
+
+- **Org ID source.** The org ID must come from the Turnkey dashboard **home** page. IDs shown on deployment or app pages are different UUIDs and will fail the `tvc login` verification step.
+- **First `tvc login` needs a TTY.** The flow pauses for dashboard registration. Do NOT wrap it in `--non-interactive` or a headless script on first setup.
+- **Non-interactive login requires an existing API key.** In `--non-interactive` mode `tvc login` will not generate a new key; run interactive login once first, then automate afterwards.
+- **Debug logs need double opt-in.** App created with `--dangerous-enable-debug-mode-deployments` **and** deployment created with `--dangerous-deploy-debug-mode`. Turning debug mode on permanently marks the app's quorum key as insecure — never do this on a production app.
+- **`deploy status` vs `deploy get-status`.** The first shows the Turnkey deployment record; the second polls the live cluster. Same for `app status` (live cluster). Pick the one that answers the question you're actually asking.
+- **Env-var auth is all-or-nothing.** Set `TVC_ORG_ID`, `TVC_API_KEY_PUBLIC`, and `TVC_API_KEY_PRIVATE` together or not at all. Partial sets are rejected with a message naming the missing vars.
+- **`--api-base-url` is stored per org on `tvc login`.** Setting it on login updates the on-disk value; other commands read from the stored config, so you generally don't need to pass it again.
+- **Config is only persisted after credential verification.** If `tvc login` fails at the `whoami` step, the config file is left untouched — no cleanup needed. Fix the org ID or credentials and re-run.
+- **`--message-format json` implies `--non-interactive`.** JSON mode never prompts; it fails fast on missing required inputs. Provide every value up front.

--- a/tvc/README.md
+++ b/tvc/README.md
@@ -28,6 +28,32 @@ Some commands support environment variables and command-line flags for
 programmatic use. Run command help, such as `tvc deploy create --help`, to see
 the supported inputs and precedence for that command.
 
+## Configuration
+
+### `--api-base-url`
+
+The `--api-base-url` flag (also settable as `TVC_API_BASE_URL`) overrides which
+Turnkey API endpoint `tvc` talks to. It defaults to `https://api.turnkey.com`.
+
+You typically only need this when pointing `tvc` at a non-production Turnkey
+environment — for example a staging cluster or a local API for development.
+The flag is available on `tvc login`; for newly configured orgs the value is
+stored alongside the org so subsequent commands hit the same environment, and
+for existing orgs it updates the stored value on that login.
+
+For programmatic use (CI, scripts), `TVC_API_BASE_URL` is also read directly by
+env-var auth alongside `TVC_ORG_ID` / `TVC_API_KEY_PUBLIC` / `TVC_API_KEY_PRIVATE`.
+
+```bash
+# One-off: log in against a staging environment
+tvc login --api-base-url https://api.staging.example.turnkey.com
+
+# CI: authenticate directly with env vars, including a non-prod base URL
+TVC_ORG_ID=... TVC_API_KEY_PUBLIC=... TVC_API_KEY_PRIVATE=... \
+  TVC_API_BASE_URL=https://api.staging.example.turnkey.com \
+  tvc app list
+```
+
 ## Usage
 
 ### Create an App

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -23,7 +23,12 @@ pub struct Args {
     /// If not provided, will prompt interactively.
     #[arg(long, env = "TVC_ORG")]
     pub org: Option<String>,
-    /// Turnkey API base URL. Defaults to production for newly configured orgs.
+    /// Override the Turnkey API base URL (defaults to https://api.turnkey.com).
+    ///
+    /// Useful for pointing tvc at non-production Turnkey environments (e.g. a
+    /// staging or local API). For newly configured orgs the value is stored
+    /// alongside the org so subsequent commands hit the same environment; for
+    /// existing orgs it updates the stored value on this login.
     #[arg(long, env = "TVC_API_BASE_URL", value_name = "URL")]
     pub api_base_url: Option<String>,
 }
@@ -326,8 +331,11 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
 
     shell_println!(ctx, "Selected org: {} ({})", alias, org_config.id)?;
 
+    // Point active_org at the requested profile in memory. We deliberately do
+    // NOT persist the config yet: the whoami round-trip below is what proves
+    // the org ID is real and reachable with the current API key, and we don't
+    // want to leave a partially valid config on disk if that fails.
     config.set_active_org(&alias)?;
-    config.save().await?;
 
     let api_key = match StoredApiKey::load(&org_config).await? {
         Some(api_key) => {
@@ -352,10 +360,28 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     shell_println!(ctx)?;
     shell_println!(ctx, "Verifying credentials...")?;
 
-    let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url).await?;
+    // Validate the org ID BEFORE persisting the config so an invalid or
+    // unreachable org never leaves an entry pointing at nothing.
+    let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url)
+        .await
+        .map_err(|err| org_verification_error(&org_config.id, err))?;
+
+    // Verification passed: safe to persist config now.
+    config.save().await?;
+
     let operator_key = find_or_generate_operator_key(ctx, &org_config).await?;
 
     print_success(ctx, &alias, &org_config, &api_key, &operator_key, &whoami)
+}
+
+/// Wrap a whoami failure with a user-facing message that names the org ID and
+/// points at the dashboard as the canonical source of truth for it.
+fn org_verification_error(org_id: &str, source: anyhow::Error) -> anyhow::Error {
+    source.context(format!(
+        "organization ID {org_id} could not be verified. \
+         Please check the ID and try again.\n\
+         You can copy the org ID from the Turnkey dashboard home page."
+    ))
 }
 
 fn prompt_for_org_plan(

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -1,6 +1,10 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use std::collections::HashMap;
+use std::fs;
 use tempfile::TempDir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use tvc::config::turnkey::{Config, KeyCurve, OrgConfig, StoredApiKey};
 
 /// When `--org <alias>` points to an alias that is not present in the local
 /// config, we fail fast without entering any interactive flow. Exercises the
@@ -30,4 +34,87 @@ fn login_help_shows_api_base_url_override() {
         .success()
         .stdout(predicate::str::contains("--api-base-url"))
         .stdout(predicate::str::contains("TVC_API_BASE_URL"));
+}
+
+/// When the org ID cannot be verified against the API (bad ID, wrong creds, or
+/// an unreachable base URL), the login command must:
+///   1. Surface a clear, user-actionable error message that names the org ID
+///      and points at the Turnkey dashboard as the canonical source of truth.
+///   2. Refuse to persist any config changes to disk — leaving a partially
+///      valid entry pointing at an unverified org is exactly the bug this
+///      guards against.
+///
+/// This exercises the reorder that moved `config.save()` to *after*
+/// `verify_credentials` in `execute_login`. We simulate whoami failure by
+/// pointing the org at an unroutable local port (`http://127.0.0.1:1`).
+#[test]
+fn login_rejects_unverifiable_org_before_persisting_config() {
+    let temp = TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config").join("turnkey");
+    let org_dir = turnkey_dir.join("orgs").join("test");
+    let api_key_path = org_dir.join("api_key.json");
+    let operator_key_path = org_dir.join("operator.json");
+    fs::create_dir_all(&org_dir).unwrap();
+
+    // Seed a real API key on disk so we get past the "generate + wait for
+    // dashboard registration" step and reach the whoami call. The key material
+    // itself is arbitrary; whoami is what we're exercising.
+    let stamper = TurnkeyP256ApiKey::generate();
+    let public_key = hex::encode(stamper.compressed_public_key());
+    let private_key = hex::encode(stamper.private_key());
+    fs::write(
+        &api_key_path,
+        serde_json::to_string_pretty(&StoredApiKey {
+            public_key,
+            private_key,
+            curve: KeyCurve::P256,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Point the org at an unreachable local port so the whoami round-trip is
+    // guaranteed to fail. Leave `active_org = None` so that a successful save
+    // would visibly change the file (making the "did not persist" assertion
+    // meaningful).
+    let config = Config {
+        active_org: None,
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-bogus".to_string(),
+                api_key_path,
+                operator_key_path,
+                api_base_url: "http://127.0.0.1:1".to_string(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+    };
+    let config_path = turnkey_dir.join("tvc.config.toml");
+    let original_config_bytes = toml::to_string_pretty(&config).unwrap();
+    fs::write(&config_path, &original_config_bytes).unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("login")
+        .arg("--non-interactive")
+        .arg("--org")
+        .arg("test")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "organization ID org-bogus could not be verified",
+        ))
+        .stderr(predicate::str::contains(
+            "copy the org ID from the Turnkey dashboard home page",
+        ));
+
+    // Verification failed, so the config file must be byte-for-byte unchanged
+    // (in particular, `active_org` was never flipped to "test").
+    let post_bytes = fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        post_bytes, original_config_bytes,
+        "config file must not be modified when org verification fails"
+    );
 }


### PR DESCRIPTION
## 1. Validate org ID on `tvc login` before persisting config

Previously `tvc login` called `config.save()` before running the `whoami`
verification, so an invalid or unreachable org ID left a config entry on disk
pointing at nothing. Users then hit an opaque error on the next `tvc` command
instead of a clear "that org ID is wrong" message during login.

- `execute_login` in `tvc/src/commands/login.rs` now reorders so
  `verify_credentials` (the lightweight `GetWhoami` call, already present) runs
  **before** `config.save()`. No new API surface added.
- Verification failures are wrapped via a new `org_verification_error` helper
  that produces the user-actionable message specified in the ask:
  > organization ID `<id>` could not be verified. Please check the ID and try again.
  > You can copy the org ID from the Turnkey dashboard home page.
- Added an integration test `login_rejects_unverifiable_org_before_persisting_config`
  in `tvc/tests/login.rs`. It seeds a config with a valid keypair but points
  `api_base_url` at an unroutable local port (`http://127.0.0.1:1`), runs
  `tvc login --non-interactive --org test`, and asserts both the new error
  message and that the on-disk config file is byte-for-byte unchanged after
  the failed login.

## 2. Document `--api-base-url`

The `--api-base-url` flag (and its `TVC_API_BASE_URL` env var) exists on
`tvc login` but was effectively undocumented — the clap doc-comment was a
single terse sentence and the README didn't mention the flag at all.

- Expanded the `#[arg]` doc-comment in `tvc/src/commands/login.rs` so
  `tvc login --help` prints the default (`https://api.turnkey.com`), the use
  case (non-prod Turnkey environments), and how the stored value flows through
  to subsequent commands. (Shipped in the login commit because they touch the
  same struct.)
- Added a **Configuration** section to `tvc/README.md` documenting the flag,
  its default, when to reach for it, and both interactive (`tvc login
  --api-base-url ...`) and CI (`TVC_API_BASE_URL=... tvc app list`) worked
  examples.

## 3. Add `tvc/AGENTS.md`

New agent onboarding guide at `tvc/AGENTS.md` (using the emerging `AGENTS.md`
cross-tool convention rather than a tool-specific filename). Audience is AI
coding agents driving `tvc` on behalf of a human. Structure is a runnable
playbook:

1. **What TVC is** — Nitro Enclaves + remote attestation, 2 sentences.
2. **Prerequisites** — including the org-ID-is-on-dashboard-home-page callout.
3. **First-time `tvc login`** — with the whoami verification step called out.
4. **Common workflows** — `app init/create/list/status`, `deploy
   init/create/approve/status/get-status/debug-logs`, `app set-live-deploy`,
   deletes. Every command name verified by reading `tvc/src/commands/` — no
   invented flags or subcommands.
5. **Configuration overrides** — `--non-interactive`, JSON mode,
   `--api-base-url`, per-command env vars, and precedence order.
6. **Where things live** — pointers to `tkhq/tvc-examples` and the Turnkey
   docs.
7. **Common gotchas** — org ID source, TTY-required first login, non-
   interactive login can't generate keys, debug-log double opt-in, `status`
   vs `get-status`, all-or-nothing env auth, and a note that failed logins
   now leave the config untouched (from change 1 above).

## Testing

Ran from the repo root:

```
cargo build -p tvc                        # ok
cargo test  -p tvc                        # all suites pass; 141 unit tests +
                                          # all integration suites; new
                                          # login_rejects_unverifiable_org_before_persisting_config
                                          # among them
cargo fmt   -p tvc -- --check             # clean
cargo clippy -p tvc --all-targets -- -D warnings   # clean
```

Spot-checked `tvc login --help` output to confirm the new `--api-base-url`
help text renders as expected.

## Scope discipline

- No API contract changes.
- No new CLI subcommands.
- No changes outside `tvc/`.
- No changes to existing test fixtures (new test seeds its own config).