### PR TITLE
feat(tvc): extend create-quorum-key to accept operator-ids and use PubKey struct

### DIFF
--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -1,30 +1,69 @@
 //! Create a hosted quorum key from operator encryption public keys.
 
-use crate::{client::build_client, outcome::Outcome, output::StdCtx};
+use crate::{
+    client::build_client,
+    config::turnkey::Config,
+    operator::{OperatorPublicKey, ensure_authenticated_org, resolve_hosted_operator_encrypt_key},
+    outcome::Outcome,
+    output::StdCtx,
+};
 use anyhow::{Context, Result, anyhow, ensure};
-use clap::Args as ClapArgs;
-use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
+use clap::{ArgAction, ArgGroup, Args as ClapArgs, builder::RangedU64ValueParser};
 use serde::Serialize;
-use std::collections::HashSet;
-use std::fmt::{self, Display, Formatter};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::HashSet,
+    fmt::{self, Display, Formatter},
+    time::{SystemTime, UNIX_EPOCH},
+};
 use turnkey_client::generated::{CreateTvcQuorumKeyIntent, CreateTvcQuorumKeyResult};
+use uuid::Uuid;
 
 // `qos_crypto::shamir::shares_generate` supports at most 255 shares. Hosted
 // quorum generation keeps the operator key count strictly below that bound.
 const MAX_OPERATOR_ENCRYPT_KEY_COUNT_EXCLUSIVE: usize = 255;
 
+fn threshold_parser() -> RangedU64ValueParser<u8> {
+    RangedU64ValueParser::new().range(2..)
+}
+
 /// Create a hosted quorum key encrypted to hosted operator keys.
 #[derive(Debug, ClapArgs)]
 #[command(about, long_about = None)]
+#[command(group(
+    ArgGroup::new("operator_source")
+        .args(["operator_encrypt_keys", "operator_ids"])
+        .required(true)
+        .multiple(false)
+))]
 pub struct Args {
     /// Number of operator shares required to reconstruct the quorum key.
-    #[arg(long, env = "TVC_QUORUM_KEY_THRESHOLD")]
-    pub threshold: u8,
+    #[arg(
+        long,
+        env = "TVC_QUORUM_KEY_THRESHOLD",
+        value_parser = threshold_parser()
+    )]
+    threshold: u8,
 
     /// Comma-separated, uncompressed P-256 operator encryption public keys.
-    #[arg(long, value_name = "HEX,HEX,...", env = "TVC_OPERATOR_ENCRYPT_KEYS")]
-    pub operator_encrypt_keys: String,
+    #[arg(
+        long,
+        value_name = "HEX",
+        value_delimiter = ',',
+        action = ArgAction::Set,
+        env = "TVC_OPERATOR_ENCRYPT_KEYS"
+    )]
+    operator_encrypt_keys: Vec<OperatorPublicKey>,
+
+    /// Comma-separated hosted operator UUIDs from the active organization.
+    #[arg(
+        long,
+        value_name = "UUID",
+        value_delimiter = ',',
+        value_parser = parse_operator_id,
+        action = ArgAction::Set,
+        env = "TVC_OPERATOR_IDS"
+    )]
+    operator_ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -47,15 +86,47 @@ impl Display for QuorumKeyCreated {
     }
 }
 
+enum OperatorSource {
+    EncryptKeys(Vec<OperatorPublicKey>),
+    OperatorIds(Vec<Uuid>),
+}
+
+impl OperatorSource {
+    fn len(&self) -> usize {
+        match self {
+            Self::EncryptKeys(keys) => keys.len(),
+            Self::OperatorIds(ids) => ids.len(),
+        }
+    }
+}
+
 /// Run the hosted quorum-key creation command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let operator_encrypt_keys = parse_operator_encrypt_keys(&args.operator_encrypt_keys)?;
-    validate_operator_count(operator_encrypt_keys.len())?;
-    validate_threshold(args.threshold, operator_encrypt_keys.len())?;
+    let Args {
+        threshold,
+        operator_encrypt_keys,
+        operator_ids,
+    } = args;
+    // The required, mutually exclusive Clap group guarantees exactly one
+    // source is non-empty.
+    let operator_source = if operator_ids.is_empty() {
+        OperatorSource::EncryptKeys(operator_encrypt_keys)
+    } else {
+        OperatorSource::OperatorIds(operator_ids)
+    };
+    validate_operator_count(operator_source.len())?;
+    validate_threshold(threshold, operator_source.len())?;
 
-    let intent = build_create_tvc_quorum_key_intent(args.threshold, operator_encrypt_keys);
+    let (operator_encrypt_keys, configured_org_id) =
+        resolve_operator_encrypt_keys(operator_source).await?;
+    let operator_encrypt_keys = normalize_operator_encrypt_keys(operator_encrypt_keys)?;
+
+    let intent = build_create_tvc_quorum_key_intent(threshold, operator_encrypt_keys);
     let expected_share_count = intent.operator_encrypt_keys.len();
     let auth = build_client().await?;
+    if let Some(configured_org_id) = configured_org_id {
+        ensure_authenticated_org(&auth.org_id, &configured_org_id)?;
+    }
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system time before unix epoch")?
@@ -71,40 +142,61 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     Ok(Outcome::KeysCreateQuorumKey(output))
 }
 
-fn parse_operator_encrypt_keys(input: &str) -> Result<Vec<String>> {
+fn parse_operator_id(value: &str) -> std::result::Result<Uuid, String> {
+    Uuid::parse_str(value.trim()).map_err(|_| "must be a UUID".to_string())
+}
+
+async fn resolve_operator_encrypt_keys(
+    operator_source: OperatorSource,
+) -> Result<(Vec<OperatorPublicKey>, Option<String>)> {
+    match operator_source {
+        OperatorSource::EncryptKeys(keys) => Ok((keys, None)),
+        OperatorSource::OperatorIds(operator_ids) => {
+            validate_operator_ids(&operator_ids)?;
+            let config = Config::load().await?;
+            resolve_operator_ids(&config, &operator_ids)
+        }
+    }
+}
+
+fn resolve_operator_ids(
+    config: &Config,
+    operator_ids: &[Uuid],
+) -> Result<(Vec<OperatorPublicKey>, Option<String>)> {
+    let (_, org) = config
+        .active_org_config()
+        .context("No active organization. Run `tvc login` first.")?;
+    let configured_org_id = org.id.clone();
+    let mut keys = Vec::with_capacity(operator_ids.len());
+
+    for operator_id in operator_ids {
+        keys.push(resolve_hosted_operator_encrypt_key(config, operator_id)?);
+    }
+
+    Ok((keys, Some(configured_org_id)))
+}
+
+fn validate_operator_ids(operator_ids: &[Uuid]) -> Result<()> {
     let mut seen = HashSet::new();
-    input
-        .split(',')
-        .enumerate()
-        .map(|(index, key)| {
-            let key = key.trim();
-            ensure!(
-                !key.is_empty(),
-                "operator encryption public key at index {index} is empty"
-            );
+    for (index, operator_id) in operator_ids.iter().enumerate() {
+        ensure!(
+            seen.insert(operator_id),
+            "duplicate operator ID at index {index}: {operator_id}"
+        );
+    }
+    Ok(())
+}
 
-            let bytes = hex::decode(key).with_context(|| {
-                format!(
-                    "operator encryption public key at index {index} must be bare hex encoded"
-                )
-            })?;
-            ensure!(
-                bytes.len() == 65 && bytes.first() == Some(&0x04),
-                "operator encryption public key at index {index} must be a 65-byte uncompressed P-256 public key"
-            );
-
-            let public_key = PublicKey::from_sec1_bytes(&bytes).with_context(|| {
-                format!("operator encryption public key at index {index} is not a valid P-256 point")
-            })?;
-            let normalized = hex::encode(public_key.to_encoded_point(false).as_bytes());
-            ensure!(
-                seen.insert(normalized.clone()),
-                "duplicate operator encryption public key at index {index}"
-            );
-
-            Ok(normalized)
-        })
-        .collect()
+fn normalize_operator_encrypt_keys(input: Vec<OperatorPublicKey>) -> Result<Vec<String>> {
+    let normalized: Vec<_> = input.into_iter().map(|key| key.to_string()).collect();
+    let mut seen = HashSet::new();
+    for (index, key) in normalized.iter().enumerate() {
+        ensure!(
+            seen.insert(key),
+            "duplicate operator encryption public key at index {index}"
+        );
+    }
+    Ok(normalized)
 }
 
 fn validate_operator_count(operator_count: usize) -> Result<()> {
@@ -116,7 +208,6 @@ fn validate_operator_count(operator_count: usize) -> Result<()> {
 }
 
 fn validate_threshold(threshold: u8, operator_count: usize) -> Result<()> {
-    ensure!(threshold >= 2, "threshold must be at least 2");
     ensure!(
         threshold as usize <= operator_count,
         "threshold ({threshold}) cannot exceed operator encryption public key count ({operator_count})"
@@ -166,8 +257,15 @@ fn validate_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::turnkey::{
+        HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
+    };
     use qos_p256::P256Pair;
     use serde_json::Value;
+    use std::{collections::HashMap, path::PathBuf};
+
+    const FIRST_OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const SECOND_OPERATOR_ID: &str = "22222222-2222-4222-8222-222222222222";
 
     fn operator_encrypt_key() -> String {
         let public_key = P256Pair::generate().unwrap().public_key().to_bytes();
@@ -182,86 +280,61 @@ mod tests {
         }
     }
 
+    fn hosted_operator(name: &str, operator_id: &str, wallet_id: &str) -> (OperatorRecord, String) {
+        let public = P256Pair::generate().unwrap().public_key().to_bytes();
+        let encrypt_public_key = hex::encode(&public[..65]);
+        (
+            OperatorRecord {
+                name: name.to_string(),
+                kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                    operator_id: Uuid::parse_str(operator_id).unwrap(),
+                    wallet_id: Uuid::parse_str(wallet_id).unwrap(),
+                    path: "m/5527107'/0'/0'".to_string(),
+                    encrypt_public_key: encrypt_public_key.clone(),
+                    sign_public_key: hex::encode(&public[65..]),
+                    extra: toml::Table::new(),
+                }),
+            },
+            encrypt_public_key,
+        )
+    }
+
+    fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
+        Config {
+            active_org: Some("active".to_string()),
+            orgs: HashMap::from([(
+                "active".to_string(),
+                OrgConfig {
+                    id: "org-id".to_string(),
+                    api_key_path: PathBuf::from("api-key.json"),
+                    api_base_url: "https://api.turnkey.com".to_string(),
+                    default_operator_kind: OperatorKind::Local,
+                    operators,
+                    extra: toml::Table::new(),
+                },
+            )]),
+            ..Config::default()
+        }
+    }
+
     #[test]
-    fn parses_trims_and_normalizes_operator_encrypt_keys() {
+    fn normalizes_operator_encrypt_keys() {
         let first = operator_encrypt_key();
         let second = operator_encrypt_key();
-        let parsed = parse_operator_encrypt_keys(&format!(
-            "  {} , {}  ",
-            first.to_uppercase(),
-            second.to_uppercase()
-        ))
-        .unwrap();
+        let keys = vec![
+            format!("  {}  ", first.to_uppercase()).parse().unwrap(),
+            second.to_uppercase().parse().unwrap(),
+        ];
+        let parsed = normalize_operator_encrypt_keys(keys).unwrap();
 
         assert_eq!(parsed, vec![first, second]);
     }
 
     #[test]
-    fn rejects_empty_operator_encrypt_key() {
-        let key = operator_encrypt_key();
-        let error = parse_operator_encrypt_keys(&format!("{key},,"))
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(error, "operator encryption public key at index 1 is empty");
-    }
-
-    #[test]
-    fn rejects_non_hex_operator_encrypt_key() {
-        let error = parse_operator_encrypt_keys("not-hex")
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(
-            error,
-            "operator encryption public key at index 0 must be bare hex encoded"
-        );
-    }
-
-    #[test]
-    fn rejects_wrong_length_operator_encrypt_key() {
-        let error = parse_operator_encrypt_keys("04abcd")
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(
-            error,
-            "operator encryption public key at index 0 must be a 65-byte uncompressed P-256 public key"
-        );
-    }
-
-    #[test]
-    fn rejects_compressed_operator_encrypt_key() {
-        let uncompressed = operator_encrypt_key();
-        let public_key = PublicKey::from_sec1_bytes(&hex::decode(uncompressed).unwrap()).unwrap();
-        let compressed = hex::encode(public_key.to_encoded_point(true).as_bytes());
-        let error = parse_operator_encrypt_keys(&compressed)
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(
-            error,
-            "operator encryption public key at index 0 must be a 65-byte uncompressed P-256 public key"
-        );
-    }
-
-    #[test]
-    fn rejects_invalid_curve_point() {
-        let invalid = format!("04{}", "00".repeat(64));
-        let error = parse_operator_encrypt_keys(&invalid)
-            .unwrap_err()
-            .to_string();
-
-        assert_eq!(
-            error,
-            "operator encryption public key at index 0 is not a valid P-256 point"
-        );
-    }
-
-    #[test]
     fn rejects_duplicate_operator_encrypt_keys_after_normalization() {
         let key = operator_encrypt_key();
-        let error = parse_operator_encrypt_keys(&format!("{key},{}", key.to_uppercase()))
+        let keys = vec![key.parse().unwrap(), key.to_uppercase().parse().unwrap()];
+        let error = normalize_operator_encrypt_keys(keys)
             .unwrap_err()
             .to_string();
 
@@ -269,11 +342,20 @@ mod tests {
     }
 
     #[test]
-    fn validates_threshold_boundaries() {
+    fn rejects_duplicate_operator_ids() {
+        let operator_id = Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap();
+        let error = validate_operator_ids(&[operator_id, operator_id])
+            .unwrap_err()
+            .to_string();
+
         assert_eq!(
-            validate_threshold(1, 2).unwrap_err().to_string(),
-            "threshold must be at least 2"
+            error,
+            "duplicate operator ID at index 1: 11111111-1111-4111-8111-111111111111"
         );
+    }
+
+    #[test]
+    fn validates_threshold_boundaries() {
         assert_eq!(
             validate_threshold(3, 2).unwrap_err().to_string(),
             "threshold (3) cannot exceed operator encryption public key count (2)"
@@ -301,6 +383,37 @@ mod tests {
                 threshold: 2,
                 operator_encrypt_keys,
             }
+        );
+    }
+
+    #[test]
+    fn operator_ids_reject_duplicate_resolved_keys() {
+        let (first, shared_key) = hosted_operator(
+            "first",
+            FIRST_OPERATOR_ID,
+            "33333333-3333-4333-8333-333333333333",
+        );
+        let (mut second_record, _) = hosted_operator(
+            "second",
+            SECOND_OPERATOR_ID,
+            "44444444-4444-4444-8444-444444444444",
+        );
+        let OperatorRecordKind::Hosted(second) = &mut second_record.kind else {
+            panic!("expected hosted operator")
+        };
+        second.encrypt_public_key = shared_key;
+        let config = config_with_operators(vec![first, second_record]);
+        let operator_ids = [
+            Uuid::parse_str(FIRST_OPERATOR_ID).unwrap(),
+            Uuid::parse_str(SECOND_OPERATOR_ID).unwrap(),
+        ];
+
+        let (keys, _) = resolve_operator_ids(&config, &operator_ids).unwrap();
+        assert_eq!(
+            normalize_operator_encrypt_keys(keys)
+                .unwrap_err()
+                .to_string(),
+            "duplicate operator encryption public key at index 1"
         );
     }
 

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -11,11 +11,19 @@ use crate::pair::{LocalPair, Pair};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
 use qos_core::protocol::services::boot::{Approval, VersionedManifest};
-use std::time::{SystemTime, UNIX_EPOCH};
-use turnkey_client::TurnkeyClientError;
-use turnkey_client::generated::immutable::common::v1::{HashFunction, PayloadEncoding};
-use turnkey_client::generated::{
-    CreateTvcOperatorIntent, CreateTvcOperatorResult, SignRawPayloadIntentV2, SignRawPayloadResult,
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use thiserror::Error;
+use turnkey_client::{
+    TurnkeyClientError,
+    generated::{
+        CreateTvcOperatorIntent, CreateTvcOperatorResult, SignRawPayloadIntentV2,
+        SignRawPayloadResult,
+        immutable::common::v1::{HashFunction, PayloadEncoding},
+    },
 };
 use uuid::Uuid;
 
@@ -28,6 +36,57 @@ use uuid::Uuid;
 /// signing account. Callers creating more than one operator in the same wallet
 /// must currently provide a different base path themselves.
 pub const DEFAULT_HOSTED_OPERATOR_BASE_PATH: &str = "m/5527107'/0'/0'";
+
+/// A validated, uncompressed P-256 operator public key.
+///
+/// String parsing accepts bare hexadecimal input with surrounding whitespace.
+/// Display always emits canonical lowercase hexadecimal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OperatorPublicKey(PublicKey);
+
+/// Error returned when parsing an [`OperatorPublicKey`].
+#[derive(Debug, Error)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub(crate) enum OperatorPublicKeyParseError {
+    /// The input was empty after trimming surrounding whitespace.
+    #[error("must not be empty")]
+    Empty,
+    /// The input was not bare hexadecimal.
+    #[error("must be bare hex encoded")]
+    InvalidHex,
+    /// The bytes were not an uncompressed 65-byte SEC1 point.
+    #[error("must be a 65-byte uncompressed P-256 public key")]
+    InvalidEncoding,
+    /// The bytes did not identify a valid point on the P-256 curve.
+    #[error("is not a valid P-256 point")]
+    InvalidPoint,
+}
+
+impl FromStr for OperatorPublicKey {
+    type Err = OperatorPublicKeyParseError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(OperatorPublicKeyParseError::Empty);
+        }
+
+        let bytes = hex::decode(value).map_err(|_| OperatorPublicKeyParseError::InvalidHex)?;
+        if bytes.len() != 65 || bytes.first() != Some(&0x04) {
+            return Err(OperatorPublicKeyParseError::InvalidEncoding);
+        }
+
+        PublicKey::from_sec1_bytes(&bytes)
+            .map(Self)
+            .map_err(|_| OperatorPublicKeyParseError::InvalidPoint)
+    }
+}
+
+impl Display for OperatorPublicKey {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0.to_encoded_point(false).as_bytes()))
+    }
+}
 
 /// Inputs for creating one hosted TVC operator.
 #[derive(Debug, PartialEq, Eq)]
@@ -117,38 +176,40 @@ fn parse_uuid(value: &str, field: &str) -> Result<Uuid> {
     Uuid::parse_str(value).map_err(|_| anyhow!("{field} must be a UUID"))
 }
 
+fn parse_public_key(value: &str, field: &str) -> Result<OperatorPublicKey> {
+    value
+        .parse()
+        .map_err(|error: OperatorPublicKeyParseError| anyhow!("{field} {error}"))
+}
+
 fn normalize_public_key(value: &str, field: &str) -> Result<String> {
-    let bytes = hex::decode(value).with_context(|| format!("{field} must be hex encoded"))?;
-    ensure!(
-        bytes.len() == 65 && bytes.first() == Some(&0x04),
-        "{field} must be a 65-byte uncompressed P-256 public key"
-    );
-    let key = PublicKey::from_sec1_bytes(&bytes)
-        .with_context(|| format!("{field} is not a valid P-256 point"))?;
-    Ok(hex::encode(key.to_encoded_point(false).as_bytes()))
+    Ok(parse_public_key(value, field)?.to_string())
 }
 
 fn composite_public_key(record: &HostedOperatorRecord) -> Result<Vec<u8>> {
-    let encrypt = hex::decode(normalize_public_key(
+    let encrypt = parse_public_key(
         &record.encrypt_public_key,
         "hosted operator encryption public key",
-    )?)?;
-    let sign = hex::decode(normalize_public_key(
+    )?;
+    let sign = parse_public_key(
         &record.sign_public_key,
         "hosted operator signing public key",
-    )?)?;
+    )?;
     ensure!(
         encrypt != sign,
         "hosted operator encryption and signing public keys must be distinct"
     );
 
-    Ok(encrypt.into_iter().chain(sign).collect())
+    let mut composite = Vec::with_capacity(130);
+    composite.extend_from_slice(encrypt.0.to_encoded_point(false).as_bytes());
+    composite.extend_from_slice(sign.0.to_encoded_point(false).as_bytes());
+    Ok(composite)
 }
 
 fn validate_hosted_record(
     name: &str,
     record: HostedOperatorRecord,
-) -> Result<HostedOperatorRecord> {
+) -> Result<ValidatedHostedOperatorRecord> {
     let HostedOperatorRecord {
         operator_id,
         wallet_id,
@@ -166,22 +227,26 @@ fn validate_hosted_record(
         "hosted operator account path must not be empty"
     );
 
-    let validated = HostedOperatorRecord {
+    let encrypt_public_key =
+        parse_public_key(&encrypt_public_key, "hosted operator encryption public key")?;
+    let sign_public_key = parse_public_key(&sign_public_key, "hosted operator signing public key")?;
+    ensure!(
+        encrypt_public_key != sign_public_key,
+        "hosted operator encryption and signing public keys must be distinct"
+    );
+
+    let record = HostedOperatorRecord {
         operator_id,
         wallet_id,
         path,
-        encrypt_public_key: normalize_public_key(
-            &encrypt_public_key,
-            "hosted operator encryption public key",
-        )?,
-        sign_public_key: normalize_public_key(
-            &sign_public_key,
-            "hosted operator signing public key",
-        )?,
+        encrypt_public_key: encrypt_public_key.to_string(),
+        sign_public_key: sign_public_key.to_string(),
         extra,
     };
-    let _ = composite_public_key(&validated)?;
-    Ok(validated)
+    Ok(ValidatedHostedOperatorRecord {
+        record,
+        encrypt_public_key,
+    })
 }
 
 /// A non-serializable operator with its credentials resolved for use.
@@ -204,6 +269,11 @@ pub(crate) enum ResolvedOperatorKind {
 /// Shared dependencies for operator-level workflows.
 pub(crate) struct OperatorCtx<'a> {
     pub(crate) auth: Option<&'a AuthenticatedClient>,
+}
+
+struct ValidatedHostedOperatorRecord {
+    record: HostedOperatorRecord,
+    encrypt_public_key: OperatorPublicKey,
 }
 
 impl ResolvedOperator {
@@ -314,7 +384,8 @@ pub(crate) async fn resolve_operator(
         None => None,
     };
 
-    if let Some((organization_id, name, record)) = hosted {
+    if let Some((organization_id, name, validated)) = hosted {
+        let record = validated.record;
         return Ok(ResolvedOperator {
             name: Some(name),
             operator_id: Some(record.operator_id),
@@ -370,7 +441,7 @@ pub(crate) async fn resolve_operator(
 fn find_hosted_operator(
     config: &Config,
     operator_id: &Uuid,
-) -> Result<Option<(String, String, HostedOperatorRecord)>> {
+) -> Result<Option<(String, String, ValidatedHostedOperatorRecord)>> {
     let Some((_, org)) = config.active_org_config() else {
         return Ok(None);
     };
@@ -394,6 +465,22 @@ fn find_hosted_operator(
         ))),
         _ => bail!("multiple hosted operators have ID {operator_id}"),
     }
+}
+
+/// Resolve a hosted operator's encryption public key from the active organization.
+pub(crate) fn resolve_hosted_operator_encrypt_key(
+    config: &Config,
+    operator_id: &Uuid,
+) -> Result<OperatorPublicKey> {
+    let (alias, _) = config
+        .active_org_config()
+        .context("No active organization. Run `tvc login` first.")?;
+
+    let (_, _, validated) = find_hosted_operator(config, operator_id)?.ok_or_else(|| {
+        anyhow!("hosted operator ID '{operator_id}' was not found in org '{alias}'")
+    })?;
+
+    Ok(validated.encrypt_public_key)
 }
 
 async fn sign_hosted_manifest(
@@ -456,7 +543,10 @@ fn timestamp_ms() -> Result<u128> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::turnkey::{LocalOperatorRecord, OrgConfig};
     use qos_p256::P256Pair;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
 
     const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
     const WALLET_ID: &str = "22222222-2222-4222-8222-222222222222";
@@ -477,6 +567,157 @@ mod tests {
             sign_public_key,
             extra: toml::Table::new(),
         }
+    }
+
+    fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
+        Config {
+            active_org: Some("active".to_string()),
+            orgs: HashMap::from([(
+                "active".to_string(),
+                OrgConfig {
+                    id: "org-id".to_string(),
+                    api_key_path: PathBuf::from("api-key.json"),
+                    api_base_url: "https://api.turnkey.com".to_string(),
+                    default_operator_kind: OperatorKind::Local,
+                    operators,
+                    extra: toml::Table::new(),
+                },
+            )]),
+            ..Config::default()
+        }
+    }
+
+    fn hosted_operator(name: &str, record: HostedOperatorRecord) -> OperatorRecord {
+        OperatorRecord {
+            name: name.to_string(),
+            kind: OperatorRecordKind::Hosted(record),
+        }
+    }
+
+    #[test]
+    fn operator_public_key_parses_and_canonicalizes() {
+        let (key, _) = public_keys();
+        let parsed: OperatorPublicKey = format!("  {}  ", key.to_uppercase()).parse().unwrap();
+
+        assert_eq!(parsed.to_string(), key);
+    }
+
+    #[test]
+    fn operator_public_key_rejects_invalid_inputs() {
+        assert_eq!(
+            " ".parse::<OperatorPublicKey>().unwrap_err(),
+            OperatorPublicKeyParseError::Empty
+        );
+        assert_eq!(
+            "not-hex".parse::<OperatorPublicKey>().unwrap_err(),
+            OperatorPublicKeyParseError::InvalidHex
+        );
+        assert_eq!(
+            "04abcd".parse::<OperatorPublicKey>().unwrap_err(),
+            OperatorPublicKeyParseError::InvalidEncoding
+        );
+
+        let (uncompressed, _) = public_keys();
+        let public_key = PublicKey::from_sec1_bytes(&hex::decode(uncompressed).unwrap()).unwrap();
+        let compressed = hex::encode(public_key.to_encoded_point(true).as_bytes());
+        assert_eq!(
+            compressed.parse::<OperatorPublicKey>().unwrap_err(),
+            OperatorPublicKeyParseError::InvalidEncoding
+        );
+
+        let invalid_point = format!("04{}", "00".repeat(64));
+        assert_eq!(
+            invalid_point.parse::<OperatorPublicKey>().unwrap_err(),
+            OperatorPublicKeyParseError::InvalidPoint
+        );
+    }
+
+    #[test]
+    fn resolves_hosted_operator_encrypt_key_from_active_org() {
+        let record = hosted_record();
+        let expected = record.encrypt_public_key.parse().unwrap();
+        let config = config_with_operators(vec![hosted_operator("hosted", record)]);
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+
+        let resolved = resolve_hosted_operator_encrypt_key(&config, &operator_id).unwrap();
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn hosted_operator_resolution_requires_active_org_and_matching_hosted_record() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let no_active = Config::default();
+        assert_eq!(
+            resolve_hosted_operator_encrypt_key(&no_active, &operator_id)
+                .unwrap_err()
+                .to_string(),
+            "No active organization. Run `tvc login` first."
+        );
+
+        let local = OperatorRecord {
+            name: "local".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path: PathBuf::from("operator.json"),
+                operator_id: Some(OPERATOR_ID.to_string()),
+                extra: toml::Table::new(),
+            }),
+        };
+        let config = config_with_operators(vec![local]);
+        assert_eq!(
+            resolve_hosted_operator_encrypt_key(&config, &operator_id)
+                .unwrap_err()
+                .to_string(),
+            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
+        );
+
+        let mut cross_org = config_with_operators(Vec::new());
+        let mut inactive_org = cross_org.orgs["active"].clone();
+        inactive_org.id = "inactive-org-id".to_string();
+        inactive_org.operators = vec![hosted_operator("hosted", hosted_record())];
+        cross_org.orgs.insert("inactive".to_string(), inactive_org);
+        assert_eq!(
+            resolve_hosted_operator_encrypt_key(&cross_org, &operator_id)
+                .unwrap_err()
+                .to_string(),
+            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
+        );
+    }
+
+    #[test]
+    fn hosted_operator_resolution_rejects_duplicate_and_malformed_records() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let record = hosted_record();
+        let duplicate = config_with_operators(vec![
+            hosted_operator("first", record.clone()),
+            hosted_operator("second", record.clone()),
+        ]);
+        assert_eq!(
+            resolve_hosted_operator_encrypt_key(&duplicate, &operator_id)
+                .unwrap_err()
+                .to_string(),
+            "multiple hosted operators have ID 11111111-1111-4111-8111-111111111111"
+        );
+
+        let mut malformed = record;
+        malformed.encrypt_public_key = "not-hex".to_string();
+        let malformed = config_with_operators(vec![hosted_operator("hosted", malformed)]);
+        assert_eq!(
+            resolve_hosted_operator_encrypt_key(&malformed, &operator_id)
+                .unwrap_err()
+                .to_string(),
+            "hosted operator encryption public key must be bare hex encoded"
+        );
+    }
+
+    #[test]
+    fn authenticated_org_must_match_configured_org() {
+        assert_eq!(
+            ensure_authenticated_org("authenticated", "configured")
+                .unwrap_err()
+                .to_string(),
+            "authenticated organization (authenticated) does not match configured organization (configured)"
+        );
     }
 
     #[test]

--- a/tvc/tests/keys_create_quorum_key.rs
+++ b/tvc/tests/keys_create_quorum_key.rs
@@ -2,6 +2,9 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use qos_p256::P256Pair;
 
+const FIRST_OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
+const SECOND_OPERATOR_ID: &str = "22222222-2222-4222-8222-222222222222";
+
 fn operator_encrypt_key() -> String {
     let public_key = P256Pair::generate().unwrap().public_key().to_bytes();
     hex::encode(&public_key[..65])
@@ -17,15 +20,14 @@ fn create_quorum_key_help_lists_required_explicit_inputs() {
         .success()
         .stdout(predicate::str::contains("--threshold <THRESHOLD>"))
         .stdout(predicate::str::contains("TVC_QUORUM_KEY_THRESHOLD"))
-        .stdout(predicate::str::contains(
-            "--operator-encrypt-keys <HEX,HEX,...>",
-        ))
+        .stdout(predicate::str::contains("--operator-encrypt-keys <HEX>"))
         .stdout(predicate::str::contains("TVC_OPERATOR_ENCRYPT_KEYS"))
-        .stdout(predicate::str::contains("--operators").not());
+        .stdout(predicate::str::contains("--operator-ids <UUID>"))
+        .stdout(predicate::str::contains("TVC_OPERATOR_IDS"));
 }
 
 #[test]
-fn create_quorum_key_requires_both_explicit_inputs() {
+fn create_quorum_key_requires_threshold_and_one_operator_source() {
     cargo_bin_cmd!("tvc")
         .env_clear()
         .arg("keys")
@@ -37,7 +39,7 @@ fn create_quorum_key_requires_both_explicit_inputs() {
         ))
         .stderr(predicate::str::contains("--threshold <THRESHOLD>"))
         .stderr(predicate::str::contains(
-            "--operator-encrypt-keys <HEX,HEX,...>",
+            "<--operator-encrypt-keys <HEX>|--operator-ids <UUID>>",
         ));
 }
 
@@ -48,16 +50,57 @@ fn create_quorum_key_reads_explicit_inputs_from_env() {
 
     cargo_bin_cmd!("tvc")
         .env_clear()
-        .env("TVC_QUORUM_KEY_THRESHOLD", "1")
+        .env("TVC_QUORUM_KEY_THRESHOLD", "3")
         .env("TVC_OPERATOR_ENCRYPT_KEYS", format!("{first},{second}"))
         .arg("keys")
         .arg("create-quorum-key")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("threshold must be at least 2"))
+        .stderr(predicate::str::contains(
+            "threshold (3) cannot exceed operator encryption public key count (2)",
+        ))
         .stderr(
             predicate::str::contains("the following required arguments were not provided").not(),
         );
+}
+
+#[test]
+fn create_quorum_key_reads_operator_ids_from_env() {
+    cargo_bin_cmd!("tvc")
+        .env_clear()
+        .env("TVC_QUORUM_KEY_THRESHOLD", "3")
+        .env(
+            "TVC_OPERATOR_IDS",
+            format!("{FIRST_OPERATOR_ID},{SECOND_OPERATOR_ID}"),
+        )
+        .arg("keys")
+        .arg("create-quorum-key")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "threshold (3) cannot exceed operator encryption public key count (2)",
+        ));
+}
+
+#[test]
+fn create_quorum_key_operator_sources_are_mutually_exclusive() {
+    cargo_bin_cmd!("tvc")
+        .env_clear()
+        .arg("keys")
+        .arg("create-quorum-key")
+        .arg("--threshold")
+        .arg("2")
+        .arg("--operator-encrypt-keys")
+        .arg(format!(
+            "{},{}",
+            operator_encrypt_key(),
+            operator_encrypt_key()
+        ))
+        .arg("--operator-ids")
+        .arg(format!("{FIRST_OPERATOR_ID},{SECOND_OPERATOR_ID}"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]
@@ -76,5 +119,7 @@ fn create_quorum_key_rejects_threshold_above_u8_range() {
         ))
         .assert()
         .failure()
-        .stderr(predicate::str::contains("256 is not in 0..=255"));
+        .stderr(predicate::str::contains(
+            "out of range integral type conversion attempted",
+        ));
 }


### PR DESCRIPTION
This PR extends https://github.com/tkhq/rust-sdk/pull/204 by integrating with the operator registry and supporting `--operator-ids`. It also implements @Avi-D-coder 's [suggestion](https://github.com/tkhq/rust-sdk/pull/204#discussion_r3618543897) of using a PubKey struct for parsing.