### PR TITLE
feat(tvc): guard against operator key collisions in operator/app create

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -245,7 +245,7 @@ impl Commands {
             },
             Commands::Login(args) => commands::login::run(ctx, args).await,
             Commands::Operator { command } => match command {
-                OperatorCommands::Create(args) => commands::operator::create::run(ctx, args).await,
+                OperatorCommands::Create(args) => args.run(ctx).await.map(Into::into),
             },
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(delete_args) => {

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -88,6 +88,81 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         }
     }
 
+    // Key-collision guards (after reuse resolution, which may have cleared
+    // new_operators): duplicated keys mint distinct operator IDs backed by
+    // identical keys. Detection is pure; this endpoint resolves per mode.
+    let saved_key = load_saved_operator_public_key().await;
+
+    if let Some(SavedKeyCollision {
+        operator_names,
+        existing_ids,
+    }) = find_saved_key_collision(
+        app_config.manifest_set_params.as_ref(),
+        saved_key.as_deref(),
+        &saved_ids,
+    ) {
+        let names = operator_names.join(", ");
+
+        if ctx.is_non_interactive() {
+            let ids = existing_ids.join(", ");
+            bail!(
+                r#"manifestSetParams.newOperators entries [{names}] use the saved local operator key, which already backs operator ID(s) [{ids}].
+Creating the app would mint another operator ID with identical keys.
+Set manifestSetParams.existingOperatorIds to reuse an existing operator, use a distinct newOperators publicKey to create a new one, or rerun interactively to choose."#
+            );
+        }
+
+        shell_println!(
+            ctx,
+            "Operator(s) [{names}] in manifestSetParams use the saved local operator key, which already backs existing operator(s)."
+        )?;
+
+        let mut options: Vec<SavedKeyResolution> = existing_ids
+            .into_iter()
+            .map(SavedKeyResolution::Reuse)
+            .collect();
+        options.push(SavedKeyResolution::CreateAnyway);
+        options.push(SavedKeyResolution::Cancel);
+
+        match prompts::select(
+            "A newOperators key already backs existing operator(s). How do you want to proceed?",
+            options,
+        )? {
+            SavedKeyResolution::Reuse(id) => apply_operator_reuse(ctx, &mut app_config, id)?,
+            SavedKeyResolution::CreateAnyway => {}
+            SavedKeyResolution::Cancel => bail!("operation cancelled by user: app creation"),
+        }
+    }
+
+    // Within-set duplicates, checked second (a Reuse choice above clears the
+    // manifest set's new_operators). Only sets the user wrote are checked; the
+    // built-in default share set is guarded by a unit test instead.
+    for (set, params) in [
+        ("manifestSetParams", app_config.manifest_set_params.as_ref()),
+        ("shareSetParams", app_config.share_set_params.as_ref()),
+    ] {
+        let Some(params) = params else { continue };
+
+        for group in find_duplicate_new_operator_keys(params) {
+            let names = group.join(", ");
+
+            if ctx.is_non_interactive() {
+                bail!(
+                    r#"{set}.newOperators entries [{names}] share the same public key.
+Each entry would become a separate operator ID backed by identical keys.
+Give each {set}.newOperators entry a distinct publicKey, or replace duplicates with {set}.existingOperatorIds."#
+                );
+            }
+
+            prompts::confirm_or_bail(
+                &format!(
+                    "{set}.newOperators entries [{names}] share the same public key; each will become a separate operator with identical keys. Create anyway?"
+                ),
+                "app creation",
+            )?;
+        }
+    }
+
     run_with_config(ctx, args, app_config).await
 }
 
@@ -158,6 +233,113 @@ async fn load_saved_operator_ids() -> Vec<String> {
     match turnkey::Config::load().await {
         Ok(config) => config.get_last_operator_ids().unwrap_or_default(),
         Err(_) => Vec::new(),
+    }
+}
+
+/// Canonical form for comparing operator public keys from configs and local
+/// key files: trimmed, ASCII-lowercased hex. A string comparison rather than a
+/// parse — app-config keys carry no format guarantee, and a non-key string
+/// simply never matches a real key.
+fn canonical_operator_key(key: &str) -> String {
+    key.trim().to_ascii_lowercase()
+}
+
+/// Manifest-set newOperators entries whose key already backs known operators.
+#[derive(Debug, PartialEq, Eq)]
+struct SavedKeyCollision {
+    /// Names of the newOperators entries using the saved local operator key.
+    operator_names: Vec<String>,
+    /// Operator IDs already backed by that key: config existingOperatorIds
+    /// first, then last-run IDs, deduplicated preserving order.
+    existing_ids: Vec<String>,
+}
+
+/// Detect manifest-set newOperators entries that reuse the saved local
+/// operator key when operator IDs backed by it are already known.
+///
+/// Pure and mode-agnostic: the caller prompts to choose (interactive) or
+/// errors with remediation (non-interactive). Returns `None` when there is no
+/// saved key, no known IDs, or no matching entry — a first run that filled the
+/// saved key into a fresh config stays untouched.
+fn find_saved_key_collision(
+    manifest_set_params: Option<&OperatorSetParams>,
+    saved_public_key: Option<&str>,
+    saved_operator_ids: &[String],
+) -> Option<SavedKeyCollision> {
+    let params = manifest_set_params?;
+    let saved_key = canonical_operator_key(saved_public_key?);
+
+    let operator_names: Vec<String> = params
+        .new_operators
+        .iter()
+        .filter(|operator| canonical_operator_key(&operator.public_key) == saved_key)
+        .map(|operator| operator.name.clone())
+        .collect();
+
+    if operator_names.is_empty() {
+        return None;
+    }
+
+    let mut existing_ids: Vec<String> = Vec::new();
+
+    for id in params
+        .existing_operator_ids
+        .iter()
+        .chain(saved_operator_ids)
+    {
+        if !existing_ids.contains(id) {
+            existing_ids.push(id.clone());
+        }
+    }
+
+    if existing_ids.is_empty() {
+        return None;
+    }
+
+    Some(SavedKeyCollision {
+        operator_names,
+        existing_ids,
+    })
+}
+
+/// Groups of newOperators names (within one set) sharing an identical public
+/// key, in first-occurrence order. Each group would mint multiple operator IDs
+/// backed by the same key.
+fn find_duplicate_new_operator_keys(params: &OperatorSetParams) -> Vec<Vec<String>> {
+    let mut groups: Vec<(String, Vec<String>)> = Vec::new();
+
+    for operator in &params.new_operators {
+        let key = canonical_operator_key(&operator.public_key);
+
+        match groups.iter_mut().find(|(existing, _)| *existing == key) {
+            Some((_, names)) => names.push(operator.name.clone()),
+            None => groups.push((key, vec![operator.name.clone()])),
+        }
+    }
+
+    groups
+        .into_iter()
+        .filter_map(|(_, names)| (names.len() > 1).then_some(names))
+        .collect()
+}
+
+/// How the user chose to resolve a saved-key collision.
+enum SavedKeyResolution {
+    /// Reuse this existing operator ID instead of creating a new operator.
+    Reuse(String),
+    /// Create a new operator ID backed by the same key anyway.
+    CreateAnyway,
+    /// Cancel app creation.
+    Cancel,
+}
+
+impl Display for SavedKeyResolution {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reuse(id) => write!(f, "Reuse existing operator {id} (do not create a new one)"),
+            Self::CreateAnyway => f.write_str("Create a new operator ID backed by the same key"),
+            Self::Cancel => f.write_str("Cancel app creation"),
+        }
     }
 }
 
@@ -614,5 +796,157 @@ mod tests {
         let params = config.manifest_set_params.unwrap();
         assert!(params.new_operators.is_empty());
         assert_eq!(params.existing_operator_ids, vec!["op-1".to_string()]);
+    }
+
+    const SAVED_KEY: &str = "04abcdef";
+
+    fn params_with_operator_keys(operators: &[(&str, &str)]) -> OperatorSetParams {
+        OperatorSetParams {
+            name: "manifest-set".to_string(),
+            threshold: 1,
+            new_operators: operators
+                .iter()
+                .map(|(name, key)| OperatorParams {
+                    name: name.to_string(),
+                    public_key: key.to_string(),
+                })
+                .collect(),
+            existing_operator_ids: vec![],
+        }
+    }
+
+    /// A matching key with no known operator IDs is the first-run happy path
+    /// (fill_interactively defaulted the saved key) -> no collision.
+    #[test]
+    fn saved_key_collision_requires_known_operator_ids() {
+        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+
+        assert_eq!(
+            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &[]),
+            None
+        );
+    }
+
+    /// IDs saved from the last create run make a matching key a collision.
+    #[test]
+    fn saved_key_collision_fires_on_saved_last_run_ids() {
+        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+        let saved = vec!["op-1".to_string()];
+
+        assert_eq!(
+            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
+            Some(SavedKeyCollision {
+                operator_names: vec!["op-a".to_string()],
+                existing_ids: vec!["op-1".to_string()],
+            })
+        );
+    }
+
+    /// Config pinning existingOperatorIds alongside a colliding newOperators
+    /// entry counts as known IDs too.
+    #[test]
+    fn saved_key_collision_fires_on_config_existing_ids() {
+        let mut params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+        params.existing_operator_ids = vec!["cfg-op".to_string()];
+
+        assert_eq!(
+            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &[]),
+            Some(SavedKeyCollision {
+                operator_names: vec!["op-a".to_string()],
+                existing_ids: vec!["cfg-op".to_string()],
+            })
+        );
+    }
+
+    /// Config IDs come first, then saved last-run IDs, deduplicated.
+    #[test]
+    fn saved_key_collision_merges_and_dedupes_id_sources() {
+        let mut params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+        params.existing_operator_ids = vec!["cfg-op".to_string(), "op-1".to_string()];
+        let saved = vec!["op-1".to_string(), "op-2".to_string()];
+
+        let collision = find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved).unwrap();
+
+        assert_eq!(collision.existing_ids, vec!["cfg-op", "op-1", "op-2"]);
+    }
+
+    /// A newOperators key that differs from the saved key is a genuinely new
+    /// operator -> no collision.
+    #[test]
+    fn saved_key_collision_ignores_non_matching_key() {
+        let params = params_with_operator_keys(&[("op-a", "04fedcba")]);
+        let saved = vec!["op-1".to_string()];
+
+        assert_eq!(
+            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
+            None
+        );
+    }
+
+    /// Without a saved local key there is nothing to compare against.
+    #[test]
+    fn saved_key_collision_requires_saved_key() {
+        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+        let saved = vec!["op-1".to_string()];
+
+        assert_eq!(find_saved_key_collision(Some(&params), None, &saved), None);
+    }
+
+    /// Key comparison canonicalizes hex case and surrounding whitespace.
+    #[test]
+    fn saved_key_collision_canonicalizes_case_and_whitespace() {
+        let params = params_with_operator_keys(&[("op-a", "  04ABCDEF  ")]);
+        let saved = vec!["op-1".to_string()];
+
+        assert_eq!(
+            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
+            Some(SavedKeyCollision {
+                operator_names: vec!["op-a".to_string()],
+                existing_ids: vec!["op-1".to_string()],
+            })
+        );
+    }
+
+    /// Entries sharing a key are grouped under the key's first occurrence.
+    #[test]
+    fn duplicate_keys_within_set_are_grouped_by_first_occurrence() {
+        let params = params_with_operator_keys(&[("a", "04aa"), ("b", "04bb"), ("c", "04aa")]);
+
+        assert_eq!(
+            find_duplicate_new_operator_keys(&params),
+            vec![vec!["a".to_string(), "c".to_string()]]
+        );
+    }
+
+    /// Distinct keys never form a group.
+    #[test]
+    fn distinct_keys_produce_no_duplicate_groups() {
+        let params = params_with_operator_keys(&[("a", "04aa"), ("b", "04bb")]);
+
+        assert_eq!(
+            find_duplicate_new_operator_keys(&params),
+            Vec::<Vec<String>>::new()
+        );
+    }
+
+    /// Duplicate detection canonicalizes hex case and whitespace.
+    #[test]
+    fn duplicate_detection_canonicalizes_case() {
+        let params = params_with_operator_keys(&[("a", "04AA"), ("b", " 04aa ")]);
+
+        assert_eq!(
+            find_duplicate_new_operator_keys(&params),
+            vec![vec!["a".to_string(), "b".to_string()]]
+        );
+    }
+
+    /// The built-in dev share set must never trip the duplicate guard; this
+    /// protects the default happy path if KNOWN_SHARE_SET_KEYS ever change.
+    #[test]
+    fn default_dev_share_set_has_no_duplicate_keys() {
+        assert_eq!(
+            find_duplicate_new_operator_keys(&AppConfig::share_set_params()),
+            Vec::<Vec<String>>::new()
+        );
     }
 }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -13,6 +13,7 @@ use crate::{
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
@@ -21,6 +22,11 @@ use std::{
 };
 use tracing::debug;
 use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperatorSetParams};
+use uuid::Uuid;
+
+/// App-config field names, as they appear in the JSON users edit.
+const MANIFEST_SET_PARAMS: &str = "manifestSetParams";
+const SHARE_SET_PARAMS: &str = "shareSetParams";
 
 /// Create a new TVC application from a config file.
 #[derive(Debug, ClapArgs)]
@@ -67,7 +73,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     // runs don't mint a fresh operator ID for the same local key. The decision
     // itself is pure (`decide_operator_reuse`); this endpoint does the I/O
     // (loading saved IDs) and adapts multi-candidate handling to the mode.
-    let saved_ids = load_saved_operator_ids().await;
+    let saved_ids = load_saved_operator_ids().await?;
     match decide_operator_reuse(
         args.no_operator_reuse,
         app_config.manifest_set_params.as_ref(),
@@ -79,7 +85,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
             if ctx.is_non_interactive() {
                 bail!(
                     "multiple saved operator IDs for the active org; \
-                     set manifestSetParams.existingOperatorIds in your config to reuse one, \
+                     set {MANIFEST_SET_PARAMS}.existingOperatorIds in your config to reuse one, \
                      or pass --no-operator-reuse to create a new operator"
                 );
             }
@@ -88,41 +94,54 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         }
     }
 
-    // Key-collision guards (after reuse resolution, which may have cleared
-    // new_operators): duplicated keys mint distinct operator IDs backed by
-    // identical keys. Detection is pure; this endpoint resolves per mode.
-    let saved_key = load_saved_operator_public_key().await;
+    // Key-collision guards run after reuse resolution (which may have cleared
+    // new_operators): a duplicated key mints a distinct operator ID backed by
+    // identical keys, which is almost always a mistake.
+    let saved_key = load_saved_operator_public_key()
+        .await
+        .map(|key| CanonicalOperatorKey::from(key.as_str()));
 
-    if let Some(SavedKeyCollision {
-        operator_names,
-        existing_ids,
-    }) = find_saved_key_collision(
-        app_config.manifest_set_params.as_ref(),
-        saved_key.as_deref(),
-        &saved_ids,
-    ) {
-        let names = operator_names.join(", ");
+    // Manifest-set newOperators entries reusing the saved local operator key
+    // while saved operator IDs backed by that key already exist.
+    let colliding_names: Vec<&str> = match (app_config.manifest_set_params.as_ref(), &saved_key) {
+        (Some(params), Some(saved_key)) if !saved_ids.is_empty() => params
+            .new_operators
+            .iter()
+            .filter(|operator| {
+                CanonicalOperatorKey::from(operator.public_key.as_str()) == *saved_key
+            })
+            .map(|operator| operator.name.as_str())
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    if !colliding_names.is_empty() {
+        let names = colliding_names.join(", ");
 
         if ctx.is_non_interactive() {
-            let ids = existing_ids.join(", ");
+            let ids = saved_ids
+                .iter()
+                .map(Uuid::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
             bail!(
-                r#"manifestSetParams.newOperators entries [{names}] use the saved local operator key, which already backs operator ID(s) [{ids}].
+                r#"{MANIFEST_SET_PARAMS}.newOperators entries [{names}] use the saved local operator key, which already backs operator ID(s) [{ids}].
 Creating the app would mint another operator ID with identical keys.
-Set manifestSetParams.existingOperatorIds to reuse an existing operator, use a distinct newOperators publicKey to create a new one, or rerun interactively to choose."#
+Set {MANIFEST_SET_PARAMS}.existingOperatorIds to reuse an existing operator, use a distinct newOperators publicKey to create a new one, or rerun interactively to choose."#
             );
         }
 
         shell_println!(
             ctx,
-            "Operator(s) [{names}] in manifestSetParams use the saved local operator key, which already backs existing operator(s)."
+            "Operator(s) [{names}] in {MANIFEST_SET_PARAMS} use the saved local operator key, which already backs existing operator(s)."
         )?;
 
-        let mut options: Vec<SavedKeyResolution> = existing_ids
-            .into_iter()
+        let options: Vec<SavedKeyResolution> = saved_ids
+            .iter()
+            .copied()
             .map(SavedKeyResolution::Reuse)
+            .chain([SavedKeyResolution::CreateAnyway, SavedKeyResolution::Cancel])
             .collect();
-        options.push(SavedKeyResolution::CreateAnyway);
-        options.push(SavedKeyResolution::Cancel);
 
         match prompts::select(
             "A newOperators key already backs existing operator(s). How do you want to proceed?",
@@ -137,30 +156,12 @@ Set manifestSetParams.existingOperatorIds to reuse an existing operator, use a d
     // Within-set duplicates, checked second (a Reuse choice above clears the
     // manifest set's new_operators). Only sets the user wrote are checked; the
     // built-in default share set is guarded by a unit test instead.
-    for (set, params) in [
-        ("manifestSetParams", app_config.manifest_set_params.as_ref()),
-        ("shareSetParams", app_config.share_set_params.as_ref()),
-    ] {
-        let Some(params) = params else { continue };
+    if let Some(params) = app_config.manifest_set_params.as_ref() {
+        resolve_duplicate_new_operator_keys(ctx, MANIFEST_SET_PARAMS, params)?;
+    }
 
-        for group in find_duplicate_new_operator_keys(params) {
-            let names = group.join(", ");
-
-            if ctx.is_non_interactive() {
-                bail!(
-                    r#"{set}.newOperators entries [{names}] share the same public key.
-Each entry would become a separate operator ID backed by identical keys.
-Give each {set}.newOperators entry a distinct publicKey, or replace duplicates with {set}.existingOperatorIds."#
-                );
-            }
-
-            prompts::confirm_or_bail(
-                &format!(
-                    "{set}.newOperators entries [{names}] share the same public key; each will become a separate operator with identical keys. Create anyway?"
-                ),
-                "app creation",
-            )?;
-        }
+    if let Some(params) = app_config.share_set_params.as_ref() {
+        resolve_duplicate_new_operator_keys(ctx, SHARE_SET_PARAMS, params)?;
     }
 
     run_with_config(ctx, args, app_config).await
@@ -172,9 +173,9 @@ enum OperatorReuse {
     /// Leave the config as-is: create new operators, or honor an explicit config.
     KeepConfig,
     /// Reuse exactly this saved operator ID.
-    Reuse(String),
+    Reuse(Uuid),
     /// Several saved operator IDs are candidates; the caller picks one.
-    MultipleCandidates(Vec<String>),
+    MultipleCandidates(Vec<Uuid>),
 }
 
 /// Decide whether to reuse a previously-created operator for the manifest set.
@@ -185,7 +186,7 @@ enum OperatorReuse {
 fn decide_operator_reuse(
     no_reuse: bool,
     manifest_set_params: Option<&OperatorSetParams>,
-    saved_ids: &[String],
+    saved_ids: &[Uuid],
 ) -> OperatorReuse {
     // Opt-out: the user explicitly wants a fresh operator.
     if no_reuse {
@@ -202,7 +203,7 @@ fn decide_operator_reuse(
     }
     match saved_ids {
         [] => OperatorReuse::KeepConfig,
-        [id] => OperatorReuse::Reuse(id.clone()),
+        [id] => OperatorReuse::Reuse(*id),
         _ => OperatorReuse::MultipleCandidates(saved_ids.to_vec()),
     }
 }
@@ -211,14 +212,14 @@ fn decide_operator_reuse(
 fn apply_operator_reuse<Out: io::Write, Err: io::Write>(
     ctx: &mut Ctx<Out, Err>,
     config: &mut AppConfig,
-    operator_id: String,
+    operator_id: Uuid,
 ) -> anyhow::Result<()> {
     if let Some(params) = config.manifest_set_params.as_mut() {
         params.new_operators.clear();
-        params.existing_operator_ids = vec![operator_id.clone()];
+        params.existing_operator_ids = vec![operator_id.to_string()];
     }
 
-    debug!(operator_id = %operator_id, "reusing existing operator");
+    debug!(%operator_id, "reusing existing operator");
 
     shell_println!(
         ctx,
@@ -226,121 +227,95 @@ fn apply_operator_reuse<Out: io::Write, Err: io::Write>(
     )
 }
 
+// Review answer (delete me): yes, these are UUIDs — TVC operator IDs are
+// server-minted UUIDs (`operator create` already UUID-parses the same entity),
+// so this flow now holds them as `Uuid` end-to-end and converts back to
+// `String` only at serde/wire boundaries (config `existingOperatorIds`, the
+// create intent).
 /// Best-effort load of the active org's most recently created operator IDs.
-/// Reuse is a convenience, so config-load failures fall back to no reuse; the
-/// real error surfaces later when `run_with_config` reloads the config.
-async fn load_saved_operator_ids() -> Vec<String> {
-    match turnkey::Config::load().await {
-        Ok(config) => config.get_last_operator_ids().unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
-}
+/// Reuse is a convenience, so config-load failures fall back to no reuse (the
+/// real error surfaces later when `run_with_config` reloads the config), but a
+/// malformed saved ID is a bad write of our own and surfaces immediately.
+async fn load_saved_operator_ids() -> Result<Vec<Uuid>> {
+    let Ok(config) = turnkey::Config::load().await else {
+        return Ok(Vec::new());
+    };
 
-/// Canonical form for comparing operator public keys from configs and local
-/// key files: trimmed, ASCII-lowercased hex. A string comparison rather than a
-/// parse — app-config keys carry no format guarantee, and a non-key string
-/// simply never matches a real key.
-fn canonical_operator_key(key: &str) -> String {
-    key.trim().to_ascii_lowercase()
-}
-
-/// Manifest-set newOperators entries whose key already backs known operators.
-#[derive(Debug, PartialEq, Eq)]
-struct SavedKeyCollision {
-    /// Names of the newOperators entries using the saved local operator key.
-    operator_names: Vec<String>,
-    /// Operator IDs already backed by that key: config existingOperatorIds
-    /// first, then last-run IDs, deduplicated preserving order.
-    existing_ids: Vec<String>,
-}
-
-/// Detect manifest-set newOperators entries that reuse the saved local
-/// operator key when operator IDs backed by it are already known.
-///
-/// Pure and mode-agnostic: the caller prompts to choose (interactive) or
-/// errors with remediation (non-interactive). Returns `None` when there is no
-/// saved key, no known IDs, or no matching entry — a first run that filled the
-/// saved key into a fresh config stays untouched.
-fn find_saved_key_collision(
-    manifest_set_params: Option<&OperatorSetParams>,
-    saved_public_key: Option<&str>,
-    saved_operator_ids: &[String],
-) -> Option<SavedKeyCollision> {
-    let params = manifest_set_params?;
-    let saved_key = canonical_operator_key(saved_public_key?);
-
-    let operator_names: Vec<String> = params
-        .new_operators
+    config
+        .get_last_operator_ids()
+        .unwrap_or_default()
         .iter()
-        .filter(|operator| canonical_operator_key(&operator.public_key) == saved_key)
-        .map(|operator| operator.name.clone())
-        .collect();
-
-    if operator_names.is_empty() {
-        return None;
-    }
-
-    let mut existing_ids: Vec<String> = Vec::new();
-
-    for id in params
-        .existing_operator_ids
-        .iter()
-        .chain(saved_operator_ids)
-    {
-        if !existing_ids.contains(id) {
-            existing_ids.push(id.clone());
-        }
-    }
-
-    if existing_ids.is_empty() {
-        return None;
-    }
-
-    Some(SavedKeyCollision {
-        operator_names,
-        existing_ids,
-    })
-}
-
-/// Groups of newOperators names (within one set) sharing an identical public
-/// key, in first-occurrence order. Each group would mint multiple operator IDs
-/// backed by the same key.
-fn find_duplicate_new_operator_keys(params: &OperatorSetParams) -> Vec<Vec<String>> {
-    let mut groups: Vec<(String, Vec<String>)> = Vec::new();
-
-    for operator in &params.new_operators {
-        let key = canonical_operator_key(&operator.public_key);
-
-        match groups.iter_mut().find(|(existing, _)| *existing == key) {
-            Some((_, names)) => names.push(operator.name.clone()),
-            None => groups.push((key, vec![operator.name.clone()])),
-        }
-    }
-
-    groups
-        .into_iter()
-        .filter_map(|(_, names)| (names.len() > 1).then_some(names))
+        .map(|id| {
+            Uuid::parse_str(id).with_context(|| format!("saved operator ID {id} must be a UUID"))
+        })
         .collect()
 }
 
+/// Operator public key in canonical comparison form: trimmed, ASCII-lowercase.
+///
+/// Comparison-only parse — app-config keys carry no format guarantee (validity
+/// is the server's call), so canonicalization cannot fail; a non-key string
+/// simply never matches a real key.
+#[derive(PartialEq, Eq, Hash)]
+struct CanonicalOperatorKey(String);
+
+impl From<&str> for CanonicalOperatorKey {
+    fn from(key: &str) -> Self {
+        Self(key.trim().to_ascii_lowercase())
+    }
+}
+
 /// How the user chose to resolve a saved-key collision.
+#[derive(displaydoc::Display)]
 enum SavedKeyResolution {
-    /// Reuse this existing operator ID instead of creating a new operator.
-    Reuse(String),
-    /// Create a new operator ID backed by the same key anyway.
+    /// Reuse existing operator {0} (do not create a new one)
+    Reuse(Uuid),
+    /// Create a new operator ID backed by the same key
     CreateAnyway,
-    /// Cancel app creation.
+    /// Cancel app creation
     Cancel,
 }
 
-impl Display for SavedKeyResolution {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Reuse(id) => write!(f, "Reuse existing operator {id} (do not create a new one)"),
-            Self::CreateAnyway => f.write_str("Create a new operator ID backed by the same key"),
-            Self::Cancel => f.write_str("Cancel app creation"),
+/// Flag `set`.newOperators entries that share a public key: each duplicate
+/// group would mint a separate operator ID backed by identical keys. Confirms
+/// per group in interactive mode; errors with remediation otherwise.
+fn resolve_duplicate_new_operator_keys<Out: io::Write, Err: io::Write>(
+    ctx: &mut Ctx<Out, Err>,
+    set: &str,
+    params: &OperatorSetParams,
+) -> Result<()> {
+    let groups =
+        params
+            .new_operators
+            .iter()
+            .fold(HashMap::<_, Vec<&str>>::new(), |mut groups, operator| {
+                groups
+                    .entry(CanonicalOperatorKey::from(operator.public_key.as_str()))
+                    .or_default()
+                    .push(operator.name.as_str());
+                groups
+            });
+
+    for names in groups.into_values().filter(|names| names.len() > 1) {
+        let names = names.join(", ");
+
+        if ctx.is_non_interactive() {
+            bail!(
+                r#"{set}.newOperators entries [{names}] share the same public key.
+Each entry would become a separate operator ID backed by identical keys.
+Give each {set}.newOperators entry a distinct publicKey, or replace duplicates with {set}.existingOperatorIds."#
+            );
         }
+
+        prompts::confirm_or_bail(
+            &format!(
+                "{set}.newOperators entries [{names}] share the same public key; each will become a separate operator with identical keys. Create anyway?"
+            ),
+            "app creation",
+        )?;
     }
+
+    Ok(())
 }
 
 async fn build_app_config_interactive(ctx: &mut StdCtx, args: &Args) -> Result<AppConfig> {
@@ -545,6 +520,24 @@ mod tests {
         output::{Ctx, EmptyShell},
     };
 
+    const OP_1: Uuid = Uuid::from_u128(1);
+    const OP_2: Uuid = Uuid::from_u128(2);
+
+    fn params_with_operator_keys(operators: &[(&str, &str)]) -> OperatorSetParams {
+        OperatorSetParams {
+            name: "manifest-set".to_string(),
+            threshold: 1,
+            new_operators: operators
+                .iter()
+                .map(|(name, key)| OperatorParams {
+                    name: name.to_string(),
+                    public_key: key.to_string(),
+                })
+                .collect(),
+            existing_operator_ids: vec![],
+        }
+    }
+
     fn valid_config() -> AppConfig {
         AppConfig {
             name: "test-app".to_string(),
@@ -725,9 +718,8 @@ mod tests {
     #[test]
     fn decide_reuse_keeps_config_when_flag_set() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(true, Some(&params), &saved),
+            decide_operator_reuse(true, Some(&params), &[OP_1]),
             OperatorReuse::KeepConfig
         );
     }
@@ -747,9 +739,8 @@ mod tests {
     fn decide_reuse_keeps_config_when_config_pins_existing_ids() {
         let mut params = manifest_params_with_new_operator();
         params.existing_operator_ids = vec!["explicit-op".to_string()];
-        let saved = vec!["op-1".to_string(), "op-2".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
+            decide_operator_reuse(false, Some(&params), &[OP_1, OP_2]),
             OperatorReuse::KeepConfig
         );
     }
@@ -757,9 +748,8 @@ mod tests {
     /// No manifest_set_params (e.g. reusing a whole set via manifestSetId) -> nothing to do.
     #[test]
     fn decide_reuse_keeps_config_without_manifest_params() {
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, None, &saved),
+            decide_operator_reuse(false, None, &[OP_1]),
             OperatorReuse::KeepConfig
         );
     }
@@ -768,10 +758,9 @@ mod tests {
     #[test]
     fn decide_reuse_reuses_single_saved_id() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
-            OperatorReuse::Reuse("op-1".to_string())
+            decide_operator_reuse(false, Some(&params), &[OP_1]),
+            OperatorReuse::Reuse(OP_1)
         );
     }
 
@@ -779,10 +768,9 @@ mod tests {
     #[test]
     fn decide_reuse_returns_candidates_for_multiple_saved_ids() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string(), "op-2".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
-            OperatorReuse::MultipleCandidates(saved.clone())
+            decide_operator_reuse(false, Some(&params), &[OP_1, OP_2]),
+            OperatorReuse::MultipleCandidates(vec![OP_1, OP_2])
         );
     }
 
@@ -791,162 +779,49 @@ mod tests {
     fn apply_operator_reuse_swaps_new_operators_for_existing_id() {
         let mut ctx = Ctx::new(EmptyShell::default(), true);
         let mut config = valid_config();
-        apply_operator_reuse(&mut ctx, &mut config, "op-1".to_string()).unwrap();
+        apply_operator_reuse(&mut ctx, &mut config, OP_1).unwrap();
 
         let params = config.manifest_set_params.unwrap();
         assert!(params.new_operators.is_empty());
-        assert_eq!(params.existing_operator_ids, vec!["op-1".to_string()]);
+        assert_eq!(params.existing_operator_ids, vec![OP_1.to_string()]);
     }
 
-    const SAVED_KEY: &str = "04abcdef";
-
-    fn params_with_operator_keys(operators: &[(&str, &str)]) -> OperatorSetParams {
-        OperatorSetParams {
-            name: "manifest-set".to_string(),
-            threshold: 1,
-            new_operators: operators
-                .iter()
-                .map(|(name, key)| OperatorParams {
-                    name: name.to_string(),
-                    public_key: key.to_string(),
-                })
-                .collect(),
-            existing_operator_ids: vec![],
-        }
-    }
-
-    /// A matching key with no known operator IDs is the first-run happy path
-    /// (fill_interactively defaulted the saved key) -> no collision.
+    /// Duplicate keys within a set error non-interactively, naming the set,
+    /// every entry in the group, and the remediation field. Key comparison
+    /// canonicalizes hex case and surrounding whitespace.
     #[test]
-    fn saved_key_collision_requires_known_operator_ids() {
-        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
+    fn duplicate_new_operator_keys_error_non_interactively() {
+        let mut ctx = Ctx::new(EmptyShell::default(), true);
+        let params = params_with_operator_keys(&[("a", "04aa"), ("b", " 04AA "), ("c", "04bb")]);
 
-        assert_eq!(
-            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &[]),
-            None
-        );
+        let error = resolve_duplicate_new_operator_keys(&mut ctx, MANIFEST_SET_PARAMS, &params)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("manifestSetParams.newOperators entries [a, b]"));
+        assert!(error.contains("existingOperatorIds"));
     }
 
-    /// IDs saved from the last create run make a matching key a collision.
+    /// Distinct keys pass without prompting or erroring.
     #[test]
-    fn saved_key_collision_fires_on_saved_last_run_ids() {
-        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
-        let saved = vec!["op-1".to_string()];
-
-        assert_eq!(
-            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
-            Some(SavedKeyCollision {
-                operator_names: vec!["op-a".to_string()],
-                existing_ids: vec!["op-1".to_string()],
-            })
-        );
-    }
-
-    /// Config pinning existingOperatorIds alongside a colliding newOperators
-    /// entry counts as known IDs too.
-    #[test]
-    fn saved_key_collision_fires_on_config_existing_ids() {
-        let mut params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
-        params.existing_operator_ids = vec!["cfg-op".to_string()];
-
-        assert_eq!(
-            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &[]),
-            Some(SavedKeyCollision {
-                operator_names: vec!["op-a".to_string()],
-                existing_ids: vec!["cfg-op".to_string()],
-            })
-        );
-    }
-
-    /// Config IDs come first, then saved last-run IDs, deduplicated.
-    #[test]
-    fn saved_key_collision_merges_and_dedupes_id_sources() {
-        let mut params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
-        params.existing_operator_ids = vec!["cfg-op".to_string(), "op-1".to_string()];
-        let saved = vec!["op-1".to_string(), "op-2".to_string()];
-
-        let collision = find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved).unwrap();
-
-        assert_eq!(collision.existing_ids, vec!["cfg-op", "op-1", "op-2"]);
-    }
-
-    /// A newOperators key that differs from the saved key is a genuinely new
-    /// operator -> no collision.
-    #[test]
-    fn saved_key_collision_ignores_non_matching_key() {
-        let params = params_with_operator_keys(&[("op-a", "04fedcba")]);
-        let saved = vec!["op-1".to_string()];
-
-        assert_eq!(
-            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
-            None
-        );
-    }
-
-    /// Without a saved local key there is nothing to compare against.
-    #[test]
-    fn saved_key_collision_requires_saved_key() {
-        let params = params_with_operator_keys(&[("op-a", SAVED_KEY)]);
-        let saved = vec!["op-1".to_string()];
-
-        assert_eq!(find_saved_key_collision(Some(&params), None, &saved), None);
-    }
-
-    /// Key comparison canonicalizes hex case and surrounding whitespace.
-    #[test]
-    fn saved_key_collision_canonicalizes_case_and_whitespace() {
-        let params = params_with_operator_keys(&[("op-a", "  04ABCDEF  ")]);
-        let saved = vec!["op-1".to_string()];
-
-        assert_eq!(
-            find_saved_key_collision(Some(&params), Some(SAVED_KEY), &saved),
-            Some(SavedKeyCollision {
-                operator_names: vec!["op-a".to_string()],
-                existing_ids: vec!["op-1".to_string()],
-            })
-        );
-    }
-
-    /// Entries sharing a key are grouped under the key's first occurrence.
-    #[test]
-    fn duplicate_keys_within_set_are_grouped_by_first_occurrence() {
-        let params = params_with_operator_keys(&[("a", "04aa"), ("b", "04bb"), ("c", "04aa")]);
-
-        assert_eq!(
-            find_duplicate_new_operator_keys(&params),
-            vec![vec!["a".to_string(), "c".to_string()]]
-        );
-    }
-
-    /// Distinct keys never form a group.
-    #[test]
-    fn distinct_keys_produce_no_duplicate_groups() {
+    fn distinct_new_operator_keys_pass() {
+        let mut ctx = Ctx::new(EmptyShell::default(), true);
         let params = params_with_operator_keys(&[("a", "04aa"), ("b", "04bb")]);
 
-        assert_eq!(
-            find_duplicate_new_operator_keys(&params),
-            Vec::<Vec<String>>::new()
-        );
-    }
-
-    /// Duplicate detection canonicalizes hex case and whitespace.
-    #[test]
-    fn duplicate_detection_canonicalizes_case() {
-        let params = params_with_operator_keys(&[("a", "04AA"), ("b", " 04aa ")]);
-
-        assert_eq!(
-            find_duplicate_new_operator_keys(&params),
-            vec![vec!["a".to_string(), "b".to_string()]]
-        );
+        resolve_duplicate_new_operator_keys(&mut ctx, SHARE_SET_PARAMS, &params).unwrap();
     }
 
     /// The built-in dev share set must never trip the duplicate guard; this
     /// protects the default happy path if KNOWN_SHARE_SET_KEYS ever change.
     #[test]
     fn default_dev_share_set_has_no_duplicate_keys() {
-        assert_eq!(
-            find_duplicate_new_operator_keys(&AppConfig::share_set_params()),
-            Vec::<Vec<String>>::new()
-        );
+        let mut ctx = Ctx::new(EmptyShell::default(), true);
+
+        resolve_duplicate_new_operator_keys(
+            &mut ctx,
+            SHARE_SET_PARAMS,
+            &AppConfig::share_set_params(),
+        )
+        .unwrap();
     }
 }

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -9,8 +9,9 @@ use crate::{
     },
     outcome::Outcome,
     output::StdCtx,
+    prompts,
 };
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgGroup, Args as ClapArgs, builder::NonEmptyStringValueParser};
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
@@ -96,15 +97,46 @@ Saved: true"#,
     }
 }
 
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let mut config = Config::load().await?;
-    let (alias, configured_org_id) = config
+    let (alias, org) = config
         .active_org_config()
-        .map(|(alias, org)| (alias.clone(), org.id.as_str()))
         .context("No active organization. Run `tvc login` first.")?;
+    let alias = alias.clone();
+
+    // Only an existing wallet can collide: --wallet-name mints a fresh wallet
+    // (fresh seed), so its derived keys cannot match any saved record.
+    if let Some(wallet_id) = args.wallet_id {
+        let collisions = find_hosted_key_collisions(&org.operators, wallet_id, &args.account_path);
+
+        if !collisions.is_empty() {
+            let existing = collisions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            if ctx.is_non_interactive() {
+                bail!(
+                    r#"wallet {wallet_id} at path {path} already backs hosted operator(s) {existing}.
+Hosted operator keys are derived from the wallet and account path, so the new operator's keys would be identical under a different operator ID.
+Use a different --account-path or --wallet-id, or rerun interactively to confirm creating an operator with duplicate keys."#,
+                    path = args.account_path
+                );
+            }
+
+            prompts::confirm_or_bail(
+                &format!(
+                    "Operator(s) {existing} are already backed by wallet {wallet_id} at path {}; the new operator's keys will be identical. Create anyway?",
+                    args.account_path
+                ),
+                "hosted operator creation",
+            )?;
+        }
+    }
 
     let auth = build_client().await?;
-    ensure_authenticated_org(&auth.org_id, configured_org_id)?;
+    ensure_authenticated_org(&auth.org_id, &org.id)?;
 
     let record = create_hosted_operator(&auth, hosted_operator_spec(args)).await?;
     let output = output_from_record(record.clone())?;
@@ -146,6 +178,49 @@ fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
     HostedOperatorSpec::new(args.name, wallet, args.account_path)
 }
 
+/// Identity of an existing hosted operator already backed by a wallet + path.
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+struct CollidingHostedOperator {
+    name: String,
+    operator_id: Uuid,
+}
+
+impl Display for CollidingHostedOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "'{}' ({})", self.name, self.operator_id)
+    }
+}
+
+/// Find hosted operators whose keys a new operator would duplicate.
+///
+/// Hosted operator keys are derived server-side from the wallet and base
+/// derivation path, so an existing record with the same wallet ID and account
+/// path implies identical keys under a different operator ID. Pure and
+/// mode-agnostic; the caller prompts (interactive) or errors (non-interactive)
+/// on matches. Path comparison is textual (trimmed), so equivalent derivation
+/// paths spelled differently are not caught.
+fn find_hosted_key_collisions(
+    operators: &[OperatorRecord],
+    wallet_id: Uuid,
+    account_path: &str,
+) -> Vec<CollidingHostedOperator> {
+    operators
+        .iter()
+        .filter_map(|record| match &record.kind {
+            OperatorRecordKind::Hosted(hosted)
+                if hosted.wallet_id == wallet_id && hosted.path.trim() == account_path.trim() =>
+            {
+                Some(CollidingHostedOperator {
+                    name: record.name.clone(),
+                    operator_id: hosted.operator_id,
+                })
+            }
+            OperatorRecordKind::Hosted(_) | OperatorRecordKind::Local(_) => None,
+        })
+        .collect()
+}
+
 fn output_from_record(record: OperatorRecord) -> Result<OperatorCreated> {
     let OperatorRecord { name, kind } = record;
     let OperatorRecordKind::Hosted(hosted) = kind else {
@@ -179,20 +254,119 @@ fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::turnkey::HostedOperatorRecord;
+    use crate::config::turnkey::{HostedOperatorRecord, LocalOperatorRecord};
+    use std::path::PathBuf;
+
+    const FIXTURE_WALLET: &str = "22222222-2222-4222-8222-222222222222";
+    const FIXTURE_PATH: &str = "m/5527107'/0'/0'";
+
+    fn fixture_wallet_id() -> Uuid {
+        Uuid::parse_str(FIXTURE_WALLET).unwrap()
+    }
 
     fn hosted_record() -> OperatorRecord {
         OperatorRecord {
             name: "tvc-operator".to_string(),
             kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
                 operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
-                wallet_id: Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap(),
-                path: "m/5527107'/0'/0'".to_string(),
+                wallet_id: fixture_wallet_id(),
+                path: FIXTURE_PATH.to_string(),
                 encrypt_public_key: format!("04{}", "11".repeat(64)),
                 sign_public_key: format!("04{}", "22".repeat(64)),
                 extra: toml::Table::new(),
             }),
         }
+    }
+
+    fn local_record() -> OperatorRecord {
+        OperatorRecord {
+            name: "default".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path: PathBuf::from("operator.json"),
+                operator_id: None,
+                extra: toml::Table::new(),
+            }),
+        }
+    }
+
+    /// Nothing to collide with: no records, or only a local operator (local
+    /// keys are not wallet-derived).
+    #[test]
+    fn no_collisions_without_matching_hosted_records() {
+        assert_eq!(
+            find_hosted_key_collisions(&[], fixture_wallet_id(), FIXTURE_PATH),
+            vec![]
+        );
+        assert_eq!(
+            find_hosted_key_collisions(&[local_record()], fixture_wallet_id(), FIXTURE_PATH),
+            vec![]
+        );
+    }
+
+    /// Same wallet at another path, or another wallet at the same path,
+    /// derives different keys -> no collision.
+    #[test]
+    fn no_collision_when_wallet_or_path_differs() {
+        let records = [hosted_record()];
+
+        assert_eq!(
+            find_hosted_key_collisions(&records, fixture_wallet_id(), "m/5527107'/0'/1'"),
+            vec![]
+        );
+
+        let other_wallet = Uuid::parse_str("33333333-3333-4333-8333-333333333333").unwrap();
+
+        assert_eq!(
+            find_hosted_key_collisions(&records, other_wallet, FIXTURE_PATH),
+            vec![]
+        );
+    }
+
+    /// Same wallet + path repeats the server-side key derivation -> the
+    /// existing operator's identity is surfaced for the prompt/error.
+    #[test]
+    fn collision_returns_existing_operator_identity() {
+        let expected = CollidingHostedOperator {
+            name: "tvc-operator".to_string(),
+            operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
+        };
+
+        assert_eq!(
+            find_hosted_key_collisions(&[hosted_record()], fixture_wallet_id(), FIXTURE_PATH),
+            vec![expected]
+        );
+    }
+
+    /// Every matching record is reported, in registry order.
+    #[test]
+    fn collision_returns_every_matching_record() {
+        let mut second = hosted_record();
+        second.name = "tvc-operator-2".to_string();
+
+        let collisions = find_hosted_key_collisions(
+            &[hosted_record(), local_record(), second],
+            fixture_wallet_id(),
+            FIXTURE_PATH,
+        );
+
+        assert_eq!(
+            collisions
+                .iter()
+                .map(|collision| collision.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tvc-operator", "tvc-operator-2"]
+        );
+    }
+
+    /// Path comparison trims surrounding whitespace (and is otherwise textual).
+    #[test]
+    fn collision_path_comparison_trims_whitespace() {
+        let padded_path = format!("  {FIXTURE_PATH} ");
+
+        assert_eq!(
+            find_hosted_key_collisions(&[hosted_record()], fixture_wallet_id(), &padded_path).len(),
+            1
+        );
     }
 
     #[test]

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     client::build_client,
+    commands::Run,
     config::turnkey::{Config, OperatorRecord, OperatorRecordKind},
     operator::{
         DEFAULT_HOSTED_OPERATOR_BASE_PATH, HostedOperatorSpec, HostedOperatorWallet,
@@ -75,6 +76,12 @@ pub struct OperatorCreated {
     saved: bool,
 }
 
+impl From<OperatorCreated> for Outcome {
+    fn from(outcome: OperatorCreated) -> Self {
+        Outcome::OperatorCreated(outcome)
+    }
+}
+
 impl Display for OperatorCreated {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -97,76 +104,97 @@ Saved: true"#,
     }
 }
 
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let mut config = Config::load().await?;
-    let (alias, org) = config
-        .active_org_config()
-        .context("No active organization. Run `tvc login` first.")?;
-    let alias = alias.clone();
+impl Run for Args {
+    type Outcome = OperatorCreated;
 
-    // Only an existing wallet can collide: --wallet-name mints a fresh wallet
-    // (fresh seed), so its derived keys cannot match any saved record.
-    if let Some(wallet_id) = args.wallet_id {
-        let collisions = find_hosted_key_collisions(&org.operators, wallet_id, &args.account_path);
+    async fn run(self, ctx: &mut StdCtx) -> Result<OperatorCreated> {
+        let mut config = Config::load().await?;
+        let (alias, org) = config
+            .active_org_config()
+            .context("No active organization. Run `tvc login` first.")?;
+        // Review answer (delete me): the clone is needed because `alias` names
+        // the org-map slot we re-borrow mutably at `config.orgs.get_mut(&alias)`
+        // after the network call; keeping the `&String` borrow of `config` alive
+        // that long conflicts with the `&mut`. It's inherent to the data flow
+        // (we keep the key), not induced by a helper boundary.
+        let alias = alias.clone();
 
-        if !collisions.is_empty() {
-            let existing = collisions
+        // Only an existing wallet can collide: --wallet-name mints a fresh
+        // wallet (fresh seed), so its derived keys cannot match any saved
+        // record. Hosted operator keys are derived server-side from the wallet
+        // and base derivation path, so an existing record with the same wallet
+        // + path (textual comparison) implies identical keys under a different
+        // operator ID.
+        if let Some(wallet_id) = self.wallet_id {
+            let existing: Vec<String> = org
+                .operators
                 .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ");
+                .filter_map(|record| match &record.kind {
+                    OperatorRecordKind::Hosted(hosted)
+                        if hosted.wallet_id == wallet_id
+                            && hosted.path.trim() == self.account_path.trim() =>
+                    {
+                        Some(format!("'{}' ({})", record.name, hosted.operator_id))
+                    }
+                    OperatorRecordKind::Hosted(_) | OperatorRecordKind::Local(_) => None,
+                })
+                .collect();
 
-            if ctx.is_non_interactive() {
-                bail!(
-                    r#"wallet {wallet_id} at path {path} already backs hosted operator(s) {existing}.
+            if !existing.is_empty() {
+                let existing = existing.join(", ");
+
+                if ctx.is_non_interactive() {
+                    bail!(
+                        r#"wallet {wallet_id} at path {path} already backs hosted operator(s) {existing}.
 Hosted operator keys are derived from the wallet and account path, so the new operator's keys would be identical under a different operator ID.
 Use a different --account-path or --wallet-id, or rerun interactively to confirm creating an operator with duplicate keys."#,
-                    path = args.account_path
-                );
+                        path = self.account_path
+                    );
+                }
+
+                prompts::confirm_or_bail(
+                    &format!(
+                        "Operator(s) {existing} are already backed by wallet {wallet_id} at path {}; the new operator's keys will be identical. Create anyway?",
+                        self.account_path
+                    ),
+                    "hosted operator creation",
+                )?;
             }
-
-            prompts::confirm_or_bail(
-                &format!(
-                    "Operator(s) {existing} are already backed by wallet {wallet_id} at path {}; the new operator's keys will be identical. Create anyway?",
-                    args.account_path
-                ),
-                "hosted operator creation",
-            )?;
         }
-    }
 
-    let auth = build_client().await?;
-    ensure_authenticated_org(&auth.org_id, &org.id)?;
+        let auth = build_client().await?;
+        ensure_authenticated_org(&auth.org_id, &org.id)?;
 
-    let record = create_hosted_operator(&auth, hosted_operator_spec(args)).await?;
-    let output = output_from_record(record.clone())?;
+        let record = create_hosted_operator(&auth, hosted_operator_spec(self)).await?;
+        let output = output_from_record(record.clone())?;
 
-    config
-        .orgs
-        .get_mut(&alias)
-        .with_context(|| format!("active organization '{alias}' disappeared from config"))?
-        .operators
-        .push(record);
-
-    if let Err(save_error) = config.save().await {
-        let record = config
+        config
             .orgs
-            .get(&alias)
-            .and_then(|org| org.operators.last())
-            .with_context(|| {
-                format!("hosted operator disappeared from active organization '{alias}'")
-            })?;
-        let recovery = recovery_toml(&alias, record)?;
-        return Err(anyhow!(
-            r#"hosted operator {} was created remotely, but saving the local config failed: {save_error}
+            .get_mut(&alias)
+            .with_context(|| format!("active organization '{alias}' disappeared from config"))?
+            .operators
+            .push(record);
+
+        if let Err(save_error) = config.save().await {
+            let record = config
+                .orgs
+                .get(&alias)
+                .and_then(|org| org.operators.last())
+                .with_context(|| {
+                    format!("hosted operator disappeared from active organization '{alias}'")
+                })?;
+            let recovery = recovery_toml(&alias, record)?;
+            return Err(anyhow!(
+                r#"hosted operator {} was created remotely, but saving the local config failed: {save_error}
 Do not retry creation blindly; doing so would create another remote operator. Restore this record under the active organization in tvc.config.toml:
 
 {recovery}"#,
-            output.operator_id
-        ));
-    }
+                output.operator_id
+            ));
+        }
 
-    Ok(Outcome::OperatorCreated(output))
+        Ok(output)
+    }
 }
 
 fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
@@ -176,49 +204,6 @@ fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
     };
 
     HostedOperatorSpec::new(args.name, wallet, args.account_path)
-}
-
-/// Identity of an existing hosted operator already backed by a wallet + path.
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-struct CollidingHostedOperator {
-    name: String,
-    operator_id: Uuid,
-}
-
-impl Display for CollidingHostedOperator {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "'{}' ({})", self.name, self.operator_id)
-    }
-}
-
-/// Find hosted operators whose keys a new operator would duplicate.
-///
-/// Hosted operator keys are derived server-side from the wallet and base
-/// derivation path, so an existing record with the same wallet ID and account
-/// path implies identical keys under a different operator ID. Pure and
-/// mode-agnostic; the caller prompts (interactive) or errors (non-interactive)
-/// on matches. Path comparison is textual (trimmed), so equivalent derivation
-/// paths spelled differently are not caught.
-fn find_hosted_key_collisions(
-    operators: &[OperatorRecord],
-    wallet_id: Uuid,
-    account_path: &str,
-) -> Vec<CollidingHostedOperator> {
-    operators
-        .iter()
-        .filter_map(|record| match &record.kind {
-            OperatorRecordKind::Hosted(hosted)
-                if hosted.wallet_id == wallet_id && hosted.path.trim() == account_path.trim() =>
-            {
-                Some(CollidingHostedOperator {
-                    name: record.name.clone(),
-                    operator_id: hosted.operator_id,
-                })
-            }
-            OperatorRecordKind::Hosted(_) | OperatorRecordKind::Local(_) => None,
-        })
-        .collect()
 }
 
 fn output_from_record(record: OperatorRecord) -> Result<OperatorCreated> {
@@ -254,119 +239,20 @@ fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::turnkey::{HostedOperatorRecord, LocalOperatorRecord};
-    use std::path::PathBuf;
-
-    const FIXTURE_WALLET: &str = "22222222-2222-4222-8222-222222222222";
-    const FIXTURE_PATH: &str = "m/5527107'/0'/0'";
-
-    fn fixture_wallet_id() -> Uuid {
-        Uuid::parse_str(FIXTURE_WALLET).unwrap()
-    }
+    use crate::config::turnkey::HostedOperatorRecord;
 
     fn hosted_record() -> OperatorRecord {
         OperatorRecord {
             name: "tvc-operator".to_string(),
             kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
                 operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
-                wallet_id: fixture_wallet_id(),
-                path: FIXTURE_PATH.to_string(),
+                wallet_id: Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap(),
+                path: "m/5527107'/0'/0'".to_string(),
                 encrypt_public_key: format!("04{}", "11".repeat(64)),
                 sign_public_key: format!("04{}", "22".repeat(64)),
                 extra: toml::Table::new(),
             }),
         }
-    }
-
-    fn local_record() -> OperatorRecord {
-        OperatorRecord {
-            name: "default".to_string(),
-            kind: OperatorRecordKind::Local(LocalOperatorRecord {
-                key_path: PathBuf::from("operator.json"),
-                operator_id: None,
-                extra: toml::Table::new(),
-            }),
-        }
-    }
-
-    /// Nothing to collide with: no records, or only a local operator (local
-    /// keys are not wallet-derived).
-    #[test]
-    fn no_collisions_without_matching_hosted_records() {
-        assert_eq!(
-            find_hosted_key_collisions(&[], fixture_wallet_id(), FIXTURE_PATH),
-            vec![]
-        );
-        assert_eq!(
-            find_hosted_key_collisions(&[local_record()], fixture_wallet_id(), FIXTURE_PATH),
-            vec![]
-        );
-    }
-
-    /// Same wallet at another path, or another wallet at the same path,
-    /// derives different keys -> no collision.
-    #[test]
-    fn no_collision_when_wallet_or_path_differs() {
-        let records = [hosted_record()];
-
-        assert_eq!(
-            find_hosted_key_collisions(&records, fixture_wallet_id(), "m/5527107'/0'/1'"),
-            vec![]
-        );
-
-        let other_wallet = Uuid::parse_str("33333333-3333-4333-8333-333333333333").unwrap();
-
-        assert_eq!(
-            find_hosted_key_collisions(&records, other_wallet, FIXTURE_PATH),
-            vec![]
-        );
-    }
-
-    /// Same wallet + path repeats the server-side key derivation -> the
-    /// existing operator's identity is surfaced for the prompt/error.
-    #[test]
-    fn collision_returns_existing_operator_identity() {
-        let expected = CollidingHostedOperator {
-            name: "tvc-operator".to_string(),
-            operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
-        };
-
-        assert_eq!(
-            find_hosted_key_collisions(&[hosted_record()], fixture_wallet_id(), FIXTURE_PATH),
-            vec![expected]
-        );
-    }
-
-    /// Every matching record is reported, in registry order.
-    #[test]
-    fn collision_returns_every_matching_record() {
-        let mut second = hosted_record();
-        second.name = "tvc-operator-2".to_string();
-
-        let collisions = find_hosted_key_collisions(
-            &[hosted_record(), local_record(), second],
-            fixture_wallet_id(),
-            FIXTURE_PATH,
-        );
-
-        assert_eq!(
-            collisions
-                .iter()
-                .map(|collision| collision.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["tvc-operator", "tvc-operator-2"]
-        );
-    }
-
-    /// Path comparison trims surrounding whitespace (and is otherwise textual).
-    #[test]
-    fn collision_path_comparison_trims_whitespace() {
-        let padded_path = format!("  {FIXTURE_PATH} ");
-
-        assert_eq!(
-            find_hosted_key_collisions(&[hosted_record()], fixture_wallet_id(), &padded_path).len(),
-            1
-        );
     }
 
     #[test]

--- a/tvc/src/config/turnkey/qos_operator_key.rs
+++ b/tvc/src/config/turnkey/qos_operator_key.rs
@@ -8,7 +8,8 @@ use tracing::debug;
 /// Operator key stored in operator.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredQosOperatorKey {
-    /// Hex-encoded compressed public key
+    /// Hex-encoded `qos_p256` composite public key: two uncompressed SEC1
+    /// points (encrypt then sign), 130 bytes total.
     pub public_key: String,
     /// Hex-encoded private key
     pub private_key: String,

--- a/tvc/src/config/turnkey/qos_operator_key.rs
+++ b/tvc/src/config/turnkey/qos_operator_key.rs
@@ -8,6 +8,12 @@ use tracing::debug;
 /// Operator key stored in operator.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredQosOperatorKey {
+    // Review answer (delete me): re "?" — verified against qos_p256 v0.12.1.
+    // login writes `hex::encode(P256Pair::public_key().to_bytes())`, and
+    // `P256Public::to_bytes` is documented "Serialize each public key as a
+    // SEC1 encoded point, not compressed. Encodes as
+    // `encrypt_public||sign_public`" (qos_p256 src/lib.rs:365-366), i.e.
+    // 65 + 65 bytes. The previous "compressed" wording was wrong.
     /// Hex-encoded `qos_p256` composite public key: two uncompressed SEC1
     /// points (encrypt then sign), 130 bytes total.
     pub public_key: String,

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -77,6 +77,37 @@ fn write_api_key(path: &std::path::Path) {
     .unwrap();
 }
 
+fn write_operator_key(path: &std::path::Path, public_key: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        serde_json::json!({ "public_key": public_key, "private_key": "00" }).to_string(),
+    )
+    .unwrap();
+}
+
+fn write_app_config(path: &std::path::Path, manifest_operators: &[(&str, &str)]) {
+    let new_operators: Vec<_> = manifest_operators
+        .iter()
+        .map(|(name, key)| serde_json::json!({ "name": name, "publicKey": key }))
+        .collect();
+
+    fs::write(
+        path,
+        serde_json::json!({
+            "name": "demo",
+            "quorumPublicKey": "not-a-real-key",
+            "manifestSetParams": {
+                "name": "manifest-set",
+                "threshold": 1,
+                "newOperators": new_operators,
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
 #[test]
 fn login_without_org_errors_when_non_interactive_forced() {
     let temp = TempDir::new().unwrap();
@@ -392,4 +423,65 @@ fn deploy_init_template_does_not_require_readable_existing_config() {
         ));
 
     assert!(output.exists(), "deploy init should write the template");
+}
+
+/// A manifest newOperators entry reusing the saved local operator key (modulo
+/// case/whitespace) while saved operator IDs exist would mint another operator
+/// ID with identical keys; non-interactive mode errors instead of prompting.
+#[test]
+fn app_create_errors_when_new_operator_reuses_saved_key() {
+    let temp = TempDir::new().unwrap();
+    let org_dir = temp.path().join(".config/turnkey/orgs/test");
+    let operator_key_path = org_dir.join("operator.json");
+    write_config(
+        &temp,
+        org_dir.join("api_key.json"),
+        operator_key_path.clone(),
+        vec!["33333333-3333-4333-8333-333333333333".to_string()],
+    );
+    write_operator_key(&operator_key_path, "04abcdef");
+    let app_config = temp.path().join("app.json");
+    write_app_config(&app_config, &[("op-a", " 04ABCDEF ")]);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .args(["app", "create", "--no-operator-reuse", "-c"])
+        .arg(&app_config)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "manifestSetParams.newOperators entries [op-a] use the saved local operator key",
+        ))
+        .stderr(predicate::str::contains(
+            "33333333-3333-4333-8333-333333333333",
+        ));
+}
+
+/// Two manifest newOperators entries sharing one public key would mint two
+/// operator IDs backed by identical keys; non-interactive mode errors instead
+/// of prompting.
+#[test]
+fn app_create_errors_on_duplicate_new_operator_keys() {
+    let temp = TempDir::new().unwrap();
+    let org_dir = temp.path().join(".config/turnkey/orgs/test");
+    write_config(
+        &temp,
+        org_dir.join("api_key.json"),
+        org_dir.join("operator.json"),
+        vec![],
+    );
+    let app_config = temp.path().join("app.json");
+    write_app_config(&app_config, &[("op-a", "04aa"), ("op-b", "04aa")]);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .args(["app", "create", "-c"])
+        .arg(&app_config)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "manifestSetParams.newOperators entries [op-a, op-b] share the same public key",
+        ));
 }

--- a/tvc/tests/operator_create.rs
+++ b/tvc/tests/operator_create.rs
@@ -1,5 +1,100 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+use tvc::config::turnkey::{
+    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
+};
+use uuid::Uuid;
+
+const WALLET_ID: &str = "22222222-2222-4222-8222-222222222222";
+const ACCOUNT_PATH: &str = "m/5527107'/0'/0'";
+
+/// Write a config whose active org already has a hosted operator backed by
+/// `WALLET_ID` at `ACCOUNT_PATH`.
+fn write_config_with_hosted_operator(home: &TempDir) {
+    let turnkey_dir = home.path().join(".config").join("turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let config = Config {
+        active_org: Some("test".to_string()),
+        orgs: HashMap::from([(
+            "test".to_string(),
+            OrgConfig {
+                id: "org-test".to_string(),
+                api_key_path: turnkey_dir.join("orgs/test/api_key.json"),
+                api_base_url: "http://127.0.0.1:1".to_string(),
+                default_operator_kind: OperatorKind::Hosted,
+                operators: vec![OperatorRecord {
+                    name: "tvc-operator".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111")
+                            .unwrap(),
+                        wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
+                        path: ACCOUNT_PATH.to_string(),
+                        encrypt_public_key: format!("04{}", "11".repeat(64)),
+                        sign_public_key: format!("04{}", "22".repeat(64)),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+        extra: toml::Table::new(),
+    };
+
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+}
+
+/// Sad path: the same wallet + account path as a saved hosted operator means
+/// the server would derive identical keys; non-interactive mode must error
+/// before any network call.
+#[test]
+fn operator_create_errors_on_key_collision_non_interactively() {
+    let temp = TempDir::new().unwrap();
+    write_config_with_hosted_operator(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .args(["operator", "create", "--non-interactive"])
+        .args(["--wallet-id", WALLET_ID, "--account-path", ACCOUNT_PATH])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "already backs hosted operator(s) 'tvc-operator' (11111111-1111-4111-8111-111111111111)",
+        ))
+        .stderr(predicate::str::contains("--account-path"));
+}
+
+/// Happy path: a different account path derives different keys, so creation
+/// proceeds past the collision guard and fails later at credential loading —
+/// proving the guard did not fire.
+#[test]
+fn operator_create_passes_collision_guard_for_different_path() {
+    let temp = TempDir::new().unwrap();
+    write_config_with_hosted_operator(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .args(["operator", "create", "--non-interactive"])
+        .args([
+            "--wallet-id",
+            WALLET_ID,
+            "--account-path",
+            "m/5527107'/0'/1'",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No API key found"))
+        .stderr(predicate::str::contains("already backs").not());
+}
 
 #[test]
 fn operator_create_help_documents_defaults_and_env_inputs() {


### PR DESCRIPTION
Interactive mode prompts on operator key collisions; non-interactive errors with remediation. No implicit picks, no override flag.

- `operator create`: pre-flight check when `--wallet-id` is given — same wallet + account path re-derives identical keys under a new operator ID. Confirm (default No) or error.
- `app create`: after reuse resolution, detect manifest `newOperators` reusing the saved local operator key when operator IDs backed by it are already known (select: reuse / create anyway / cancel), and within-set duplicate keys in either set.
- Behavior change: non-interactive `--no-operator-reuse` runs whose config key matches the saved key now error instead of minting another same-key operator ID.

Closes TVC-123.