### PR TITLE
feat(tvc): add hosted operator creation and deploy approval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4296,6 +4296,9 @@ name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ qos_p256 = { version = "0.12.1", default-features = false }
 base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 bs58 = { version = "0.5.0", features = ["std", "check"], default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
-uuid = { version = "1.13.1", default-features = false }
+uuid = { version = "1.13.1", default-features = false, features = ["serde", "std"] }
 serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
 serde_bytes = { version = "0.11", default-features = false }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -161,6 +161,9 @@ impl Commands {
                 }
             },
             Commands::Login(args) => commands::login::run(ctx, args).await,
+            Commands::Operator { command } => match command {
+                OperatorCommands::Create(args) => commands::operator::create::run(ctx, args).await,
+            },
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(delete_args) => {
                     commands::login::run_delete(ctx, delete_args).await
@@ -174,6 +177,11 @@ impl Commands {
 enum Commands {
     /// Authenticate with Turnkey.
     Login(commands::login::Args),
+    /// Manage hosted TVC operators.
+    Operator {
+        #[command(subcommand)]
+        command: OperatorCommands,
+    },
     /// Manage saved login profiles.
     Profile {
         #[command(subcommand)]
@@ -200,6 +208,9 @@ impl Commands {
     fn name(&self) -> &'static str {
         match self {
             Commands::Login(_) => "login",
+            Commands::Operator { command } => match command {
+                OperatorCommands::Create(_) => "operator create",
+            },
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(_) => "profile delete",
             },
@@ -208,6 +219,12 @@ impl Commands {
             Commands::Keys { command } => command.name(),
         }
     }
+}
+
+#[derive(Debug, Subcommand)]
+enum OperatorCommands {
+    /// Create a hosted TVC operator and save it to the active organization.
+    Create(commands::operator::create::Args),
 }
 
 #[derive(Debug, Subcommand)]

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -1,32 +1,33 @@
 //! Approve deploy command - cryptographically approve a QOS manifest.
 
-use crate::config::turnkey::Config;
-use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
-use crate::outcome::Outcome;
-use crate::output::StdCtx;
-use crate::pair::HexSeed;
-use crate::prompts;
-use crate::prompts::{bail_required_in_non_interactive, stdin_can_prompt};
-use crate::util::{read_file_to_string, write_file};
-use crate::{shell_print, shell_println};
+use crate::{
+    client::build_client,
+    config::turnkey::Config,
+    local_operator_key::LocalOperatorSeedSource,
+    operator::{OperatorCtx, ResolvedOperator, resolve_operator},
+    outcome::Outcome,
+    output::StdCtx,
+    pair::HexSeed,
+    prompts::{self, bail_required_in_non_interactive, stdin_can_prompt},
+    shell_print, shell_println,
+    util::{read_file_to_string, write_file},
+};
 use anyhow::{Context, anyhow, bail};
 use clap::{ArgGroup, Args as ClapArgs};
-use qos_core::protocol::services::boot::Approval;
 use qos_core::protocol::services::boot::{
-    ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
+    Approval, ManifestSet, Namespace, NitroConfig, QuorumMember, ShareSet, VersionedManifest,
 };
 use serde::{Serialize, Serializer};
 use std::collections::HashSet;
-use std::fmt::Write;
-use std::fmt::{self, Display, Formatter};
-use std::path::Path;
-use std::path::PathBuf;
+use std::fmt::{self, Display, Formatter, Write};
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
 use turnkey_client::generated::{
     CreateTvcManifestApprovalsIntent, GetTvcDeploymentRequest, TvcManifestApproval,
 };
+use uuid::Uuid;
 
 const QUORUM_REACHED_MESSAGE: &str =
     "Manifest approval quorum reached. Your deployment will be available soon.";
@@ -60,10 +61,11 @@ pub struct Args {
     #[arg(long, env = "TVC_MANIFEST_ID")]
     pub manifest_id: Option<String>,
 
-    /// Turnkey operator ID (UUID) for the approving operator.
-    /// Required when posting approval to the API.
+    /// Turnkey operator UUID for the approving operator. When posting without
+    /// this flag, TVC selects from the last manifest's saved operator IDs. A
+    /// configured hosted operator is selected by its UUID.
     #[arg(long, env = "TVC_OPERATOR_ID")]
-    pub operator_id: Option<String>,
+    pub operator_id: Option<Uuid>,
 
     /// Hex-encoded 32-byte master seed for the operator key.
     /// If no seed flag is provided, uses the operator key from the logged-in org config.
@@ -96,14 +98,15 @@ pub struct Args {
     #[arg(short = 'o', long, value_name = "PATH", env = "TVC_APPROVAL_OUT")]
     pub approval_out: Option<PathBuf>,
 
-    /// Don't post approval to the API.
+    /// Generate a local-operator approval without posting it to the API. This
+    /// supports offline signing and cannot be used with a hosted operator.
     #[arg(long, env = "TVC_SKIP_POST")]
     pub skip_post: bool,
 }
 
 struct PostApprovalPlan<'a> {
     manifest_id: &'a str,
-    operator_id: &'a str,
+    operator_id: &'a Uuid,
     deploy_id: Option<&'a str>,
 }
 
@@ -238,15 +241,16 @@ impl Display for ApprovalDryRun {
 
 struct PostTarget {
     manifest_id: String,
-    operator_id: String,
     deploy_id: Option<String>,
 }
 
 struct ResolvedApproveInputs {
     manifest: VersionedManifest,
     operator_seed_source: Option<LocalOperatorSeedSource>,
+    operator_id: Option<Uuid>,
     approval_out: Option<PathBuf>,
     dry_run: bool,
+    skip_post: bool,
     post_target: Option<PostTarget>,
 }
 
@@ -285,11 +289,11 @@ async fn build_inputs_interactive(
         interactive_approve(ctx, &manifest)?;
     }
 
+    let mut operator_id = args.operator_id;
     let post_target = if !args.dry_run && !args.skip_post {
         let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
-        let operator_id = match &args.operator_id {
-            Some(id) => id.clone(),
-            None => {
+        if operator_id.is_none() {
+            operator_id = Some({
                 let saved_ids = load_saved_operator_ids().await?;
                 match &*saved_ids {
                     [] => bail!(
@@ -297,21 +301,18 @@ async fn build_inputs_interactive(
                          No saved operator IDs found. \
                          Use --skip-post to only generate the approval locally."
                     ),
-                    [id] => id.clone(),
-                    _ if stdin_can_prompt() => prompts::select(
-                        "Select approving operator",
-                        saved_ids.iter().map(String::as_str).collect::<Vec<_>>(),
-                    )?
-                    .to_string(),
+                    [id] => *id,
+                    _ if stdin_can_prompt() => {
+                        prompts::select("Select approving operator", saved_ids)?
+                    }
                     _ => bail!(
                         "--operator-id is required to post approval to API when multiple saved operator IDs are available"
                     ),
                 }
-            }
-        };
+            });
+        }
         Some(PostTarget {
             manifest_id,
-            operator_id,
             deploy_id: args.deploy_id.clone(),
         })
     } else {
@@ -321,8 +322,10 @@ async fn build_inputs_interactive(
     Ok(ResolvedApproveInputs {
         manifest,
         operator_seed_source,
+        operator_id,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
+        skip_post: args.skip_post,
         post_target,
     })
 }
@@ -338,11 +341,11 @@ async fn build_inputs_non_interactive(
 
     let (manifest, fetched_manifest_id) = load_manifest(ctx, &args).await?;
 
+    let mut operator_id = args.operator_id;
     let post_target = if !args.dry_run && !args.skip_post {
         let manifest_id = resolve_manifest_id(&args, fetched_manifest_id.as_deref())?;
-        let operator_id = match &args.operator_id {
-            Some(id) => id.clone(),
-            None => {
+        if operator_id.is_none() {
+            operator_id = Some({
                 let saved_ids = load_saved_operator_ids().await?;
                 match &*saved_ids {
                     [] => bail!(
@@ -350,16 +353,15 @@ async fn build_inputs_non_interactive(
                          No saved operator IDs found. \
                          Use --skip-post to only generate the approval locally."
                     ),
-                    [id] => id.clone(),
+                    [id] => *id,
                     _ => bail!(
                         "--operator-id is required to post approval to API when multiple saved operator IDs are available"
                     ),
                 }
-            }
-        };
+            });
+        }
         Some(PostTarget {
             manifest_id,
-            operator_id,
             deploy_id: args.deploy_id.clone(),
         })
     } else {
@@ -369,8 +371,10 @@ async fn build_inputs_non_interactive(
     Ok(ResolvedApproveInputs {
         manifest,
         operator_seed_source,
+        operator_id,
         approval_out: args.approval_out,
         dry_run: args.dry_run,
+        skip_post: args.skip_post,
         post_target,
     })
 }
@@ -383,8 +387,20 @@ async fn run_with_resolved_inputs(
         return Ok(ApproveOutcome::DryRun(ApprovalDryRun {}));
     }
 
+    let operator = resolve_operator(inputs.operator_seed_source, inputs.operator_id).await?;
+    if inputs.skip_post && operator.is_hosted() {
+        bail!("--skip-post is only supported for local operators");
+    }
+    let auth = if operator.is_hosted() {
+        Some(build_client().await?)
+    } else {
+        None
+    };
     let approval = sign_and_write_approval(
-        inputs.operator_seed_source,
+        &operator,
+        &OperatorCtx {
+            auth: auth.as_ref(),
+        },
         inputs.approval_out.as_deref(),
         &inputs.manifest,
     )
@@ -404,9 +420,12 @@ async fn run_with_resolved_inputs(
 
     match inputs.post_target {
         Some(target) => {
+            let operator_id = operator
+                .id()
+                .context("resolved operator ID required to post approval")?;
             let plan = PostApprovalPlan {
                 manifest_id: target.manifest_id.as_str(),
-                operator_id: target.operator_id.as_str(),
+                operator_id: &operator_id,
                 deploy_id: target.deploy_id.as_deref(),
             };
             let posted = post_approval_to_api(ctx, plan, &approval).await?;
@@ -415,7 +434,7 @@ async fn run_with_resolved_inputs(
                 approval: inline_approval,
                 written_to,
                 manifest_id: target.manifest_id,
-                operator_id: target.operator_id,
+                operator_id: operator_id.to_string(),
                 approval_ids: posted.approval_ids,
                 quorum_reached: posted.quorum_reached,
             }))
@@ -445,14 +464,12 @@ async fn load_manifest(
 /// that file. Reporting the approval (inline payload or file path) is the
 /// terminal outcome's job.
 async fn sign_and_write_approval(
-    operator_seed_source: Option<LocalOperatorSeedSource>,
+    operator: &ResolvedOperator,
+    operator_ctx: &OperatorCtx<'_>,
     approval_out: Option<&Path>,
     manifest: &VersionedManifest,
 ) -> anyhow::Result<Approval> {
-    let pair: Box<dyn crate::pair::Pair> =
-        Box::new(resolve_local_operator(operator_seed_source).await?);
-
-    let approval = generate_approval(pair, manifest).await?;
+    let approval = operator.approve_manifest(operator_ctx, manifest).await?;
 
     if let Some(path) = approval_out {
         let json = serde_json::to_string_pretty(&approval)?;
@@ -474,9 +491,16 @@ fn resolve_manifest_id(args: &Args, fetched_manifest_id: Option<&str>) -> anyhow
         })
 }
 
-async fn load_saved_operator_ids() -> anyhow::Result<Vec<String>> {
+async fn load_saved_operator_ids() -> anyhow::Result<Vec<Uuid>> {
     let config = Config::load().await?;
-    Ok(config.get_last_operator_ids().unwrap_or_default())
+    config
+        .get_last_operator_ids()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|id| {
+            Uuid::parse_str(&id).with_context(|| format!("saved operator ID '{id}' is not a UUID"))
+        })
+        .collect()
 }
 
 async fn post_approval_to_api(
@@ -490,7 +514,7 @@ async fn post_approval_to_api(
     let auth = crate::client::build_client().await?;
 
     let tvc_approval = TvcManifestApproval {
-        operator_id: plan.operator_id.into(),
+        operator_id: plan.operator_id.to_string(),
         signature: hex::encode(&approval.signature),
     };
 
@@ -566,29 +590,6 @@ fn manifest_approval_quorum_reached(deployment: &TvcDeployment) -> bool {
     }
 
     operator_ids.len() >= manifest_set.threshold as usize
-}
-
-async fn generate_approval(
-    pair: Box<dyn crate::pair::Pair>,
-    manifest: &VersionedManifest,
-) -> anyhow::Result<Approval> {
-    let public_key = pair.public_key();
-    let member = manifest
-        .manifest_set()
-        .members
-        .iter()
-        .find(|m| m.pub_key == public_key)
-        .cloned()
-        .ok_or_else(|| {
-            anyhow!(
-                "operator ({}) not part of manifest set",
-                hex::encode(&public_key)
-            )
-        })?;
-
-    let signature = pair.sign(manifest.manifest_hash().to_vec()).await?;
-
-    Ok(Approval { signature, member })
 }
 
 /// Walk the user through each section of the manifest for approval.

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod deploy;
 pub mod display;
 pub mod keys;
 pub mod login;
+pub mod operator;

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -1,0 +1,232 @@
+//! Create a Turnkey-hosted TVC operator.
+
+use crate::{
+    client::build_client,
+    config::turnkey::{Config, OperatorRecord, OperatorRecordKind},
+    operator::{
+        DEFAULT_HOSTED_OPERATOR_BASE_PATH, HostedOperatorSpec, HostedOperatorWallet,
+        create_hosted_operator, ensure_authenticated_org,
+    },
+    outcome::Outcome,
+    output::StdCtx,
+};
+use anyhow::{Context, Result, anyhow};
+use clap::{ArgGroup, Args as ClapArgs, builder::NonEmptyStringValueParser};
+use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
+use uuid::Uuid;
+
+const DEFAULT_OPERATOR_NAME: &str = "tvc-operator";
+const DEFAULT_WALLET_NAME: &str = "tvc-wallet";
+
+/// Create one hosted TVC operator and save it to the active organization.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+#[command(group(
+    ArgGroup::new("wallet")
+        .args(["wallet_name", "wallet_id"])
+        .multiple(false)
+))]
+pub struct Args {
+    /// Human-readable operator name.
+    #[arg(
+        long,
+        env = "TVC_OPERATOR_NAME",
+        default_value = DEFAULT_OPERATOR_NAME,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    name: String,
+
+    /// Name for a newly created wallet. Defaults to tvc-wallet.
+    #[arg(
+        long,
+        env = "TVC_OPERATOR_WALLET_NAME",
+        default_value = DEFAULT_WALLET_NAME,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    wallet_name: String,
+
+    /// Existing wallet UUID in which to create the operator accounts.
+    #[arg(long, env = "TVC_OPERATOR_WALLET_ID")]
+    wallet_id: Option<Uuid>,
+
+    /// Base derivation path. Defaults to m/5527107'/0'/0'. The server appends
+    /// the encrypt/sign role paths.
+    #[arg(
+        long,
+        env = "TVC_OPERATOR_ACCOUNT_PATH",
+        default_value = DEFAULT_HOSTED_OPERATOR_BASE_PATH,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    account_path: String,
+}
+
+#[derive(Serialize)]
+#[cfg_attr(test, derive(Default))]
+#[serde(rename_all = "camelCase")]
+pub struct OperatorCreated {
+    name: String,
+    operator_id: Uuid,
+    encrypt_public_key: String,
+    sign_public_key: String,
+    composite_public_key: String,
+    saved: bool,
+}
+
+impl Display for OperatorCreated {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#"Hosted operator created!
+Operator name: {}
+Operator ID: {}
+Encryption public key: {}
+Signing public key: {}
+Composite public key: {}
+Saved: true"#,
+            self.name,
+            self.operator_id,
+            self.encrypt_public_key,
+            self.sign_public_key,
+            self.composite_public_key
+        )
+    }
+}
+
+pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+    let mut config = Config::load().await?;
+    let (alias, configured_org_id) = config
+        .active_org_config()
+        .map(|(alias, org)| (alias.clone(), org.id.as_str()))
+        .context("No active organization. Run `tvc login` first.")?;
+
+    let auth = build_client().await?;
+    ensure_authenticated_org(&auth.org_id, configured_org_id)?;
+
+    let record = create_hosted_operator(&auth, hosted_operator_spec(args)).await?;
+    let output = output_from_record(record.clone())?;
+
+    config
+        .orgs
+        .get_mut(&alias)
+        .with_context(|| format!("active organization '{alias}' disappeared from config"))?
+        .operators
+        .push(record);
+
+    if let Err(save_error) = config.save().await {
+        let record = config
+            .orgs
+            .get(&alias)
+            .and_then(|org| org.operators.last())
+            .with_context(|| {
+                format!("hosted operator disappeared from active organization '{alias}'")
+            })?;
+        let recovery = recovery_toml(&alias, record)?;
+        return Err(anyhow!(
+            r#"hosted operator {} was created remotely, but saving the local config failed: {save_error}
+Do not retry creation blindly; doing so would create another remote operator. Restore this record under the active organization in tvc.config.toml:
+
+{recovery}"#,
+            output.operator_id
+        ));
+    }
+
+    Ok(Outcome::OperatorCreate(output))
+}
+
+fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
+    let wallet = match args.wallet_id {
+        Some(id) => HostedOperatorWallet::Existing(id),
+        None => HostedOperatorWallet::New(args.wallet_name),
+    };
+
+    HostedOperatorSpec::new(args.name, wallet, args.account_path)
+}
+
+fn output_from_record(record: OperatorRecord) -> Result<OperatorCreated> {
+    let OperatorRecord { name, kind } = record;
+    let OperatorRecordKind::Hosted(hosted) = kind else {
+        return Err(anyhow!("hosted operator creation returned a local record"));
+    };
+    let composite_public_key = format!("{}{}", hosted.encrypt_public_key, hosted.sign_public_key);
+
+    Ok(OperatorCreated {
+        name,
+        operator_id: hosted.operator_id,
+        encrypt_public_key: hosted.encrypt_public_key,
+        sign_public_key: hosted.sign_public_key,
+        composite_public_key,
+        saved: true,
+    })
+}
+
+fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
+    let quoted_alias = serde_json::to_string(alias)
+        .context("failed to quote organization alias for recovery record")?;
+    let record = toml::to_string_pretty(record)
+        .context("failed to serialize hosted operator recovery record")?;
+    Ok(format!(
+        r#"[[orgs.{quoted_alias}.operators]]
+{}"#,
+        record.trim()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::turnkey::HostedOperatorRecord;
+    use crate::output::Message;
+
+    fn hosted_record() -> OperatorRecord {
+        OperatorRecord {
+            name: "tvc-operator".to_string(),
+            kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
+                wallet_id: Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap(),
+                path: "m/5527107'/0'/0'".to_string(),
+                encrypt_public_key: format!("04{}", "11".repeat(64)),
+                sign_public_key: format!("04{}", "22".repeat(64)),
+                extra: toml::Table::new(),
+            }),
+        }
+    }
+
+    #[test]
+    fn recovery_toml_contains_complete_hosted_record() {
+        #[derive(serde::Deserialize)]
+        struct Recovery {
+            orgs: std::collections::HashMap<String, RecoveryOrg>,
+        }
+        #[derive(serde::Deserialize)]
+        struct RecoveryOrg {
+            operators: Vec<OperatorRecord>,
+        }
+
+        let expected = hosted_record();
+        let recovery: Recovery =
+            toml::from_str(&recovery_toml("default", &expected).unwrap()).unwrap();
+
+        assert_eq!(recovery.orgs["default"].operators, vec![expected]);
+    }
+
+    #[test]
+    fn operator_created_serializes_expected_json() {
+        let output = output_from_record(hosted_record()).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&Outcome::OperatorCreate(output).to_json_string()).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "reason": "operator-created",
+                "name": "tvc-operator",
+                "operatorId": "11111111-1111-4111-8111-111111111111",
+                "encryptPublicKey": format!("04{}", "11".repeat(64)),
+                "signPublicKey": format!("04{}", "22".repeat(64)),
+                "compositePublicKey": format!("04{}04{}", "11".repeat(64), "22".repeat(64)),
+                "saved": true,
+            })
+        );
+    }
+}

--- a/tvc/src/commands/operator/mod.rs
+++ b/tvc/src/commands/operator/mod.rs
@@ -1,0 +1,3 @@
+//! Hosted operator commands.
+
+pub mod create;

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -20,6 +20,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::path::PathBuf;
 use tracing::debug;
+use uuid::Uuid;
 
 const CONFIG_DIR: &str = ".config/turnkey";
 const CONFIG_FILE: &str = "tvc.config.toml";
@@ -247,7 +248,7 @@ impl Display for OperatorKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct OperatorRecord {
-    /// Unique human-readable name within the organization.
+    /// Human-readable name within the organization.
     pub name: String,
     #[serde(flatten)]
     pub kind: OperatorRecordKind,
@@ -298,8 +299,8 @@ pub struct LocalOperatorRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct HostedOperatorRecord {
-    pub operator_id: String,
-    pub wallet_id: String,
+    pub operator_id: Uuid,
+    pub wallet_id: Uuid,
     pub path: String,
     pub encrypt_public_key: String,
     pub sign_public_key: String,

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -331,8 +331,8 @@ pub struct OrgConfig {
 }
 
 impl OrgConfig {
-    /// Return the sole active local operator record.
-    pub fn select_local_record(&self, org_alias: &str) -> Result<&LocalOperatorRecord> {
+    /// Return the sole active local operator registry entry.
+    pub(crate) fn select_local_operator(&self, org_alias: &str) -> Result<&OperatorRecord> {
         if self.default_operator_kind != OperatorKind::Local {
             bail!(
                 "the active operator kind for org '{org_alias}' is {}",
@@ -343,10 +343,7 @@ impl OrgConfig {
         let candidates: Vec<_> = self
             .operators
             .iter()
-            .filter_map(|operator| match &operator.kind {
-                OperatorRecordKind::Local(local) => Some(local),
-                _ => None,
-            })
+            .filter(|operator| matches!(operator.kind, OperatorRecordKind::Local(_)))
             .collect();
 
         // TODO: Decouple this function from its org_alias callsite so it is more
@@ -356,6 +353,15 @@ impl OrgConfig {
             [operator] => Ok(*operator),
             _ => bail!("Multiple local operators are configured for org '{org_alias}'"),
         }
+    }
+
+    /// Return the kind-specific record for the sole active local operator.
+    pub fn select_local_record(&self, org_alias: &str) -> Result<&LocalOperatorRecord> {
+        let operator = self.select_local_operator(org_alias)?;
+        let OperatorRecordKind::Local(local) = &operator.kind else {
+            bail!("selected operator is not local");
+        };
+        Ok(local)
     }
 }
 

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -13,6 +13,7 @@ pub mod commands;
 pub mod config;
 pub(crate) mod local_operator_key;
 pub mod logging;
+pub mod operator;
 pub mod outcome;
 pub mod output;
 pub mod pair;

--- a/tvc/src/local_operator_key.rs
+++ b/tvc/src/local_operator_key.rs
@@ -58,11 +58,19 @@ pub async fn resolve_local_operator(
                 )
             })?;
             let local = org_config.select_local_record(alias)?;
-            LocalCredentialSource::RegisteredKeyFile(local.key_path.clone())
+            return resolve_registered_local_operator(local.key_path.clone()).await;
         }
     };
 
     resolve_local_credential(source).await
+}
+
+/// Resolve a registered local operator without loading its registry entry
+/// again. The path points to `StoredQosOperatorKey` JSON.
+pub(crate) async fn resolve_registered_local_operator(
+    key_path: PathBuf,
+) -> anyhow::Result<LocalPair> {
+    resolve_local_credential(LocalCredentialSource::RegisteredKeyFile(key_path)).await
 }
 
 /// Load a local pair with the parser required by the credential source.

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -1,0 +1,210 @@
+//! Hosted TVC operator creation.
+
+use crate::client::AuthenticatedClient;
+use crate::config::turnkey::{HostedOperatorRecord, OperatorRecord, OperatorRecordKind};
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
+use std::time::{SystemTime, UNIX_EPOCH};
+use turnkey_client::TurnkeyClientError;
+use turnkey_client::generated::{CreateTvcOperatorIntent, CreateTvcOperatorResult};
+use uuid::Uuid;
+
+/// Default base derivation path for hosted TVC operator accounts.
+///
+/// `5527107` is `0x545643` (the ASCII bytes for `TVC`) and reserves a
+/// TVC-specific hardened BIP32 namespace. The next component is the path
+/// version (`0`) and the final component is the operator index (`0`). The
+/// Turnkey signer appends `/0` for the encryption account and `/1` for the
+/// signing account. Callers creating more than one operator in the same wallet
+/// must currently provide a different base path themselves.
+pub const DEFAULT_HOSTED_OPERATOR_BASE_PATH: &str = "m/5527107'/0'/0'";
+
+/// Inputs for creating one hosted TVC operator.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct HostedOperatorSpec {
+    name: String,
+    wallet: HostedOperatorWallet,
+    path: String,
+}
+
+/// Valid wallet selections for hosted operator creation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum HostedOperatorWallet {
+    New(String),
+    Existing(Uuid),
+}
+
+impl HostedOperatorSpec {
+    pub(crate) fn new(name: String, wallet: HostedOperatorWallet, path: String) -> Self {
+        Self { name, wallet, path }
+    }
+}
+
+/// Create one Turnkey-hosted TVC operator and return a registry-ready record.
+pub(crate) async fn create_hosted_operator(
+    auth: &AuthenticatedClient,
+    spec: HostedOperatorSpec,
+) -> Result<OperatorRecord> {
+    let HostedOperatorSpec { name, wallet, path } = spec;
+    let (wallet_name, wallet_id) = match wallet {
+        HostedOperatorWallet::New(name) => (Some(name), None),
+        HostedOperatorWallet::Existing(id) => (None, Some(id.to_string())),
+    };
+
+    let intent = CreateTvcOperatorIntent {
+        wallet_name,
+        wallet_id,
+        path: path.clone(),
+        operator_name: name.clone(),
+    };
+    let result = auth
+        .client
+        .create_tvc_operator(auth.org_id.clone(), timestamp_ms()?, intent)
+        .await
+        .map_err(|error| hosted_activity_error("create hosted TVC operator", error))?;
+
+    operator_record_from_result(name, path, result.result)
+}
+
+fn operator_record_from_result(
+    name: String,
+    path: String,
+    result: CreateTvcOperatorResult,
+) -> Result<OperatorRecord> {
+    let CreateTvcOperatorResult {
+        wallet_id,
+        operator_id,
+        encrypt_public_key,
+        sign_public_key,
+    } = result;
+    let wallet_id = parse_uuid(&wallet_id, "created wallet ID")?;
+    let operator_id = parse_uuid(&operator_id, "created operator ID")?;
+    let encrypt_public_key = normalize_public_key(
+        &encrypt_public_key,
+        "created operator encryption public key",
+    )?;
+    let sign_public_key =
+        normalize_public_key(&sign_public_key, "created operator signing public key")?;
+    ensure!(
+        encrypt_public_key != sign_public_key,
+        "created operator encryption and signing public keys must be distinct"
+    );
+
+    Ok(OperatorRecord {
+        name,
+        kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+            operator_id,
+            wallet_id,
+            path,
+            encrypt_public_key,
+            sign_public_key,
+            extra: toml::Table::new(),
+        }),
+    })
+}
+
+fn parse_uuid(value: &str, field: &str) -> Result<Uuid> {
+    Uuid::parse_str(value).map_err(|_| anyhow!("{field} must be a UUID"))
+}
+
+fn normalize_public_key(value: &str, field: &str) -> Result<String> {
+    let bytes = hex::decode(value).with_context(|| format!("{field} must be hex encoded"))?;
+    ensure!(
+        bytes.len() == 65 && bytes.first() == Some(&0x04),
+        "{field} must be a 65-byte uncompressed P-256 public key"
+    );
+    let key = PublicKey::from_sec1_bytes(&bytes)
+        .with_context(|| format!("{field} is not a valid P-256 point"))?;
+    Ok(hex::encode(key.to_encoded_point(false).as_bytes()))
+}
+
+pub(crate) fn ensure_authenticated_org(
+    authenticated_org_id: &str,
+    configured_org_id: &str,
+) -> Result<()> {
+    ensure!(
+        authenticated_org_id == configured_org_id,
+        "authenticated organization ({authenticated_org_id}) does not match configured organization ({configured_org_id})"
+    );
+    Ok(())
+}
+
+fn hosted_activity_error(operation: &str, error: TurnkeyClientError) -> anyhow::Error {
+    match error {
+        TurnkeyClientError::ActivityRequiresApproval(activity_id) => anyhow!(
+            "failed to {operation}: activity {activity_id} requires additional approvals or authentication"
+        ),
+        error => anyhow!("failed to {operation}: {error}"),
+    }
+}
+
+fn timestamp_ms() -> Result<u128> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system time before unix epoch")?
+        .as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qos_p256::P256Pair;
+
+    const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const WALLET_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn public_keys() -> (String, String) {
+        let first = P256Pair::generate().unwrap().public_key().to_bytes();
+        let second = P256Pair::generate().unwrap().public_key().to_bytes();
+        (hex::encode(&first[..65]), hex::encode(&second[65..]))
+    }
+
+    #[test]
+    fn validates_and_normalizes_creation_result() {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        let record = operator_record_from_result(
+            "operator".to_string(),
+            DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+            CreateTvcOperatorResult {
+                wallet_id: WALLET_ID.to_uppercase(),
+                operator_id: OPERATOR_ID.to_uppercase(),
+                encrypt_public_key: encrypt_public_key.to_uppercase(),
+                sign_public_key: sign_public_key.to_uppercase(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            record,
+            OperatorRecord {
+                name: "operator".to_string(),
+                kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                    operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
+                    wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
+                    path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+                    encrypt_public_key,
+                    sign_public_key,
+                    extra: toml::Table::new(),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_operator_id_from_creation_result() {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        let error = operator_record_from_result(
+            "operator".to_string(),
+            DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+            CreateTvcOperatorResult {
+                wallet_id: WALLET_ID.to_string(),
+                operator_id: "not-a-uuid".to_string(),
+                encrypt_public_key,
+                sign_public_key,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "created operator ID must be a UUID");
+    }
+}

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -1,12 +1,22 @@
-//! Hosted TVC operator creation.
+//! TVC operator creation and manifest approval.
 
 use crate::client::AuthenticatedClient;
-use crate::config::turnkey::{HostedOperatorRecord, OperatorRecord, OperatorRecordKind};
+use crate::config::turnkey::{
+    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind,
+};
+use crate::local_operator_key::{
+    LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
+};
+use crate::pair::{LocalPair, Pair};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
+use qos_core::protocol::services::boot::{Approval, VersionedManifest};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::TurnkeyClientError;
-use turnkey_client::generated::{CreateTvcOperatorIntent, CreateTvcOperatorResult};
+use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
+use turnkey_client::generated::{
+    CreateTvcOperatorIntent, CreateTvcOperatorResult, SignRawPayloadIntentV2, SignRawPayloadResult,
+};
 use uuid::Uuid;
 
 /// Default base derivation path for hosted TVC operator accounts.
@@ -118,6 +128,155 @@ fn normalize_public_key(value: &str, field: &str) -> Result<String> {
     Ok(hex::encode(key.to_encoded_point(false).as_bytes()))
 }
 
+fn composite_public_key(record: &HostedOperatorRecord) -> Result<Vec<u8>> {
+    let encrypt = hex::decode(normalize_public_key(
+        &record.encrypt_public_key,
+        "hosted operator encryption public key",
+    )?)?;
+    let sign = hex::decode(normalize_public_key(
+        &record.sign_public_key,
+        "hosted operator signing public key",
+    )?)?;
+    ensure!(
+        encrypt != sign,
+        "hosted operator encryption and signing public keys must be distinct"
+    );
+
+    Ok(encrypt.into_iter().chain(sign).collect())
+}
+
+fn validate_hosted_record(
+    name: &str,
+    record: HostedOperatorRecord,
+) -> Result<HostedOperatorRecord> {
+    let HostedOperatorRecord {
+        operator_id,
+        wallet_id,
+        path,
+        encrypt_public_key,
+        sign_public_key,
+        extra,
+    } = record;
+    ensure!(
+        !name.trim().is_empty(),
+        "hosted operator name must not be empty"
+    );
+    ensure!(
+        !path.trim().is_empty(),
+        "hosted operator account path must not be empty"
+    );
+
+    let validated = HostedOperatorRecord {
+        operator_id,
+        wallet_id,
+        path,
+        encrypt_public_key: normalize_public_key(
+            &encrypt_public_key,
+            "hosted operator encryption public key",
+        )?,
+        sign_public_key: normalize_public_key(
+            &sign_public_key,
+            "hosted operator signing public key",
+        )?,
+        extra,
+    };
+    let _ = composite_public_key(&validated)?;
+    Ok(validated)
+}
+
+/// A non-serializable operator with its credentials resolved for use.
+pub(crate) struct ResolvedOperator {
+    /// Absent for an ad-hoc local seed override.
+    name: Option<String>,
+    /// Always present for hosted operators and optional for local operators.
+    operator_id: Option<Uuid>,
+    /// Organization from which a registered operator was resolved.
+    organization_id: Option<String>,
+    pub(crate) kind: ResolvedOperatorKind,
+}
+
+/// Kind-specific runtime capability held by a [`ResolvedOperator`].
+pub(crate) enum ResolvedOperatorKind {
+    Local(LocalPair),
+    Hosted(HostedOperatorRecord),
+}
+
+/// Shared dependencies for operator-level workflows.
+pub(crate) struct OperatorCtx<'a> {
+    pub(crate) auth: Option<&'a AuthenticatedClient>,
+}
+
+impl ResolvedOperator {
+    pub(crate) fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub(crate) fn id(&self) -> Option<Uuid> {
+        self.operator_id
+    }
+
+    pub(crate) fn is_hosted(&self) -> bool {
+        matches!(self.kind, ResolvedOperatorKind::Hosted(_))
+    }
+
+    pub(crate) fn public_key(&self) -> Result<Vec<u8>> {
+        match &self.kind {
+            ResolvedOperatorKind::Local(pair) => Ok(pair.public_key()),
+            ResolvedOperatorKind::Hosted(record) => composite_public_key(record),
+        }
+    }
+
+    pub(crate) async fn approve_manifest(
+        &self,
+        ctx: &OperatorCtx<'_>,
+        manifest: &VersionedManifest,
+    ) -> Result<Approval> {
+        let public_key = self.public_key()?;
+        let member = manifest_member(manifest, &public_key, self.name())?;
+        let signature = match &self.kind {
+            ResolvedOperatorKind::Local(pair) => {
+                pair.sign(manifest.manifest_hash().to_vec()).await?
+            }
+            ResolvedOperatorKind::Hosted(record) => {
+                let auth = ctx
+                    .auth
+                    .context("authenticated client required for hosted operator approval")?;
+                let organization_id = self
+                    .organization_id
+                    .as_deref()
+                    .context("configured organization required for hosted operator approval")?;
+                ensure_authenticated_org(&auth.org_id, organization_id)?;
+                sign_hosted_manifest(auth, record, manifest).await?
+            }
+        };
+
+        Ok(Approval { signature, member })
+    }
+}
+
+fn manifest_member(
+    manifest: &VersionedManifest,
+    public_key: &[u8],
+    operator_name: Option<&str>,
+) -> Result<qos_core::protocol::services::boot::QuorumMember> {
+    manifest
+        .manifest_set()
+        .members
+        .iter()
+        .find(|member| member.pub_key == public_key)
+        .cloned()
+        .ok_or_else(|| match operator_name {
+            Some(name) => anyhow!(
+                "operator '{name}' ({}) not part of manifest set",
+                hex::encode(public_key)
+            ),
+            None => anyhow!(
+                "operator ({}) not part of manifest set",
+                hex::encode(public_key)
+            ),
+        })
+}
+
 pub(crate) fn ensure_authenticated_org(
     authenticated_org_id: &str,
     configured_org_id: &str,
@@ -127,6 +286,155 @@ pub(crate) fn ensure_authenticated_org(
         "authenticated organization ({authenticated_org_id}) does not match configured organization ({configured_org_id})"
     );
     Ok(())
+}
+
+pub(crate) async fn resolve_operator(
+    explicit: Option<LocalOperatorSeedSource>,
+    operator_id: Option<Uuid>,
+) -> Result<ResolvedOperator> {
+    if let Some(explicit) = explicit {
+        if let Some(id) = operator_id {
+            let config = Config::load().await?;
+            ensure!(
+                find_hosted_operator(&config, &id)?.is_none(),
+                "explicit local operator seed cannot be used with a hosted operator ID"
+            );
+        }
+        return Ok(ResolvedOperator {
+            name: None,
+            operator_id,
+            organization_id: None,
+            kind: ResolvedOperatorKind::Local(resolve_local_operator(Some(explicit)).await?),
+        });
+    }
+
+    let config = Config::load().await?;
+    let hosted = match operator_id {
+        Some(id) => find_hosted_operator(&config, &id)?,
+        None => None,
+    };
+
+    if let Some((organization_id, name, record)) = hosted {
+        return Ok(ResolvedOperator {
+            name: Some(name),
+            operator_id: Some(record.operator_id),
+            organization_id: Some(organization_id),
+            kind: ResolvedOperatorKind::Hosted(record),
+        });
+    }
+
+    let (alias, org) = config.active_org_config().ok_or_else(|| {
+        anyhow!(
+            "No active organization. Run `tvc login` first or provide \
+             --operator-seed or --operator-seed-path."
+        )
+    })?;
+    if org.default_operator_kind == OperatorKind::Hosted {
+        match operator_id {
+            Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
+            None => bail!("--operator-id is required to approve with a hosted operator"),
+        }
+    }
+
+    let operator = org.select_local_operator(alias)?;
+    let OperatorRecordKind::Local(local) = &operator.kind else {
+        return Err(anyhow!("selected operator is not local"));
+    };
+
+    let configured_operator_id = local
+        .operator_id
+        .as_deref()
+        .map(|id| parse_uuid(id, "configured local operator ID"))
+        .transpose()?;
+    let resolved_operator_id = match (configured_operator_id, operator_id) {
+        (Some(configured), Some(requested)) => {
+            ensure!(
+                configured == requested,
+                "requested operator ID ({requested}) does not match configured local operator ID ({configured})"
+            );
+            Some(configured)
+        }
+        (configured, requested) => configured.or(requested),
+    };
+
+    Ok(ResolvedOperator {
+        name: Some(operator.name.clone()),
+        operator_id: resolved_operator_id,
+        organization_id: Some(org.id.clone()),
+        kind: ResolvedOperatorKind::Local(
+            resolve_registered_local_operator(local.key_path.clone()).await?,
+        ),
+    })
+}
+
+fn find_hosted_operator(
+    config: &Config,
+    operator_id: &Uuid,
+) -> Result<Option<(String, String, HostedOperatorRecord)>> {
+    let Some((_, org)) = config.active_org_config() else {
+        return Ok(None);
+    };
+    let matches: Vec<_> = org
+        .operators
+        .iter()
+        .filter_map(|operator| match &operator.kind {
+            OperatorRecordKind::Hosted(hosted) => {
+                (hosted.operator_id == *operator_id).then_some((operator.name.as_str(), hosted))
+            }
+            OperatorRecordKind::Local(_) => None,
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [] => Ok(None),
+        [(name, record)] => Ok(Some((
+            org.id.clone(),
+            (*name).to_string(),
+            validate_hosted_record(name, (**record).clone())?,
+        ))),
+        _ => bail!("multiple hosted operators have ID {operator_id}"),
+    }
+}
+
+async fn sign_hosted_manifest(
+    auth: &AuthenticatedClient,
+    record: &HostedOperatorRecord,
+    manifest: &VersionedManifest,
+) -> Result<Vec<u8>> {
+    let intent = hosted_signing_intent(record.sign_public_key.clone(), &manifest.manifest_hash());
+    let result = auth
+        .client
+        .sign_raw_payload(auth.org_id.clone(), timestamp_ms()?, intent)
+        .await
+        .map_err(|error| hosted_activity_error("sign manifest with hosted operator", error))?;
+
+    signature_bytes(result.result)
+}
+
+fn hosted_signing_intent(sign_with: String, manifest_hash: &[u8]) -> SignRawPayloadIntentV2 {
+    SignRawPayloadIntentV2 {
+        sign_with,
+        payload: hex::encode(manifest_hash),
+        encoding: PayloadEncoding::Hexadecimal,
+        hash_function: HashFunction::Sha256,
+    }
+}
+
+fn signature_bytes(result: SignRawPayloadResult) -> Result<Vec<u8>> {
+    let SignRawPayloadResult { r, s, v: _ } = result;
+    let r = signature_component(&r, "r")?;
+    let s = signature_component(&s, "s")?;
+    Ok(r.into_iter().chain(s).collect())
+}
+
+fn signature_component(value: &str, component: &str) -> Result<Vec<u8>> {
+    let bytes = hex::decode(value)
+        .with_context(|| format!("hosted signature component {component} must be hex encoded"))?;
+    ensure!(
+        bytes.len() == 32,
+        "hosted signature component {component} must be exactly 32 bytes"
+    );
+    Ok(bytes)
 }
 
 fn hosted_activity_error(operation: &str, error: TurnkeyClientError) -> anyhow::Error {
@@ -157,6 +465,82 @@ mod tests {
         let first = P256Pair::generate().unwrap().public_key().to_bytes();
         let second = P256Pair::generate().unwrap().public_key().to_bytes();
         (hex::encode(&first[..65]), hex::encode(&second[65..]))
+    }
+
+    fn hosted_record() -> HostedOperatorRecord {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        HostedOperatorRecord {
+            operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
+            wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
+            path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+            encrypt_public_key,
+            sign_public_key,
+            extra: toml::Table::new(),
+        }
+    }
+
+    #[test]
+    fn resolved_hosted_operator_exposes_common_identity() {
+        let record = hosted_record();
+        let operator = ResolvedOperator {
+            name: Some("operator".to_string()),
+            operator_id: Some(record.operator_id),
+            organization_id: Some("org-id".to_string()),
+            kind: ResolvedOperatorKind::Hosted(record.clone()),
+        };
+
+        assert_eq!(operator.name(), Some("operator"));
+        assert_eq!(operator.id(), Some(Uuid::parse_str(OPERATOR_ID).unwrap()));
+        assert!(matches!(
+            &operator.kind,
+            ResolvedOperatorKind::Hosted(actual) if actual == &record
+        ));
+        assert_eq!(
+            operator.public_key().unwrap(),
+            composite_public_key(&record).unwrap()
+        );
+    }
+
+    #[test]
+    fn hosted_operator_lookup_is_scoped_to_active_organization() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let config = Config {
+            active_org: Some("active".to_string()),
+            orgs: std::collections::HashMap::from([
+                (
+                    "active".to_string(),
+                    crate::config::turnkey::OrgConfig {
+                        id: "active-org".to_string(),
+                        api_key_path: "active-api.json".into(),
+                        api_base_url: "https://api.turnkey.com".to_string(),
+                        default_operator_kind: OperatorKind::Local,
+                        operators: Vec::new(),
+                        extra: toml::Table::new(),
+                    },
+                ),
+                (
+                    "inactive".to_string(),
+                    crate::config::turnkey::OrgConfig {
+                        id: "inactive-org".to_string(),
+                        api_key_path: "inactive-api.json".into(),
+                        api_base_url: "https://api.turnkey.com".to_string(),
+                        default_operator_kind: OperatorKind::Hosted,
+                        operators: vec![OperatorRecord {
+                            name: "hosted".to_string(),
+                            kind: OperatorRecordKind::Hosted(hosted_record()),
+                        }],
+                        extra: toml::Table::new(),
+                    },
+                ),
+            ]),
+            ..Config::default()
+        };
+
+        assert!(
+            find_hosted_operator(&config, &operator_id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -206,5 +590,18 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.to_string(), "created operator ID must be a UUID");
+    }
+
+    #[test]
+    fn policy_error_includes_activity_id_and_operation() {
+        let error = hosted_activity_error(
+            "sign manifest with hosted operator",
+            TurnkeyClientError::ActivityRequiresApproval("activity-id".to_string()),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "failed to sign manifest with hosted operator: activity activity-id requires additional approvals or authentication"
+        );
     }
 }

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -11,7 +11,7 @@
 //! deliberately, never renamed after release.
 
 use crate::commands::deploy::approve::ApproveOutcome;
-use crate::commands::{app, deploy, keys, login};
+use crate::commands::{app, deploy, keys, login, operator};
 use crate::output::Message;
 use serde::{Serialize, Serializer};
 
@@ -22,6 +22,7 @@ use serde::{Serialize, Serializer};
 /// this enum; the command still returns its terminal variant.
 pub enum Outcome {
     Login(login::LoggedIn),
+    OperatorCreate(operator::create::OperatorCreated),
     ProfileDelete(login::ProfileDeleted),
     DeployApprove(ApproveOutcome),
     DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus),
@@ -50,6 +51,7 @@ macro_rules! with_message {
     ($self:expr, |$msg:ident| $body:expr) => {
         match $self {
             Outcome::Login($msg) => $body,
+            Outcome::OperatorCreate($msg) => $body,
             Outcome::ProfileDelete($msg) => $body,
             Outcome::DeployApprove($msg) => $body,
             Outcome::DeployGetStatus($msg) => $body,
@@ -88,6 +90,7 @@ impl Message for Outcome {
     fn reason(&self) -> &'static str {
         match self {
             Outcome::Login(_) => "logged-in",
+            Outcome::OperatorCreate(_) => "operator-created",
             Outcome::ProfileDelete(_) => "profile-deleted",
             Outcome::DeployApprove(ApproveOutcome::Posted(_)) => "manifest-approval-posted",
             Outcome::DeployApprove(ApproveOutcome::NotPosted(_)) => "manifest-approval-generated",
@@ -136,6 +139,7 @@ mod tests {
     fn all_terminal_shapes() -> Vec<Outcome> {
         vec![
             Outcome::Login(login::LoggedIn::default()),
+            Outcome::OperatorCreate(operator::create::OperatorCreated::default()),
             Outcome::ProfileDelete(login::ProfileDeleted::default()),
             Outcome::DeployApprove(ApproveOutcome::Posted(ApprovalPosted::default())),
             Outcome::DeployApprove(ApproveOutcome::NotPosted(ApprovalGenerated::default())),

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -1,13 +1,67 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use qos_p256::P256Pair;
+use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
+use tvc::config::turnkey::{
+    Config, HostedOperatorRecord, LocalOperatorRecord, OperatorKind, OperatorRecord,
+    OperatorRecordKind, OrgConfig, StoredQosOperatorKey,
+};
+use uuid::Uuid;
 
 fn fixture_seed_hex() -> String {
     fs::read_to_string("fixtures/seed.hex")
         .unwrap()
         .trim()
         .to_string()
+}
+
+const HOSTED_OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
+const LOCAL_OPERATOR_ID: &str = "33333333-3333-4333-8333-333333333333";
+
+fn write_config(home: &TempDir, config: &Config) {
+    let config_dir = home.path().join(".config/turnkey");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("tvc.config.toml"),
+        format!(
+            r#"version = 1
+{}"#,
+            toml::to_string_pretty(config).unwrap()
+        ),
+    )
+    .unwrap();
+}
+
+fn write_hosted_config(home: &TempDir) {
+    let public = P256Pair::generate().unwrap().public_key().to_bytes();
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path: home.path().join("api-key.json"),
+                api_base_url: "https://api.turnkey.com".to_string(),
+                default_operator_kind: OperatorKind::Hosted,
+                operators: vec![OperatorRecord {
+                    name: "hosted".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: Uuid::parse_str(HOSTED_OPERATOR_ID).unwrap(),
+                        wallet_id: Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: hex::encode(&public[..65]),
+                        sign_public_key: hex::encode(&public[65..]),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        ..Config::default()
+    };
+    write_config(home, &config);
 }
 
 #[test]
@@ -20,6 +74,261 @@ fn approve_requires_source() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("manifest source is required"));
+}
+
+#[test]
+fn hosted_dry_run_does_not_require_operator_id() {
+    let temp = TempDir::new().unwrap();
+    write_hosted_config(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--dry-run")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dry run complete"));
+}
+
+#[test]
+fn hosted_approval_requires_explicit_operator_id() {
+    let temp = TempDir::new().unwrap();
+    write_hosted_config(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--operator-id is required to approve with a hosted operator",
+        ));
+}
+
+#[test]
+fn explicit_seed_rejects_hosted_operator_id() {
+    let temp = TempDir::new().unwrap();
+    write_hosted_config(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg(fixture_seed_hex())
+        .arg("--operator-id")
+        .arg(HOSTED_OPERATOR_ID)
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "explicit local operator seed cannot be used with a hosted operator ID",
+        ));
+}
+
+#[test]
+fn hosted_operator_rejects_skip_post_before_api_activity() {
+    let temp = TempDir::new().unwrap();
+    write_hosted_config(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-id")
+        .arg(HOSTED_OPERATOR_ID)
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--skip-post is only supported for local operators",
+        ));
+}
+
+#[test]
+fn explicit_seed_does_not_load_malformed_config() {
+    let temp = TempDir::new().unwrap();
+    let config_dir = temp.path().join(".config/turnkey");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("tvc.config.toml"), "not valid toml").unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--operator-seed")
+        .arg(fixture_seed_hex())
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .success();
+}
+
+#[test]
+fn malformed_saved_operator_id_is_reported() {
+    let temp = TempDir::new().unwrap();
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path: temp.path().join("api-key.json"),
+                api_base_url: "https://api.turnkey.com".to_string(),
+                default_operator_kind: OperatorKind::Local,
+                operators: Vec::new(),
+                extra: toml::Table::new(),
+            },
+        )]),
+        last_operator_ids: HashMap::from([("test".to_string(), vec!["not-a-uuid".to_string()])]),
+        ..Config::default()
+    };
+    write_config(&temp, &config);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--manifest-id")
+        .arg("manifest-id")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "saved operator ID 'not-a-uuid' is not a UUID",
+        ));
+}
+
+#[test]
+fn malformed_registered_local_operator_id_is_reported() {
+    let temp = TempDir::new().unwrap();
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path: temp.path().join("api-key.json"),
+                api_base_url: "https://api.turnkey.com".to_string(),
+                default_operator_kind: OperatorKind::Local,
+                operators: vec![OperatorRecord {
+                    name: "local".to_string(),
+                    kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                        key_path: temp.path().join("operator.json"),
+                        operator_id: Some("not-a-uuid".to_string()),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        ..Config::default()
+    };
+    write_config(&temp, &config);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "configured local operator ID must be a UUID",
+        ));
+}
+
+#[test]
+fn auto_selected_hosted_id_controls_signer_resolution_in_mixed_registry() {
+    let temp = TempDir::new().unwrap();
+    let public = P256Pair::generate().unwrap().public_key().to_bytes();
+    let operator_key_path = temp.path().join("operator.json");
+    fs::write(
+        &operator_key_path,
+        serde_json::to_string(&StoredQosOperatorKey {
+            public_key: "unused".to_string(),
+            private_key: fixture_seed_hex(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path: temp.path().join("api-key.json"),
+                api_base_url: "https://api.turnkey.com".to_string(),
+                default_operator_kind: OperatorKind::Local,
+                operators: vec![
+                    OperatorRecord {
+                        name: "local".to_string(),
+                        kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                            key_path: operator_key_path,
+                            operator_id: Some(LOCAL_OPERATOR_ID.to_string()),
+                            extra: toml::Table::new(),
+                        }),
+                    },
+                    OperatorRecord {
+                        name: "hosted".to_string(),
+                        kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                            operator_id: Uuid::parse_str(HOSTED_OPERATOR_ID).unwrap(),
+                            wallet_id: Uuid::parse_str("22222222-2222-4222-8222-222222222222")
+                                .unwrap(),
+                            path: "m/5527107'/0'/0'".to_string(),
+                            encrypt_public_key: hex::encode(&public[..65]),
+                            sign_public_key: hex::encode(&public[65..]),
+                            extra: toml::Table::new(),
+                        }),
+                    },
+                ],
+                extra: toml::Table::new(),
+            },
+        )]),
+        last_operator_ids: HashMap::from([(
+            "test".to_string(),
+            vec![HOSTED_OPERATOR_ID.to_string()],
+        )]),
+        ..Config::default()
+    };
+    write_config(&temp, &config);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--manifest-id")
+        .arg("manifest-id")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(r#""signature""#).not())
+        .stderr(predicate::str::contains("No API key found for org 'test'"));
 }
 
 #[test]

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -345,7 +345,10 @@ fn approve_non_interactive_requires_operator_id_when_saved_ids_are_ambiguous() {
         &temp,
         api_key_path.clone(),
         operator_key_path,
-        vec!["operator-1".to_string(), "operator-2".to_string()],
+        vec![
+            "11111111-1111-4111-8111-111111111111".to_string(),
+            "22222222-2222-4222-8222-222222222222".to_string(),
+        ],
     );
     write_api_key(&api_key_path);
 

--- a/tvc/tests/operator_create.rs
+++ b/tvc/tests/operator_create.rs
@@ -1,0 +1,81 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn operator_create_help_documents_defaults_and_env_inputs() {
+    cargo_bin_cmd!("tvc")
+        .arg("operator")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("tvc-operator"))
+        .stdout(predicate::str::contains("TVC_OPERATOR_NAME"))
+        .stdout(predicate::str::contains("--wallet-name"))
+        .stdout(predicate::str::contains("tvc-wallet"))
+        .stdout(predicate::str::contains("TVC_OPERATOR_WALLET_NAME"))
+        .stdout(predicate::str::contains("--wallet-id"))
+        .stdout(predicate::str::contains("TVC_OPERATOR_WALLET_ID"))
+        .stdout(predicate::str::contains("--account-path"))
+        .stdout(predicate::str::contains("m/5527107'/0'/0'"))
+        .stdout(predicate::str::contains("TVC_OPERATOR_ACCOUNT_PATH"));
+}
+
+#[test]
+fn operator_create_wallet_inputs_are_mutually_exclusive() {
+    cargo_bin_cmd!("tvc")
+        .arg("operator")
+        .arg("create")
+        .arg("--wallet-name")
+        .arg("wallet")
+        .arg("--wallet-id")
+        .arg("11111111-1111-4111-8111-111111111111")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with '--wallet-id"));
+}
+
+#[test]
+fn operator_create_rejects_malformed_wallet_uuid() {
+    cargo_bin_cmd!("tvc")
+        .arg("operator")
+        .arg("create")
+        .arg("--wallet-id")
+        .arg("not-a-uuid")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "invalid value 'not-a-uuid' for '--wallet-id <WALLET_ID>'",
+        ));
+}
+
+#[test]
+fn operator_create_accepts_wallet_uuid_with_default_wallet_name() {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("operator")
+        .arg("create")
+        .arg("--wallet-id")
+        .arg("11111111-1111-4111-8111-111111111111")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No active organization"))
+        .stderr(predicate::str::contains("cannot be used with '--wallet-id").not());
+}
+
+#[test]
+fn operator_create_rejects_empty_text_inputs() {
+    for flag in ["--name", "--wallet-name", "--account-path"] {
+        cargo_bin_cmd!("tvc")
+            .arg("operator")
+            .arg("create")
+            .arg(flag)
+            .arg("")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("a value is required"));
+    }
+}


### PR DESCRIPTION
This PR adds the `tvc operator create` command for creating and locally registering Turnkey-hosted operators, and extends `tvc deploy approve` to support hosted-operator approvals. It does not yet change any existing behavior (eg flip an org's `default_operator_kind` or set any defaults), and requires explicitly providing a hosted operator's UUID.