### PR TITLE
tvc: warn when an app has more than two live deployments

### DIFF
--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -13,6 +13,7 @@ use crate::commands::app_status::{
     ReplicaCounts, TimestampPayload, format_replica_counts, sanitize_app_status,
 };
 use crate::commands::display::format_egress_enabled;
+use crate::commands::live_deployments::warn_on_live_deployments;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 
@@ -26,7 +27,7 @@ pub struct Args {
 }
 
 /// Run the app status command.
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 
     let app_id = args.app_id.to_string();
@@ -57,29 +58,42 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         targeted_deployment_id,
     } = app_status;
 
+    let deployments: Vec<DeploymentReplicaStatus> = deployments
+        .into_iter()
+        .map(|deployment| {
+            let DeploymentStatus {
+                deployment_id,
+                ready_replicas,
+                desired_replicas,
+                last_updated_time,
+            } = deployment;
+            DeploymentReplicaStatus {
+                deployment_id,
+                replicas: ReplicaCounts {
+                    ready: ready_replicas,
+                    desired: desired_replicas,
+                },
+                last_updated: last_updated_time.map(Into::into),
+            }
+        })
+        .collect();
+
+    // Everything the cluster reports for the app is running, and therefore
+    // billed, so this list needs no live/deleted filtering.
+    warn_on_live_deployments(
+        ctx,
+        &app_id,
+        &deployments
+            .iter()
+            .map(|deployment| deployment.deployment_id.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+
     Ok(Outcome::AppStatus(AppStatusReport {
         app_id,
         targeted_deployment_id,
         egress_enabled: app.enable_egress,
-        deployments: deployments
-            .into_iter()
-            .map(|deployment| {
-                let DeploymentStatus {
-                    deployment_id,
-                    ready_replicas,
-                    desired_replicas,
-                    last_updated_time,
-                } = deployment;
-                DeploymentReplicaStatus {
-                    deployment_id,
-                    replicas: ReplicaCounts {
-                        ready: ready_replicas,
-                        desired: desired_replicas,
-                    },
-                    last_updated: last_updated_time.map(Into::into),
-                }
-            })
-            .collect(),
+        deployments,
     }))
 }
 

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -2,6 +2,7 @@
 
 use super::format_port_summary;
 use crate::client::{build_client, fetch_tvc_app};
+use crate::commands::live_deployments::warn_on_fetched_live_deployments;
 use crate::config::deploy::{DeployConfig, DeployConfigValidationErrors};
 use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
@@ -434,9 +435,13 @@ async fn run_with_resolved_inputs(
 
     let result = auth
         .client
-        .create_tvc_deployment(auth.org_id, timestamp_ms, intent)
+        .create_tvc_deployment(auth.org_id.clone(), timestamp_ms, intent)
         .await
         .context("failed to create TVC deployment")?;
+
+    // The deployment just created counts toward the app's live total, so this is
+    // the moment a caller iterating on deploys learns it is accumulating them.
+    warn_on_fetched_live_deployments(ctx, &auth, &deploy_config.app_id).await;
 
     Ok(Outcome::DeployCreate(DeploymentCreated {
         deployment_id: result.result.deployment_id,

--- a/tvc/src/commands/live_deployments.rs
+++ b/tvc/src/commands/live_deployments.rs
@@ -1,0 +1,204 @@
+//! Advisory warning for apps that have accumulated live deployments.
+//!
+//! TVC bills for what is deployed, not for what receives traffic, and the
+//! deploy/test iteration loop makes it easy to leave old deployments running.
+//! Nothing in the CLI used to say so, so callers — humans mid-iteration and
+//! coding agents driving `tvc` non-interactively — had no signal to clean up
+//! after themselves.
+
+use crate::client::AuthenticatedClient;
+use crate::output::StdCtx;
+use anyhow::Result;
+use tracing::debug;
+use turnkey_client::generated::GetTvcAppDeploymentsRequest;
+use turnkey_client::generated::external::data::v1::TvcDeployment;
+
+/// A blue/green rollout needs exactly two live deployments at once: the one
+/// currently taking traffic and the one replacing it. Anything above two is
+/// accumulation from the deploy/test iteration loop rather than a rollout, and
+/// each extra deployment keeps costing money until it is deleted.
+pub const MAX_EXPECTED_LIVE_DEPLOYMENTS: usize = 2;
+
+/// IDs of the deployments that are still live, i.e. not marked for deletion.
+///
+/// `TvcDeployment::delete` is the API's only live/torn-down distinction, so it
+/// is what decides whether a deployment is still being billed.
+pub fn live_deployment_ids(deployments: &[TvcDeployment]) -> Vec<&str> {
+    deployments
+        .iter()
+        .filter(|deployment| !deployment.delete)
+        .map(|deployment| deployment.id.as_str())
+        .collect()
+}
+
+/// The warning text for an app's live deployments, or `None` when the count is
+/// within [`MAX_EXPECTED_LIVE_DEPLOYMENTS`].
+///
+/// Advisory only: callers emit this on stderr and never change their exit code
+/// because of it.
+pub fn live_deployment_warning(app_id: &str, live_deployment_ids: &[&str]) -> Option<String> {
+    let count = live_deployment_ids.len();
+    if count <= MAX_EXPECTED_LIVE_DEPLOYMENTS {
+        return None;
+    }
+
+    Some(format!(
+        r#"app {app_id} has {count} live deployments, more than the {MAX_EXPECTED_LIVE_DEPLOYMENTS} a blue/green rollout needs.
+  Each live deployment is billed even when it receives no traffic.
+  Live deployments: {ids}
+  Delete the ones you no longer need: tvc deploy delete --deploy-id <DEPLOY_ID>"#,
+        ids = live_deployment_ids.join(", ")
+    ))
+}
+
+/// Warn if `live_deployment_ids` is above the threshold.
+///
+/// Use this when a command already has the app's live deployments in hand, so
+/// no extra API round trip is needed.
+pub fn warn_on_live_deployments(
+    ctx: &mut StdCtx,
+    app_id: &str,
+    live_deployment_ids: &[&str],
+) -> Result<()> {
+    if let Some(warning) = live_deployment_warning(app_id, live_deployment_ids) {
+        ctx.shell().warn(warning)?;
+    }
+    Ok(())
+}
+
+/// Fetch the app's deployments and warn if too many are live.
+///
+/// Best effort: this runs after the command's real work has already succeeded,
+/// so a failure to fetch is logged and swallowed rather than surfaced. Only use
+/// this when the caller does not already have the deployment list.
+pub async fn warn_on_fetched_live_deployments(
+    ctx: &mut StdCtx,
+    auth: &AuthenticatedClient,
+    app_id: &str,
+) {
+    let deployments = match auth
+        .client
+        .get_tvc_app_deployments(GetTvcAppDeploymentsRequest {
+            organization_id: auth.org_id.clone(),
+            app_id: app_id.to_string(),
+        })
+        .await
+    {
+        Ok(response) => response.tvc_deployments,
+        Err(error) => {
+            debug!(%app_id, %error, "skipping live deployment warning: failed to list deployments");
+            return;
+        }
+    };
+
+    if let Err(error) = warn_on_live_deployments(ctx, app_id, &live_deployment_ids(&deployments)) {
+        debug!(%app_id, %error, "failed to write live deployment warning");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use turnkey_client::generated::external::data::v1::TvcContainerSpec;
+    use turnkey_client::generated::immutable::common::v1::TvcHealthCheckType;
+
+    const APP_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+    fn make_deployment(id: &str, delete: bool) -> TvcDeployment {
+        TvcDeployment {
+            id: id.to_string(),
+            organization_id: "test-org".to_string(),
+            app_id: APP_ID.to_string(),
+            manifest_set: None,
+            share_set: None,
+            manifest: None,
+            manifest_approvals: Vec::new(),
+            qos_version: "test-qos".to_string(),
+            pivot_container: Some(TvcContainerSpec {
+                container_url: "ghcr.io/team/app".to_string(),
+                path: "/usr/bin/app".to_string(),
+                args: Vec::new(),
+                has_pull_secret: false,
+                health_check_type: TvcHealthCheckType::Http,
+                health_check_port: 3000,
+                public_ingress_port: 3000,
+            }),
+            created_at: None,
+            updated_at: None,
+            delete,
+            debug_mode: false,
+        }
+    }
+
+    #[test]
+    fn no_warning_without_deployments() {
+        assert_eq!(live_deployment_warning(APP_ID, &[]), None);
+    }
+
+    #[test]
+    fn no_warning_for_a_single_deployment() {
+        assert_eq!(live_deployment_warning(APP_ID, &["dep-1"]), None);
+    }
+
+    /// Two live deployments is the steady state of a blue/green rollout, so the
+    /// threshold must not fire on it.
+    #[test]
+    fn no_warning_at_the_threshold() {
+        assert_eq!(live_deployment_warning(APP_ID, &["dep-1", "dep-2"]), None);
+    }
+
+    /// Golden text: the count, the cost, every live deployment ID, and the exact
+    /// remediation command an agent has to run are all part of the interface.
+    #[test]
+    fn warns_just_above_the_threshold() {
+        assert_eq!(
+            live_deployment_warning(APP_ID, &["dep-1", "dep-2", "dep-3"]).as_deref(),
+            Some(
+                r#"app 11111111-1111-1111-1111-111111111111 has 3 live deployments, more than the 2 a blue/green rollout needs.
+  Each live deployment is billed even when it receives no traffic.
+  Live deployments: dep-1, dep-2, dep-3
+  Delete the ones you no longer need: tvc deploy delete --deploy-id <DEPLOY_ID>"#
+            )
+        );
+    }
+
+    /// The incident that motivated this warning: four live deployments on one app.
+    #[test]
+    fn warns_further_above_the_threshold() {
+        assert_eq!(
+            live_deployment_warning(APP_ID, &["dep-1", "dep-2", "dep-3", "dep-4"]).as_deref(),
+            Some(
+                r#"app 11111111-1111-1111-1111-111111111111 has 4 live deployments, more than the 2 a blue/green rollout needs.
+  Each live deployment is billed even when it receives no traffic.
+  Live deployments: dep-1, dep-2, dep-3, dep-4
+  Delete the ones you no longer need: tvc deploy delete --deploy-id <DEPLOY_ID>"#
+            )
+        );
+    }
+
+    #[test]
+    fn live_deployment_ids_skips_deployments_marked_for_deletion() {
+        let deployments = vec![
+            make_deployment("live-1", false),
+            make_deployment("deleted-1", true),
+            make_deployment("live-2", false),
+        ];
+
+        assert_eq!(live_deployment_ids(&deployments), vec!["live-1", "live-2"]);
+    }
+
+    /// Three deployments where one is already torn down is not accumulation.
+    #[test]
+    fn deleted_deployments_do_not_trip_the_threshold() {
+        let deployments = vec![
+            make_deployment("live-1", false),
+            make_deployment("live-2", false),
+            make_deployment("deleted-1", true),
+        ];
+
+        assert_eq!(
+            live_deployment_warning(APP_ID, &live_deployment_ids(&deployments)),
+            None
+        );
+    }
+}

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -10,5 +10,6 @@ pub mod confirmation;
 pub mod deploy;
 pub mod display;
 pub mod keys;
+pub mod live_deployments;
 pub mod login;
 pub mod operator;

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -114,6 +114,19 @@ impl<W: Write, W2: Write> Shell<W, W2> {
         }
     }
 
+    /// Emit an advisory warning on stderr, in every message format.
+    ///
+    /// Unlike the [`Human`] writers this is not gated on
+    /// [`MessageFormat::Human`]: warnings are diagnostics rather than command
+    /// output, and stderr is never part of the machine-readable stdout stream,
+    /// so emitting in JSON mode keeps advisories visible to non-interactive
+    /// callers (CI, coding agents) without corrupting their parse.
+    pub fn warn(&mut self, message: impl Display) -> Result<()> {
+        let style = self.style(AnsiColor::Yellow);
+        writeln!(self.stderr, "{style}warning{style:#}: {message}")?;
+        Ok(())
+    }
+
     /// Human-only presentation writers.
     ///
     /// Every method on the returned [`Human`] handle writes only when the
@@ -152,14 +165,6 @@ impl<W: Write, W2: Write> Human<'_, W, W2> {
         if matches!(self.0.message_format, MessageFormat::Human) {
             let style = self.0.style(AnsiColor::Green);
             writeln!(self.0.stderr, "{style}{label}{style:#}: {message}")?;
-        }
-        Ok(())
-    }
-
-    pub fn warn(&mut self, message: impl Display) -> Result<()> {
-        if matches!(self.0.message_format, MessageFormat::Human) {
-            let style = self.0.style(AnsiColor::Yellow);
-            writeln!(self.0.stderr, "{style}warning{style:#}: {message}")?;
         }
         Ok(())
     }
@@ -440,6 +445,34 @@ mod tests {
         assert_eq!(
             output,
             concat!(r#"{"reason":"machine-only-message","value":"ok"}"#, "\n")
+        );
+    }
+
+    /// Warnings are advisory diagnostics, so they must reach JSON consumers too
+    /// — on stderr, leaving the newline-delimited JSON on stdout untouched.
+    #[test]
+    fn shell_warn_writes_to_stderr_in_json_mode() {
+        let mut shell = TestShell::with_json_formatter();
+
+        shell.warn("too many live deployments").unwrap();
+
+        assert!(shell.stdout.is_empty(), "stdout must stay machine-readable");
+        assert_eq!(
+            String::from_utf8(shell.into_stderr()).unwrap(),
+            "warning: too many live deployments\n"
+        );
+    }
+
+    #[test]
+    fn shell_warn_writes_to_stderr_in_human_mode() {
+        let mut shell = TestShell::with_human_formatter();
+
+        shell.warn("too many live deployments").unwrap();
+
+        assert!(shell.stdout.is_empty());
+        assert_eq!(
+            String::from_utf8(shell.into_stderr()).unwrap(),
+            "warning: too many live deployments\n"
         );
     }
 


### PR DESCRIPTION
## Problem

TVC bills for what is **deployed**, not for what receives traffic, and you have to deploy in order to test attestations. That makes the iteration loop a cost accumulator: every `tvc deploy create` adds a live deployment, and nothing in the CLI ever mentions the ones already running.

A user recently found **4 simultaneously-live deployments on a single app**, two of them running for 6 days. The high deployment count also tripped an enclave-controller edge case that broke traffic routing — but the underlying UX problem stands on its own: nobody, human or agent, was told they were accumulating.

The primary audience here is a **coding agent** driving `tvc` non-interactively, plus a human in a fast deploy/test loop. Neither one reads a pretty table, so the warning has to land in plain stderr text.

Originating Slack thread: https://turnkeycrypto.slack.com/archives/C07TWDK573N/p1784906290058509

## Threshold rationale

> `MAX_EXPECTED_LIVE_DEPLOYMENTS = 2`

A blue/green rollout needs exactly two live deployments at once: the one currently taking traffic and the one replacing it. Two is therefore a legitimate steady state and must not warn. Anything **above** two is accumulation from the deploy/test loop rather than a rollout, and each extra deployment keeps costing money until it is deleted.

"Live" is defined as `TvcDeployment::delete == false` — the API's only live/torn-down distinction, and the one that decides whether a deployment is still billed.

## The warning, as rendered

```
warning: app 11111111-1111-1111-1111-111111111111 has 4 live deployments, more than the 2 a blue/green rollout needs.
  Each live deployment is billed even when it receives no traffic.
  Live deployments: dep-1, dep-2, dep-3, dep-4
  Delete the ones you no longer need: tvc deploy delete --deploy-id <DEPLOY_ID>
```

It states the count, the cost, the live deployment IDs (an agent needs them to act), and the exact remediation command. `tvc deploy delete --deploy-id` is the real subcommand, not a guess.

## Which commands emit it

| Command | Source of the deployment list |
|---|---|
| `tvc deploy create` | One extra `get_tvc_app_deployments` call after the deployment is created. This is the moment a caller learns it is accumulating, so it is worth the round trip. Best-effort: a failed list is logged at debug and swallowed, so it can never fail a deploy that already succeeded. |
| `tvc app status` | Reuses the `AppStatus.deployments` list the command already fetches — no extra round trip. Everything the cluster reports is running, and therefore billed, so no live/deleted filtering is needed on this path. |

`tvc app list` is deliberately not a site: it reports one `liveDeploymentId` per app and never enumerates an app's deployments, so it has nothing to count.

## Output-mode behavior

`Human::warn` existed but had zero callers, and it was gated on `MessageFormat::Human` — which would have hidden this warning from exactly the non-interactive agents it is written for. It is moved to `Shell::warn`, which writes to stderr in **every** message format.

Warnings are diagnostics, not command output, and stderr is not part of the newline-delimited JSON stream on stdout, so `--message-format json` consumers see the advisory with their parse intact. Two unit tests pin this: stdout stays empty in both human and JSON mode.

Advisory only — the warning never changes an exit code and is never an error.

## Tests

The "should we warn / what does it say" decision is a pure function, `live_deployment_warning(app_id, &[&str]) -> Option<String>`:

- 0, 1, 2 live deployments -> `None` (2 is the blue/green steady state)
- 3 and 4 live deployments -> golden-text equality on the full message, covering count, cost, every ID, and the remediation command
- `live_deployment_ids` skips deployments marked for deletion
- 3 deployments where one is already torn down -> `None`
- `Shell::warn` writes to stderr and leaves stdout empty, in both human and JSON mode

## Verification

```
$ cargo build -p tvc
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.64s

$ cargo test -p tvc
    312 passed, 0 failed across 25 test binaries
    (includes 9 new: 7 in commands::live_deployments, 2 in output)

$ cargo fmt --check
    clean, no diff

$ cargo clippy -p tvc -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.92s

$ cargo clippy -p tvc --all-targets --all-features -- -D warnings   # the Makefile/CI form
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.12s
```

No pre-existing clippy issues were encountered in files this PR does not touch. (The only build-time warning in this sandbox is `hard linking files in the incremental compilation cache failed` — a property of the volume filesystem, unrelated to the code.)
