### PR TITLE
feat(tvc): stamp X-TVC-CLIENT-VERSION and add version subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4220,6 +4220,7 @@ dependencies = [
  "turnkey_client",
  "turnkey_enclave_encrypt",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -47,3 +47,4 @@ predicates = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 rexpect = { workspace = true }
 tempfile = { workspace = true }
+wiremock = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -248,6 +248,7 @@ impl Commands {
                     commands::login::run_delete(ctx, delete_args).await
                 }
             },
+            Commands::Version => commands::version::run(),
         }
     }
 }
@@ -281,6 +282,8 @@ enum Commands {
         #[command(subcommand)]
         command: KeysCommands,
     },
+    /// Print the tvc CLI version.
+    Version,
 }
 
 impl Commands {
@@ -296,6 +299,7 @@ impl Commands {
             Commands::Deploy { command } => command.name(),
             Commands::App { command } => command.name(),
             Commands::Keys { command } => command.name(),
+            Commands::Version => "version",
         }
     }
 }

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -3,6 +3,7 @@
 use crate::config::turnkey::{Config, StoredApiKey};
 use crate::errors::MissingResource;
 use anyhow::{Context, Result, anyhow, bail};
+use reqwest::header::{HeaderMap, HeaderValue};
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::{
@@ -120,6 +121,34 @@ async fn load_credentials_from_config() -> Result<(String, String, String, Strin
     ))
 }
 
+/// Header carrying the tvc release version on every API request. The backend
+/// enforces a minimum-version floor on it (enforce-when-present) to retire
+/// known-defective releases with an upgrade prompt.
+const TVC_CLIENT_VERSION_HEADER: &str = "X-TVC-CLIENT-VERSION";
+
+/// Build the Turnkey API client used for all tvc requests.
+///
+/// Every tvc client must be constructed here: this is the single place that
+/// stamps [`TVC_CLIENT_VERSION_HEADER`] with this crate's release version, and
+/// the backend's version gate relies on it riding every request.
+pub(crate) fn build_turnkey_client(
+    stamper: TurnkeyP256ApiKey,
+    api_base_url: &str,
+) -> Result<TurnkeyClient<TurnkeyP256ApiKey>> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        TVC_CLIENT_VERSION_HEADER,
+        HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+    );
+
+    TurnkeyClient::builder()
+        .api_key(stamper)
+        .base_url(api_base_url)
+        .with_reqwest_builder(|builder| builder.default_headers(headers))
+        .build()
+        .context("failed to build Turnkey client")
+}
+
 fn build_authed_client(
     org_id: &str,
     api_base_url: &str,
@@ -131,11 +160,7 @@ fn build_authed_client(
         .context("failed to load API key")?;
 
     debug!(%api_base_url, "building Turnkey API client");
-    let client = TurnkeyClient::builder()
-        .api_key(stamper)
-        .base_url(api_base_url)
-        .build()
-        .context("failed to build Turnkey client")?;
+    let client = build_turnkey_client(stamper, api_base_url)?;
 
     debug!("authenticated Turnkey client ready");
 
@@ -208,4 +233,33 @@ fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, St
         api_key_public.unwrap(),
         api_key_private.unwrap(),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn built_clients_stamp_the_tvc_release_version_on_every_request() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(header("X-TVC-CLIENT-VERSION", env!("CARGO_PKG_VERSION")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_turnkey_client(TurnkeyP256ApiKey::generate(), &server.uri())
+            .expect("client builds");
+        let response: serde_json::Value = client
+            .process_request(&serde_json::json!({}), "/any/path".to_string())
+            .await
+            .expect("request carrying the version header matches the mock");
+
+        assert_eq!(response, serde_json::json!({}));
+        server.verify().await;
+    }
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -1,5 +1,6 @@
 //! Login command for authenticating with Turnkey.
 
+use crate::client::build_turnkey_client;
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, OperatorRecordKind, OrgConfig, StoredApiKey,
     StoredQosOperatorKey, dashboard_base_url, default_api_key_path, default_operator_key_path,
@@ -617,11 +618,7 @@ async fn verify_credentials(
     let stamper = TurnkeyP256ApiKey::from_strings(&api_key.private_key, Some(&api_key.public_key))
         .context("failed to load API key")?;
 
-    let client = turnkey_client::TurnkeyClient::builder()
-        .api_key(stamper)
-        .base_url(api_base_url)
-        .build()
-        .context("failed to build Turnkey client")?;
+    let client = build_turnkey_client(stamper, api_base_url)?;
 
     let request = GetWhoamiRequest {
         organization_id: org_id.to_string(),

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod display;
 pub mod keys;
 pub mod login;
 pub mod operator;
+pub mod version;

--- a/tvc/src/commands/version.rs
+++ b/tvc/src/commands/version.rs
@@ -1,0 +1,23 @@
+//! Version command for printing the tvc release version.
+
+use crate::outcome::Outcome;
+use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
+
+/// The tvc release version.
+#[derive(Default, Serialize)]
+pub struct CliVersion {
+    version: &'static str,
+}
+
+impl Display for CliVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.version)
+    }
+}
+
+pub fn run() -> anyhow::Result<Outcome> {
+    Ok(Outcome::Version(CliVersion {
+        version: env!("CARGO_PKG_VERSION"),
+    }))
+}

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -9,7 +9,7 @@
 //! `reason` strings are stable snake_case discriminators
 
 use crate::commands::deploy::approve::ApproveOutcome;
-use crate::commands::{app, deploy, keys, login, operator};
+use crate::commands::{app, deploy, keys, login, operator, version};
 use crate::output::Message;
 use serde::{Serialize, Serializer};
 
@@ -43,6 +43,7 @@ pub enum Outcome {
     KeysGenerateQuorumKey(keys::generate_local_quorum_key::QuorumKeyGenerated),
     KeysInitQuorumKey(keys::init_local_quorum_key::QuorumKeyConfigCreated),
     KeysReEncryptShare(keys::re_encrypt_local_share::ReEncryptedShareGenerated),
+    Version(version::CliVersion),
 }
 
 /// Apply `$body` to the message carried by whichever variant `$self` is.
@@ -73,6 +74,7 @@ macro_rules! with_message {
             Outcome::KeysGenerateQuorumKey($msg) => $body,
             Outcome::KeysInitQuorumKey($msg) => $body,
             Outcome::KeysReEncryptShare($msg) => $body,
+            Outcome::Version($msg) => $body,
         }
     };
 }
@@ -115,6 +117,7 @@ impl Message for Outcome {
             Outcome::KeysGenerateQuorumKey(_) => "quorum_key_generated",
             Outcome::KeysInitQuorumKey(_) => "quorum_key_config_created",
             Outcome::KeysReEncryptShare(_) => "re_encrypted_share_generated",
+            Outcome::Version(_) => "version",
         }
     }
 
@@ -173,6 +176,7 @@ mod tests {
             Outcome::KeysReEncryptShare(
                 keys::re_encrypt_local_share::ReEncryptedShareGenerated::default(),
             ),
+            Outcome::Version(version::CliVersion::default()),
         ]
     }
 

--- a/tvc/tests/message_format.rs
+++ b/tvc/tests/message_format.rs
@@ -132,3 +132,29 @@ fn login_missing_org_in_json_mode_outputs_structured_error_to_stdout() {
     assert_eq!(message["code"], "missing_required_input");
     assert!(message["message"].as_str().unwrap().contains("--org"));
 }
+
+#[test]
+fn version_defaults_to_human_output() {
+    cargo_bin_cmd!("tvc")
+        .arg("version")
+        .assert()
+        .success()
+        .stdout(concat!(env!("CARGO_PKG_VERSION"), "\n"));
+}
+
+#[test]
+fn version_json_output_emits_structured_message() {
+    let assert = cargo_bin_cmd!("tvc")
+        .arg("--message-format=json")
+        .arg("version")
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected one JSON message, got {stdout:?}");
+
+    let message: Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(message["reason"], "version");
+    assert_eq!(message["version"], env!("CARGO_PKG_VERSION"));
+}


### PR DESCRIPTION
The backend gates TVC requests on a minimum tvc release version (enforce-when-present). The CLI now stamps `X-TVC-CLIENT-VERSION: <CARGO_PKG_VERSION>` on every API request, injected as a reqwest default header in the single client constructor — no changes to the published `turnkey_client` crate.

Also adds `tvc version`: bare version in human mode, `{"reason":"version","version":"0.13.0"}` in JSON mode.

Closes ENG-4082.

### Manual Test

I tested this in dev. I made sure that versions without the explicit header don't fail. When the version is explicitly set to an old version, this is what the error message looks like: 

```
error: failed to create TVC deployment: HTTP response was not successful: 400 ({"code":3,"message":"tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); upgrade tvc to the latest release","details":[],"turnkeyErrorCode":""})
```

I would argue that this it's easy to discern that an upgrade is needed and should be pretty easy to figure out how to perform the upgrade. We should however find a way to handle this error better a display a better message. The problem with doing that now is there could be someone using the client code that wouldn't expect this? 