### PR TITLE
chore(tvc): type UUID-backed CLI IDs as uuid::Uuid

### DIFF
--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, DeleteTvcAppAndDeploymentsIntent};
+use uuid::Uuid;
 
 /// Delete a TVC application and all of its deployments.
 #[derive(Debug, ClapArgs)]
@@ -16,7 +17,7 @@ use turnkey_client::generated::{ActivityStatus, DeleteTvcAppAndDeploymentsIntent
 pub struct Args {
     /// ID of the app to delete.
     #[arg(long, value_name = "APP_ID", env = "TVC_APP_ID")]
-    pub app_id: String,
+    pub app_id: Uuid,
 }
 
 /// Run the app delete command.
@@ -24,7 +25,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcAppAndDeploymentsIntent {
-        app_id: args.app_id.clone(),
+        app_id: args.app_id.to_string(),
     };
 
     let timestamp_ms = SystemTime::now()

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, UpdateTvcAppLiveDeploymentIntent};
+use uuid::Uuid;
 
 /// Set the live deployment for a TVC app.
 #[derive(Debug, ClapArgs)]
@@ -16,15 +17,17 @@ use turnkey_client::generated::{ActivityStatus, UpdateTvcAppLiveDeploymentIntent
 pub struct Args {
     /// ID of the deployment to set live.
     #[arg(long, env = "TVC_DEPLOY_ID", value_name = "DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 }
 
 /// Run the app set-live-deploy command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
+    let deployment_id = args.deploy_id.to_string();
+
     let intent = UpdateTvcAppLiveDeploymentIntent {
-        deployment_id: args.deploy_id.clone(),
+        deployment_id: deployment_id.clone(),
     };
 
     let timestamp_ms = SystemTime::now()
@@ -39,7 +42,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .context("failed to set TVC app live deployment")?;
 
     Ok(Outcome::AppSetLiveDeploy(LiveDeploymentSet {
-        deployment_id: args.deploy_id,
+        deployment_id,
         activity_id: result.activity_id,
         activity_status: result.status,
     }))

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::GetAppStatusRequest;
 use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
+use uuid::Uuid;
 
 use crate::client::fetch_tvc_app;
 use crate::commands::app_status::{
@@ -21,16 +22,18 @@ use crate::output::StdCtx;
 pub struct Args {
     /// ID of the app.
     #[arg(short, long, env = "TVC_APP_ID")]
-    pub app_id: String,
+    pub app_id: Uuid,
 }
 
 /// Run the app status command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
+    let app_id = args.app_id.to_string();
+
     let request = GetAppStatusRequest {
         organization_id: auth.org_id.clone(),
-        app_id: args.app_id.clone(),
+        app_id: app_id.clone(),
     };
 
     let response = auth
@@ -42,9 +45,9 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let app_status = sanitize_app_status(
         response
             .app_status
-            .ok_or_else(|| anyhow!("no status returned for app: {}", args.app_id))?,
+            .ok_or_else(|| anyhow!("no status returned for app: {app_id}"))?,
     );
-    let app = fetch_tvc_app(&auth, &args.app_id).await?;
+    let app = fetch_tvc_app(&auth, &app_id).await?;
 
     // Exhaustive destructure so a new `AppStatus` field forces a decision here
     // rather than being silently dropped.

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -54,7 +54,7 @@ pub struct Args {
         env = "TVC_DEPLOY_ID",
         help_heading = "Manifest source (pick one)"
     )]
-    pub deploy_id: Option<String>,
+    pub deploy_id: Option<Uuid>,
 
     /// Turnkey manifest ID (UUID) for the manifest being approved.
     /// Required when posting approval to the API.
@@ -313,7 +313,7 @@ async fn build_inputs_interactive(
         }
         Some(PostTarget {
             manifest_id,
-            deploy_id: args.deploy_id.clone(),
+            deploy_id: args.deploy_id.map(|id| id.to_string()),
         })
     } else {
         None
@@ -362,7 +362,7 @@ async fn build_inputs_non_interactive(
         }
         Some(PostTarget {
             manifest_id,
-            deploy_id: args.deploy_id.clone(),
+            deploy_id: args.deploy_id.map(|id| id.to_string()),
         })
     } else {
         None
@@ -453,7 +453,8 @@ async fn load_manifest(
     match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
         (_, Some(deploy_id)) => {
-            let (manifest, manifest_id) = fetch_manifest_from_deploy(ctx, deploy_id).await?;
+            let (manifest, manifest_id) =
+                fetch_manifest_from_deploy(ctx, &deploy_id.to_string()).await?;
             Ok((manifest, Some(manifest_id)))
         }
         (None, None) => bail!("a manifest source is required"),

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -17,6 +17,7 @@ use turnkey_client::generated::external::data::v1::{LogLine, Timestamp};
 use turnkey_client::generated::{
     GetTvcDeploymentDebugLogsRequest, GetTvcDeploymentDebugLogsResponse,
 };
+use uuid::Uuid;
 
 const DEFAULT_POLL_INTERVAL_SECONDS: i64 = 2;
 const POLL_OVERLAP_SECONDS: i64 = 2;
@@ -67,7 +68,7 @@ for more info."#;
 pub struct Args {
     /// ID of the deployment.
     #[arg(short = 'd', long, env = "TVC_DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 
     /// Keep polling for new lines.
     #[arg(long, env = "TVC_DEBUG_LOGS_POLL")]
@@ -128,7 +129,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
 
     let request = DebugLogQueryRequest {
         organization_id: auth.org_id,
-        deployment_id: args.deploy_id,
+        deployment_id: args.deploy_id.to_string(),
         poll: args.poll,
         poll_interval_seconds: args.poll_interval_seconds,
         tail_lines: args.tail_lines,

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, DeleteTvcDeploymentIntent};
+use uuid::Uuid;
 
 /// Delete a TVC deployment by marking it for deletion.
 #[derive(Debug, ClapArgs)]
@@ -16,7 +17,7 @@ use turnkey_client::generated::{ActivityStatus, DeleteTvcDeploymentIntent};
 pub struct Args {
     /// ID of the deployment to delete.
     #[arg(long, env = "TVC_DEPLOY_ID", value_name = "DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 }
 
 /// Run the deploy delete command.
@@ -24,7 +25,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 
     let intent = DeleteTvcDeploymentIntent {
-        deployment_id: args.deploy_id.clone(),
+        deployment_id: args.deploy_id.to_string(),
     };
 
     let timestamp_ms = SystemTime::now()

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -8,6 +8,7 @@ use turnkey_client::generated::{
     GetAppStatusRequest,
     external::data::v1::{AppStatus, DeploymentStatus},
 };
+use uuid::Uuid;
 
 use crate::{
     client::{fetch_tvc_app, fetch_tvc_deployment},
@@ -23,14 +24,12 @@ use crate::{
 pub struct Args {
     /// ID of the deployment.
     #[arg(short, long, env = "TVC_DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 }
 
 /// Run the deploy get-status command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let Args {
-        deploy_id: deployment_id,
-    } = args;
+    let deployment_id = args.deploy_id.to_string();
 
     // TODO (TVC-154):
     // this is a little backwards, all the variables that are needed to build the client
@@ -140,8 +139,35 @@ fn find_deployment_status<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::find_deployment_status;
+    use super::{Args, find_deployment_status};
+    use clap::Parser;
     use turnkey_client::generated::external::data::v1::{AppStatus, DeploymentStatus};
+    use uuid::Uuid;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: Args,
+    }
+
+    #[test]
+    fn parses_valid_uuid_deploy_id() {
+        let cli =
+            TestCli::try_parse_from(["tvc", "--deploy-id", "5376f492-d014-4e01-a6bb-20fc97448e25"])
+                .expect("valid UUID should parse");
+
+        assert_eq!(
+            cli.args.deploy_id,
+            Uuid::parse_str("5376f492-d014-4e01-a6bb-20fc97448e25").unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_uuid_deploy_id() {
+        let error = TestCli::try_parse_from(["tvc", "--deploy-id", "not-a-uuid"]).unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
 
     #[test]
     fn find_deployment_status_matches_sanitized_ids() {

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{PostTvcQuorumKeyShareIntent, QuorumKeyShareApprovalBundle};
+use uuid::Uuid;
 
 /// Post a re-encrypted quorum key share for a deployment.
 #[derive(Debug, ClapArgs)]
@@ -22,15 +23,18 @@ pub struct Args {
 
     /// Turnkey share set operator ID (UUID) for the operator posting this share.
     #[arg(long, env = "TVC_SHARE_OPERATOR_ID")]
-    pub share_operator_id: String,
+    pub share_operator_id: Uuid,
 }
 
 /// Run the deploy post-share command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let re_encrypted_share: ReEncryptedShareOutput =
         read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;
-    let intent =
-        build_post_tvc_quorum_key_share_intent(&re_encrypted_share, &args.share_operator_id);
+
+    let intent = build_post_tvc_quorum_key_share_intent(
+        &re_encrypted_share,
+        &args.share_operator_id.to_string(),
+    );
 
     let auth = crate::client::build_client().await?;
     let timestamp_ms = SystemTime::now()

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -18,6 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{
     GetTvcDeploymentProvisioningDetailsRequest, GetTvcDeploymentProvisioningDetailsResponse,
 };
+use uuid::Uuid;
 
 /// Get provisioning details for a deployment.
 #[derive(Debug, ClapArgs)]
@@ -25,7 +26,7 @@ use turnkey_client::generated::{
 pub struct Args {
     /// ID of the deployment.
     #[arg(short = 'd', long, env = "TVC_DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 
     /// Never use for sensitive applications! Skip attestation, PCR, and approval verification.
     #[arg(long, env = "TVC_DANGEROUS_SKIP_VERIFICATION")]
@@ -63,10 +64,11 @@ const SUMMARY_PCR_MAX_INDEX: usize = 17;
 /// Run the deploy provisioning-details command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
+    let deploy_id = args.deploy_id.to_string();
 
     let request = GetTvcDeploymentProvisioningDetailsRequest {
         organization_id: auth.org_id.clone(),
-        deployment_id: args.deploy_id.clone(),
+        deployment_id: deploy_id.clone(),
     };
     let fetched_at_unix_ms = u64::try_from(
         SystemTime::now()
@@ -106,7 +108,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let bundle_path = match args.provision_bundle_out.as_ref() {
         Some(path) => {
             let bundle = ProvisionBundle::new(
-                args.deploy_id.clone(),
+                deploy_id.clone(),
                 &attestation_document,
                 manifest_envelope.clone(),
                 fetched_at_unix_ms,
@@ -125,12 +127,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     };
 
     Ok(Outcome::DeployProvisioningDetails(
-        ProvisioningDetails::from_summary(
-            args.deploy_id,
-            verification_status,
-            bundle_path,
-            &summary,
-        ),
+        ProvisioningDetails::from_summary(deploy_id, verification_status, bundle_path, &summary),
     ))
 }
 

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, RestoreTvcDeploymentIntent};
+use uuid::Uuid;
 
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
@@ -16,7 +17,7 @@ use crate::output::StdCtx;
 pub struct Args {
     /// ID of the deployment.
     #[arg(short, long, env = "TVC_DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 }
 
 /// Run the deploy restore command.
@@ -24,7 +25,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let intent = RestoreTvcDeploymentIntent {
-        deployment_id: args.deploy_id,
+        deployment_id: args.deploy_id.to_string(),
     };
 
     let timestamp_ms = SystemTime::now()

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use turnkey_client::generated::GetTvcDeploymentRequest;
 use turnkey_client::generated::external::data::v1::TvcDeployment;
+use uuid::Uuid;
 
 use crate::client::fetch_tvc_app;
 use crate::commands::app_status::TimestampPayload;
@@ -19,16 +20,17 @@ use crate::output::StdCtx;
 pub struct Args {
     /// ID of the deployment.
     #[arg(short, long, env = "TVC_DEPLOY_ID")]
-    pub deploy_id: String,
+    pub deploy_id: Uuid,
 }
 
 /// Run the deploy status command.
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
+    let deploy_id = args.deploy_id.to_string();
 
     let request = GetTvcDeploymentRequest {
         organization_id: auth.org_id.clone(),
-        deployment_id: args.deploy_id.clone(),
+        deployment_id: deploy_id.clone(),
     };
 
     let response = auth
@@ -39,7 +41,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
 
     let deployment = response
         .tvc_deployment
-        .ok_or_else(|| anyhow::anyhow!("deployment not found: {}", args.deploy_id))?;
+        .ok_or_else(|| anyhow::anyhow!("deployment not found: {deploy_id}"))?;
 
     // Exhaustive destructure (rather than `..`) so a new `TvcDeployment` field
     // forces a compile error here and forces a deliberate decision about usage

--- a/tvc/tests/app_set_live_deploy.rs
+++ b/tvc/tests/app_set_live_deploy.rs
@@ -40,7 +40,7 @@ fn missing_deploy_id_fails() {
 fn set_live_deploy_reaches_auth_setup() {
     set_live_deploy_cmd()
         .arg("--deploy-id")
-        .arg("deploy_test")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .env("TVC_ORG_ID", "org_env")
         .assert()
         .failure()

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -19,7 +19,7 @@ fn app_status_cmd() -> assert_cmd::Command {
         .arg("app")
         .arg("status")
         .arg("--app-id")
-        .arg("app_test");
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25");
     cmd
 }
 

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -454,7 +454,7 @@ fn manifest_and_deploy_id_are_mutually_exclusive() {
         .arg("--manifest")
         .arg("fixtures/manifest.json")
         .arg("--deploy-id")
-        .arg("some-deploy-id")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--dangerous-skip-interactive")
         .assert()
         .failure()

--- a/tvc/tests/deploy_debug_logs.rs
+++ b/tvc/tests/deploy_debug_logs.rs
@@ -75,7 +75,7 @@ fn debug_logs_accepts_flags_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--poll")
         .arg("--poll-interval-seconds")
         .arg("3")
@@ -98,7 +98,7 @@ fn debug_logs_rejects_negative_tail_lines_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--tail-lines")
         .arg("-1")
         .assert()
@@ -114,7 +114,7 @@ fn debug_logs_rejects_zero_poll_interval_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--poll")
         .arg("--poll-interval-seconds")
         .arg("0")
@@ -133,7 +133,7 @@ fn debug_logs_rejects_negative_poll_interval_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--poll")
         .arg("--poll-interval-seconds")
         .arg("-1")
@@ -152,7 +152,7 @@ fn debug_logs_rejects_zero_poll_interval_without_poll_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--poll-interval-seconds")
         .arg("0")
         .assert()
@@ -170,7 +170,7 @@ fn debug_logs_rejects_negative_since_seconds_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--since-seconds")
         .arg("-1")
         .assert()
@@ -186,7 +186,7 @@ fn debug_logs_rejects_zero_recent_line_capacity_before_authentication() {
 
     debug_logs_cmd(&temp)
         .arg("--deploy-id")
-        .arg("deploy-123")
+        .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
         .arg("--recent-line-capacity")
         .arg("0")
         .assert()


### PR DESCRIPTION
## SYS-103: Type UUID-backed `tvc` CLI IDs as `uuid::Uuid`

Refactors Rust-sdk's `tvc` CLI/internal ID arguments that are semantically UUIDs from `String` to `uuid::Uuid`. Parsing/validation happens at the Clap input boundary (via `uuid::Uuid`'s `FromStr` impl — clap parses it natively), and conversion back to `String` happens only at the generated-API-client boundary (`.to_string()` where the request/intent struct is built).

Invalid UUID values now produce a clear CLI error (`clap` `ValueValidation`, exit code 2) **before** any API request is made. Existing API request behavior is preserved — the generated client request/intent types stay `String`.

Also satisfies item **F10 (client-side UUID validation)** of the TVC-225 audit.

### Fields converted `String` → `uuid::Uuid`

| Command | Field |
|---|---|
| `deploy get-status` | `deploy_id` |
| `deploy status` | `deploy_id` |
| `deploy delete` | `deploy_id` |
| `deploy restore` | `deploy_id` |
| `deploy debug-logs` | `deploy_id` |
| `deploy provisioning-details` | `deploy_id` |
| `deploy approve` | `deploy_id` (`Option<Uuid>`) |
| `deploy post-share` | `share_operator_id` |
| `app delete` | `app_id` |
| `app set-live-deploy` | `deploy_id` |
| `app status` | `app_id` |

Each is converted back with `.to_string()` at the point the generated request/intent (`GetTvcDeploymentRequest`, `DeleteTvcDeploymentIntent`, `GetAppStatusRequest`, `PostTvcQuorumKeyShareIntent`, etc.) or the internal request-plan struct is built. The generated client types (`client/src/generated/...`) are untouched and remain `String`.

### UUID-looking fields intentionally left as `String` (and why)

- **`deploy create --app-id`** (`Overrides.app_id`): this is a config-file **override** merged into `DeployConfig.app_id`, which is deserialized from JSON and already UUID-validated in the config layer (`config/deploy.rs`). Converting it would ripple into the JSON-backed config structs — out of scope for a surgical ID-typing change.
- **`deploy approve --manifest-id`**: `resolve_manifest_id` interleaves the user-supplied `--manifest-id` with a manifest ID **fetched from the API** (a `String` from the response). Typing the arg as `Uuid` would pull response-side data into UUID typing — out of scope and behavior-risky.
- **`org_id` / `organization_id`**: resolved from env/config (e.g. `TVC_ORG_ID`) or persisted config, not a direct CLI-parsed request ID; kept `String`.
- **`app list --name`**: a substring match, not an ID.
- **Org config `alias`**: a user-chosen name, not a UUID.
- **Response / output / persisted-artifact fields** (e.g. `AppDeleted.activity_id`, `DeploymentStatusReport.*`, `QuorumKeySharePosted.provisioning_share_id`, `ProvisionBundle.deployment_id`, attestation `module_id`, `quorum_key_id`/`share_ids` outputs): these carry values received from the API or written to disk, not values validated at the CLI input boundary.

### Dependency

`uuid` was already a direct dependency of the `tvc` crate (`uuid = { workspace = true }`, workspace pin `1.13.1`), so no `Cargo.toml` change was required.

### Tests

Kept minimal per direction: a single smoke test in `deploy/get_status.rs` covering one valid-UUID parse and one invalid-UUID parse (`clap` `ValueValidation`). Existing repo integration tests that passed non-UUID placeholder IDs (e.g. `app_test`, `deploy-123`, `deploy_test`, `some-deploy-id`) were updated to valid UUIDs so they still exercise their original auth/API/conflict paths past the now-strict parse step.

### Verification

`cargo fmt -p tvc`, `cargo build -p tvc`, `cargo test -p tvc`, and `cargo clippy -p tvc -- -D warnings` all pass. Diff is `tvc/`-only.
