### PR TITLE
rm mention of merging imports from AGENTS.md

### DIFF
--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -25,8 +25,7 @@ Default guidance for coding-agent runs in this repository.
   longer/module-qualified form when it disambiguates from another in-scope name —
   e.g. `fmt::Result` stays qualified (via `use std::fmt::{self, Display, Formatter}`)
   so it doesn't collide with `anyhow::Result`, and `std::fmt::Write` may need
-  `as _` where `std::io::Write` is also in scope. Merge imports from the same
-  module where practical.
+  `as _` where `std::io::Write` is also in scope.
 - When converting from an external/generated type (e.g. the API's `TvcApp`,
   `TvcDeployment`, `AppStatus`) into one of our own structs, destructure it
   exhaustively — `let Foo { a, b, c: _ } = value;` with no trailing `..` —

--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -25,8 +25,7 @@ Default guidance for coding-agent runs in this repository.
   longer/module-qualified form when it disambiguates from another in-scope name —
   e.g. `fmt::Result` stays qualified (via `use std::fmt::{self, Display, Formatter}`)
   so it doesn't collide with `anyhow::Result`, and `std::fmt::Write` may need
-  `as _` where `std::io::Write` is also in scope. Merge imports from the same
-  module where practical.
+  `as _` where `std::io::Write` is also in scope.
 - In doc comments and module docs, describe responsibilities, contracts, and
   relationships without naming specific source files or inventorying current
   consumers. File paths and call-site lists go stale when code moves. When a


### PR DESCRIPTION
mechanical fix like import order should be done by a linter, not by AGENTS.md.

unfortunately [imports_granularity is unstable and requires nightly Rust.](https://rust-lang.github.io/rustfmt/?version=v1.10.0&search=import#imports_granularity) We can figure this out in a different PR