### PR TITLE
refactor(tvc): serde-tagged outcome vocabulary and Run trait pilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,6 +4231,7 @@ dependencies = [
  "rexpect",
  "serde",
  "serde_json",
+ "strum",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ predicates = { version = "3", default-features = false }
 rexpect = { version = "0.5", default-features = false }
 tempfile = { version = "3.19.1", default-features = false }
 signature = "2"
+strum = { version = "0.27.2", default-features = false, features = ["derive", "std", "strum_macros"] }
 wiremock = { version = "0.6", default-features = false }
 http = { version = "0.2", default-features = false }
 hex-literal = { version = "0.4", default-features = false }

--- a/codegen/src/transform.rs
+++ b/codegen/src/transform.rs
@@ -404,15 +404,13 @@ fn extract_field_enum_type(field: &syn::Field) -> Option<EnumField> {
 
         for meta in metas {
             match meta {
-                syn::Meta::NameValue(nv) => {
-                    if nv.path.is_ident("enumeration") {
-                        if let syn::Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Str(lit_str),
-                            ..
-                        }) = &nv.value
-                        {
-                            name = Some(lit_str.value());
-                        }
+                syn::Meta::NameValue(nv) if nv.path.is_ident("enumeration") => {
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(lit_str),
+                        ..
+                    }) = &nv.value
+                    {
+                        name = Some(lit_str.value());
                     }
                 }
                 syn::Meta::Path(p) => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = [ "rustfmt", "cargo", "clippy" ]
 profile = "minimal"

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -46,5 +46,6 @@ hpke = { workspace = true }
 predicates = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 rexpect = { workspace = true }
+strum = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -1,9 +1,9 @@
 //! CLI parsing and dispatch.
 
-use crate::commands;
+use crate::commands::{self, Run};
 use crate::errors::strip_ansi;
 use crate::outcome::Outcome;
-use crate::output::{ColorChoice, Ctx, ErrorMessage, Message, MessageFormat, Shell, StdCtx};
+use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell, StdCtx};
 use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser, error::ErrorKind};
 use std::ffi::OsString;
 use std::io::Write;
@@ -159,8 +159,12 @@ fn handle_parse_error(error: clap::Error) -> ExitCode {
                     .to_string();
                 let error_message = ErrorMessage::usage_error(message);
                 let mut stdout = std::io::stdout();
+
+                // it shouldn't be possible for serialization to fail here.
+                let msg = serde_json::to_string(&error_message).unwrap_or_else(|e| e.to_string());
+
                 // Best-effort: if writing fails we still exit with the usage code.
-                let _ = writeln!(stdout, "{}", error_message.to_json_string());
+                let _ = writeln!(stdout, "{msg}");
                 std::process::exit(USAGE_ERROR_EXIT_CODE)
             } else {
                 error.exit()
@@ -193,7 +197,7 @@ impl Commands {
     async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<Outcome> {
         match self {
             Commands::Deploy { command } => match command {
-                DeployCommands::Approve(args) => commands::deploy::approve::run(ctx, args).await,
+                DeployCommands::Approve(args) => args.run(ctx).await.map(Into::into),
                 DeployCommands::GetStatus(args) => {
                     commands::deploy::get_status::run(ctx, args).await
                 }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -262,7 +262,7 @@ async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) ->
     config.set_last_operator_ids(&operator_ids)?;
     config.save().await?;
 
-    Ok(Outcome::AppCreate(AppCreated {
+    Ok(Outcome::AppCreated(AppCreated {
         app_id,
         name: app_config.name,
         manifest_set_id: result.result.manifest_set_id,

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .await
         .context("failed to delete TVC app and deployments")?;
 
-    Ok(Outcome::AppDelete(AppDeleted {
+    Ok(Outcome::AppDeleted(AppDeleted {
         app_id: result.result.app_id,
         activity_id: result.activity_id,
         activity_status: result.status,

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -64,7 +64,7 @@ async fn execute(args: Args) -> Result<Outcome> {
     std::fs::write(&args.output, json)
         .with_context(|| format!("failed to write file: {}", args.output.display()))?;
 
-    Ok(Outcome::AppInit(AppConfigCreated {
+    Ok(Outcome::AppConfigCreated(AppConfigCreated {
         command: "app init",
         path: args.output.display().to_string(),
         template: !args.interactive,

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -38,7 +38,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
 
     filter_by_name(&mut apps, args.name.as_deref());
 
-    Ok(Outcome::AppList(AppsListed {
+    Ok(Outcome::AppsListed(AppsListed {
         apps: apps.into_iter().map(AppSummary::from).collect(),
     }))
 }

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -41,7 +41,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .await
         .context("failed to set TVC app live deployment")?;
 
-    Ok(Outcome::AppSetLiveDeploy(LiveDeploymentSet {
+    Ok(Outcome::LiveDeploymentSet(LiveDeploymentSet {
         deployment_id,
         activity_id: result.activity_id,
         activity_status: result.status,

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     client::build_client,
+    commands::Run,
     config::turnkey::Config,
     errors::MissingResource,
     local_operator_key::LocalOperatorSeedSource,
@@ -129,6 +130,16 @@ pub enum ApproveOutcome {
     DryRun(ApprovalDryRun),
 }
 
+impl From<ApproveOutcome> for Outcome {
+    fn from(outcome: ApproveOutcome) -> Self {
+        match outcome {
+            ApproveOutcome::Posted(msg) => Outcome::ManifestApprovalPosted(msg),
+            ApproveOutcome::NotPosted(msg) => Outcome::ManifestApprovalGenerated(msg),
+            ApproveOutcome::DryRun(msg) => Outcome::ManifestApprovalDryRun(msg),
+        }
+    }
+}
+
 impl Serialize for ApproveOutcome {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -231,6 +242,23 @@ impl Display for ApprovalGenerated {
 }
 
 #[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalAlreadyPosted {
+    operator_id: String,
+    approval_id: String,
+}
+
+impl Display for ApprovalAlreadyPosted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Operator {} has already approved this manifest (approval ID: {}). Nothing to post.",
+            self.operator_id, self.approval_id
+        )
+    }
+}
+
+#[derive(Default, Serialize)]
 pub struct ApprovalDryRun {}
 
 impl Display for ApprovalDryRun {
@@ -254,20 +282,23 @@ struct ResolvedApproveInputs {
     post_target: Option<PostTarget>,
 }
 
-pub async fn run(ctx: &mut StdCtx, mut args: Args) -> anyhow::Result<Outcome> {
-    let operator_seed_source = LocalOperatorSeedSource::from_args(
-        args.operator_seed.take(),
-        args.operator_seed_path.take(),
-    )?;
+impl Run for Args {
+    type Outcome = ApproveOutcome;
 
-    let inputs = if ctx.is_non_interactive() {
-        build_inputs_non_interactive(ctx, args, operator_seed_source).await?
-    } else {
-        build_inputs_interactive(ctx, args, operator_seed_source).await?
-    };
+    async fn run(mut self, ctx: &mut StdCtx) -> anyhow::Result<Self::Outcome> {
+        let operator_seed_source = LocalOperatorSeedSource::from_args(
+            self.operator_seed.take(),
+            self.operator_seed_path.take(),
+        )?;
 
-    let outcome = run_with_resolved_inputs(ctx, inputs).await?;
-    Ok(Outcome::DeployApprove(outcome))
+        let inputs = if ctx.is_non_interactive() {
+            build_inputs_non_interactive(ctx, self, operator_seed_source).await?
+        } else {
+            build_inputs_interactive(ctx, self, operator_seed_source).await?
+        };
+
+        run_with_resolved_inputs(ctx, inputs).await
+    }
 }
 
 async fn build_inputs_interactive(
@@ -756,7 +787,6 @@ async fn fetch_manifest_from_deploy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::Message;
     use turnkey_client::generated::external::data::v1::{
         TvcOperator, TvcOperatorApproval, TvcOperatorSet,
     };
@@ -929,10 +959,8 @@ mod tests {
 
     #[test]
     fn approval_posted_serializes_expected_json() {
-        let value: serde_json::Value = serde_json::from_str(
-            &Outcome::DeployApprove(ApproveOutcome::Posted(posted_to_file())).to_json_string(),
-        )
-        .unwrap();
+        let value =
+            serde_json::to_value(Outcome::from(ApproveOutcome::Posted(posted_to_file()))).unwrap();
 
         assert_eq!(
             value,
@@ -960,10 +988,8 @@ mod tests {
             written_to: None,
         };
 
-        let value: serde_json::Value = serde_json::from_str(
-            &Outcome::DeployApprove(ApproveOutcome::NotPosted(generated)).to_json_string(),
-        )
-        .unwrap();
+        let value =
+            serde_json::to_value(Outcome::from(ApproveOutcome::NotPosted(generated))).unwrap();
 
         assert_eq!(
             value,
@@ -982,10 +1008,8 @@ mod tests {
 
     #[test]
     fn approval_dry_run_serializes_reason_only() {
-        let value: serde_json::Value = serde_json::from_str(
-            &Outcome::DeployApprove(ApproveOutcome::DryRun(ApprovalDryRun {})).to_json_string(),
-        )
-        .unwrap();
+        let value =
+            serde_json::to_value(Outcome::from(ApproveOutcome::DryRun(ApprovalDryRun {}))).unwrap();
 
         assert_eq!(
             value,

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -438,7 +438,7 @@ async fn run_with_resolved_inputs(
         .await
         .context("failed to create TVC deployment")?;
 
-    Ok(Outcome::DeployCreate(DeploymentCreated {
+    Ok(Outcome::DeploymentCreated(DeploymentCreated {
         deployment_id: result.result.deployment_id,
         app_id: deploy_config.app_id,
         pinned_image_url,

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -231,9 +231,9 @@ pub(crate) struct DebugLogLine {
 }
 
 impl Display for DebugLogLine {
+    /// Rebuild the API line and defer to [`format_log_line`] so human output
+    /// stays byte-identical to the pre-outcome rendering.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // Rebuild the API line and defer to `format_log_line` so human output
-        // stays byte-identical to the pre-outcome rendering.
         let line = LogLine {
             content: self.content.clone(),
             ts: self.ts.as_ref().map(|ts| Timestamp {

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::app_status::TimestampPayload;
 use crate::outcome::Outcome;
-use crate::output::{Ctx, Message, StdCtx};
+use crate::output::{Ctx, StdCtx};
 use crate::shell_eprintln;
 use anyhow::Context;
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -200,7 +200,7 @@ async fn query_debug_logs(
     // In poll mode the loop below runs until killed (or errors), so the
     // terminal outcome is only reachable in non-poll mode.
     let Some(poll_request) = poll_request else {
-        return Ok(Outcome::DeployDebugLogs(DebugLogsFetched {
+        return Ok(Outcome::DebugLogsFetched(DebugLogsFetched {
             deployment_id,
             line_count,
         }));
@@ -217,9 +217,10 @@ async fn query_debug_logs(
 }
 
 /// One streamed log line (NDJSON in JSON mode; the formatted line in human
-/// mode). Emitted inline by `deploy debug-logs`, not part of `Outcome`.
+/// mode). Emitted inline by `deploy debug-logs`, not part of `Outcome`, so it
+/// carries its own `reason` via the struct-level serde tag.
 #[derive(Default, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "reason", rename = "debug_log_line", rename_all = "camelCase")]
 pub(crate) struct DebugLogLine {
     replica: String,
     content: String,
@@ -229,12 +230,8 @@ pub(crate) struct DebugLogLine {
     include_platform_timestamp: bool,
 }
 
-impl Message for DebugLogLine {
-    fn reason(&self) -> &'static str {
-        "debug_log_line"
-    }
-
-    fn human_message(&self) -> String {
+impl Display for DebugLogLine {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // Rebuild the API line and defer to `format_log_line` so human output
         // stays byte-identical to the pre-outcome rendering.
         let line = LogLine {
@@ -244,7 +241,12 @@ impl Message for DebugLogLine {
                 nanos: ts.nanos.clone(),
             }),
         };
-        format_log_line(&self.replica, &line, self.include_platform_timestamp)
+
+        f.write_str(&format_log_line(
+            &self.replica,
+            &line,
+            self.include_platform_timestamp,
+        ))
     }
 }
 
@@ -660,8 +662,7 @@ mod tests {
 
     #[test]
     fn debug_log_line_serializes_snake_case_reason() {
-        let value: serde_json::Value =
-            serde_json::from_str(&sample_debug_log_line().to_json_string()).unwrap();
+        let value = serde_json::to_value(sample_debug_log_line()).unwrap();
 
         assert_eq!(
             value,
@@ -678,13 +679,13 @@ mod tests {
     }
 
     #[test]
-    fn debug_log_line_human_message_matches_previous_rendering() {
+    fn debug_log_line_human_rendering_matches_previous_rendering() {
         let mut line = sample_debug_log_line();
-        assert_eq!(line.human_message(), "replica 1/2 hello");
+        assert_eq!(line.to_string(), "replica 1/2 hello");
 
         line.include_platform_timestamp = true;
         assert_eq!(
-            line.human_message(),
+            line.to_string(),
             "2024-03-09T16:00:00.123456789Z replica 1/2 hello"
         );
     }

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .await
         .context("failed to delete TVC deployment")?;
 
-    Ok(Outcome::DeployDelete(DeploymentDeleted {
+    Ok(Outcome::DeploymentDeleted(DeploymentDeleted {
         deployment_id: result.result.deployment_id,
         activity_id: result.activity_id,
         activity_status: result.status,

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -60,7 +60,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
 
     let deployment_status = find_deployment_status(&app_status, &deployment_id);
 
-    Ok(Outcome::DeployGetStatus(DeploymentRuntimeStatus {
+    Ok(Outcome::DeploymentRuntimeStatus(DeploymentRuntimeStatus {
         deployment_id: deployment.id,
         app_id: app_status.app_id.clone(),
         egress_enabled: app.enable_egress,

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -119,7 +119,7 @@ async fn execute(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     std::fs::write(&output, json)
         .with_context(|| format!("failed to write file: {}", output.display()))?;
 
-    Ok(Outcome::DeployInit(DeploymentConfigCreated {
+    Ok(Outcome::DeploymentConfigCreated(DeploymentConfigCreated {
         command: "deploy init",
         path: output.display().to_string(),
         template: !is_interactive,

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -48,7 +48,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         .await
         .context("failed to post quorum key share")?;
 
-    Ok(Outcome::DeployPostShare(QuorumKeySharePosted {
+    Ok(Outcome::QuorumKeySharePosted(QuorumKeySharePosted {
         provisioning_share_id: result.result.provisioning_share_id,
     }))
 }

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -109,7 +109,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .map_err(|error| hosted_activity_error("re-encrypt hosted TVC quorum-key share", error))?;
     let output = validate_result(result.result)?;
 
-    Ok(Outcome::DeployProvision(output))
+    Ok(Outcome::ProvisioningShareCreated(output))
 }
 
 fn build_re_encrypt_intent(
@@ -179,11 +179,8 @@ fn validate_result(result: ReEncryptTvcQuorumKeyShareResult) -> Result<Provision
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        config::turnkey::{
-            HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
-        },
-        output::Message,
+    use crate::config::turnkey::{
+        HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
     };
     use qos_core::protocol::services::boot::VersionedManifestEnvelope;
     use serde::Deserialize;
@@ -476,8 +473,7 @@ mod tests {
             "Provisioning Share ID: provisioning-share-id"
         );
 
-        let value: serde_json::Value =
-            serde_json::from_str(&Outcome::DeployProvision(output).to_json_string()).unwrap();
+        let value = serde_json::to_value(Outcome::ProvisioningShareCreated(output)).unwrap();
         assert_eq!(
             value,
             serde_json::json!({

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -93,7 +93,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         "verified (attestation + approvals)"
     };
 
-    Ok(Outcome::DeployProvisioningDetails(
+    Ok(Outcome::ProvisioningDetails(
         ProvisioningDetails::from_summary(
             deployment_id.to_string(),
             verification_status,

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         .await
         .context("failed to restore TVC deployment")?;
 
-    Ok(Outcome::DeployRestore(DeploymentRestored {
+    Ok(Outcome::DeploymentRestored(DeploymentRestored {
         deployment_id: result.result.deployment_id,
         activity_id: result.activity_id,
         activity_status: result.status,

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -66,7 +66,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         manifest.ok_or_else(|| MissingResource::new("manifest", format!("deployment {id}")))?;
     let app = fetch_tvc_app(&auth, &app_id).await?;
 
-    Ok(Outcome::DeployStatus(DeploymentStatusReport {
+    Ok(Outcome::DeploymentStatus(DeploymentStatusReport {
         deployment_id: id,
         app_id,
         egress_enabled: app.enable_egress,

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -142,7 +142,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         .map_err(|error| hosted_activity_error("create hosted TVC quorum key", error))?;
     let output = validate_result(result.result, expected_share_count)?;
 
-    Ok(Outcome::KeysCreateQuorumKey(output))
+    Ok(Outcome::QuorumKeyCreated(output))
 }
 
 fn parse_operator_id(value: &str) -> std::result::Result<Uuid, String> {

--- a/tvc/src/commands/keys/generate_local_quorum_key.rs
+++ b/tvc/src/commands/keys/generate_local_quorum_key.rs
@@ -67,7 +67,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         )
     })?;
 
-    Ok(Outcome::KeysGenerateQuorumKey(QuorumKeyGenerated {
+    Ok(Outcome::QuorumKeyGenerated(QuorumKeyGenerated {
         quorum_key_public,
         threshold: config.threshold,
         metadata_path: args.quorum_key_metadata_out.display().to_string(),

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     std::fs::write(&args.output, json)
         .with_context(|| format!("failed to write file: {}", args.output.display()))?;
 
-    Ok(Outcome::KeysInitQuorumKey(QuorumKeyConfigCreated {
+    Ok(Outcome::QuorumKeyConfigCreated(QuorumKeyConfigCreated {
         path: args.output.display().to_string(),
     }))
 }

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -230,7 +230,7 @@ async fn write_output(
         }
     };
 
-    Ok(Outcome::KeysReEncryptShare(generated))
+    Ok(Outcome::ReEncryptedShareGenerated(generated))
 }
 
 #[cfg(test)]
@@ -240,7 +240,7 @@ mod tests {
         ensure_quorum_key_matches_manifest, find_share_set_member,
     };
     use crate::outcome::Outcome;
-    use crate::output::Message;
+
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
     use crate::quorum_key_metadata::{EncryptedShareMetadata, QuorumKeyMetadata};
@@ -563,9 +563,8 @@ mod tests {
 
     #[test]
     fn inline_branch_serializes_flattened_share_payload() {
-        let value: serde_json::Value =
-            serde_json::from_str(&Outcome::KeysReEncryptShare(generated_inline()).to_json_string())
-                .unwrap();
+        let value =
+            serde_json::to_value(Outcome::ReEncryptedShareGenerated(generated_inline())).unwrap();
 
         assert_eq!(
             value,
@@ -587,10 +586,9 @@ mod tests {
 
     #[test]
     fn file_branch_serializes_written_to_path() {
-        let value: serde_json::Value = serde_json::from_str(
-            &Outcome::KeysReEncryptShare(generated_written_to()).to_json_string(),
-        )
-        .unwrap();
+        let value =
+            serde_json::to_value(Outcome::ReEncryptedShareGenerated(generated_written_to()))
+                .unwrap();
 
         assert_eq!(
             value,

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -220,7 +220,7 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<Outcome> {
     // can't tell whether it is still there, so hedge with "may" and give steps.
     let dashboard_url = dashboard_base_url(&removed.api_base_url);
 
-    Ok(Outcome::ProfileDelete(ProfileDeleted {
+    Ok(Outcome::ProfileDeleted(ProfileDeleted {
         alias,
         organization_id: removed.id,
         removed_key_directory: removed_dir.map(|dir| dir.display().to_string()),
@@ -368,7 +368,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         .display()
         .to_string();
 
-    Ok(Outcome::Login(LoggedIn {
+    Ok(Outcome::LoggedIn(LoggedIn {
         organization_name: whoami.organization_name,
         organization_id: whoami.organization_id,
         username: whoami.username,

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -1,8 +1,11 @@
 //! CLI commands.
 //!
-//! Each command module should contain:
-//! - An `Args` struct deriving `clap::Args`
-//! - A `run(args, config) -> anyhow::Result<()>` function
+//! Each command module contains an `Args` struct deriving `clap::Args` and
+//! either a `run(ctx, args) -> anyhow::Result<Outcome>` function (legacy) or
+//! an implementation of [`Run`] (the target shape; `deploy approve` is the
+//! pilot).
+
+use crate::{outcome, output::StdCtx};
 
 pub mod app;
 pub mod app_status;
@@ -13,3 +16,14 @@ pub mod keys;
 pub mod login;
 pub mod operator;
 pub mod version;
+
+/// A command: consumes its parsed `Args`, returns its typed terminal outcome.
+///
+/// The associated `Outcome` is a command-local type; `Into<outcome::Outcome>`
+/// is the whole contract, since serialization (including the `reason` tag) and
+/// human rendering both live on the top-level [`outcome::Outcome`].
+pub trait Run {
+    type Outcome: Into<outcome::Outcome>;
+
+    fn run(self, ctx: &mut StdCtx) -> impl Future<Output = anyhow::Result<Self::Outcome>> + Send;
+}

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -134,7 +134,7 @@ Do not retry creation blindly; doing so would create another remote operator. Re
         ));
     }
 
-    Ok(Outcome::OperatorCreate(output))
+    Ok(Outcome::OperatorCreated(output))
 }
 
 fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
@@ -180,7 +180,6 @@ fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
 mod tests {
     use super::*;
     use crate::config::turnkey::HostedOperatorRecord;
-    use crate::output::Message;
 
     fn hosted_record() -> OperatorRecord {
         OperatorRecord {
@@ -217,8 +216,7 @@ mod tests {
     #[test]
     fn operator_created_serializes_expected_json() {
         let output = output_from_record(hosted_record()).unwrap();
-        let value: serde_json::Value =
-            serde_json::from_str(&Outcome::OperatorCreate(output).to_json_string()).unwrap();
+        let value = serde_json::to_value(Outcome::OperatorCreated(output)).unwrap();
 
         assert_eq!(
             value,

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -50,6 +50,7 @@ pub enum ErrorCode {
     MissingRequiredInput,
     /// Bad flags/args — a clap parse failure
     UsageError,
+    #[allow(dead_code)]
     /// Semantic validation failure in command code.
     InvalidInput,
     /// HTTP 401/403.
@@ -103,7 +104,7 @@ pub fn classify(error: &anyhow::Error) -> Classification {
 ///
 /// Every source link is preserved, even when a parent error's `Display`
 /// already embeds the source text.
-pub fn render_error_chain(error: &anyhow::Error) -> String {
+pub(crate) fn render_error_chain(error: &anyhow::Error) -> String {
     let mut rendered = String::new();
     for cause in error.chain() {
         let text = cause.to_string();

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -11,7 +11,7 @@ pub mod cli;
 pub mod client;
 pub mod commands;
 pub mod config;
-pub mod errors;
+pub(crate) mod errors;
 pub(crate) mod local_operator_key;
 pub mod logging;
 pub mod operator;

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -1,212 +1,140 @@
 //! The closed vocabulary of command outcomes.
 //!
-//! `Outcome` has exactly one variant per command, named after the command.
-//! Per-command message structs live in their own command modules; this
-//! enum only aggregates and delegates. A command with multiple terminal shapes
-//! (e.g. `deploy approve`) owns a command-local enum in its own module, and
-//! the top-level variant here wraps it.
+//! `Outcome` has exactly one variant per terminal shape, and the variant name
+//! IS the wire `reason`: serde's internal tagging stamps
+//! `"reason": "<variant_in_snake_case>"` onto every serialized outcome, so
+//! the vocabulary cannot drift from the type and two shapes cannot share a
+//! reason without rustc rejecting the duplicate variant name. Do not add
+//! per-variant `#[serde(rename)]` overrides — that equality is the guarantee.
 //!
-//! `reason` strings are stable snake_case discriminators
+//! Payload structs live in their own command modules. A command with multiple
+//! terminal shapes (e.g. `deploy approve`) owns a command-local enum plus a
+//! `From` impl mapping it onto these variants.
+//!
+//! `reason` strings are stable snake_case discriminators; renaming a variant
+//! is a breaking change to the JSON contract.
 
-use crate::commands::deploy::approve::ApproveOutcome;
+use crate::commands::deploy::approve::{
+    ApprovalAlreadyPosted, ApprovalDryRun, ApprovalGenerated, ApprovalPosted,
+};
 use crate::commands::{app, deploy, keys, login, operator, version};
-use crate::output::Message;
-use serde::{Serialize, Serializer};
+use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
 
-/// One wide terminal outcome per command (the wide-event model).
+/// One wide terminal outcome per command invocation (the wide-event model).
 ///
 /// Streaming messages (today: only `deploy debug-logs`'s per-line
 /// `debug_log_line`) are emitted inline by their command and are not part of
 /// this enum; the command still returns its terminal variant.
+#[derive(Serialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+#[cfg_attr(test, derive(strum::EnumIter))]
 pub enum Outcome {
-    Login(login::LoggedIn),
-    OperatorCreate(operator::create::OperatorCreated),
-    ProfileDelete(login::ProfileDeleted),
-    DeployApprove(ApproveOutcome),
-    DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus),
-    DeployProvisioningDetails(deploy::provisioning_details::ProvisioningDetails),
-    DeployProvision(deploy::provision::ProvisioningShareCreated),
-    DeployPostShare(deploy::post_share::QuorumKeySharePosted),
-    DeployStatus(deploy::status::DeploymentStatusReport),
-    DeployCreate(deploy::create::DeploymentCreated),
-    DeployInit(deploy::init::DeploymentConfigCreated),
-    DeployDebugLogs(deploy::debug_logs::DebugLogsFetched),
-    DeployDelete(deploy::delete::DeploymentDeleted),
-    DeployRestore(deploy::restore::DeploymentRestored),
+    LoggedIn(login::LoggedIn),
+    OperatorCreated(operator::create::OperatorCreated),
+    ProfileDeleted(login::ProfileDeleted),
+    ManifestApprovalPosted(ApprovalPosted),
+    ManifestApprovalGenerated(ApprovalGenerated),
+    ManifestApprovalAlreadyPosted(ApprovalAlreadyPosted),
+    ManifestApprovalDryRun(ApprovalDryRun),
+    DeploymentRuntimeStatus(deploy::get_status::DeploymentRuntimeStatus),
+    ProvisioningDetails(deploy::provisioning_details::ProvisioningDetails),
+    ProvisioningShareCreated(deploy::provision::ProvisioningShareCreated),
+    QuorumKeySharePosted(deploy::post_share::QuorumKeySharePosted),
+    DeploymentStatus(deploy::status::DeploymentStatusReport),
+    DeploymentCreated(deploy::create::DeploymentCreated),
+    DeploymentConfigCreated(deploy::init::DeploymentConfigCreated),
+    DebugLogsFetched(deploy::debug_logs::DebugLogsFetched),
+    DeploymentDeleted(deploy::delete::DeploymentDeleted),
+    DeploymentRestored(deploy::restore::DeploymentRestored),
     AppStatus(app::status::AppStatusReport),
-    AppList(app::list::AppsListed),
-    AppCreate(app::create::AppCreated),
-    AppInit(app::init::AppConfigCreated),
-    AppSetLiveDeploy(app::set_live_deploy::LiveDeploymentSet),
-    AppDelete(app::delete::AppDeleted),
-    KeysCreateQuorumKey(keys::create_quorum_key::QuorumKeyCreated),
-    KeysGenerateQuorumKey(keys::generate_local_quorum_key::QuorumKeyGenerated),
-    KeysInitQuorumKey(keys::init_local_quorum_key::QuorumKeyConfigCreated),
-    KeysReEncryptShare(keys::re_encrypt_local_share::ReEncryptedShareGenerated),
+    AppsListed(app::list::AppsListed),
+    AppCreated(app::create::AppCreated),
+    AppConfigCreated(app::init::AppConfigCreated),
+    LiveDeploymentSet(app::set_live_deploy::LiveDeploymentSet),
+    AppDeleted(app::delete::AppDeleted),
+    QuorumKeyCreated(keys::create_quorum_key::QuorumKeyCreated),
+    QuorumKeyGenerated(keys::generate_local_quorum_key::QuorumKeyGenerated),
+    QuorumKeyConfigCreated(keys::init_local_quorum_key::QuorumKeyConfigCreated),
+    ReEncryptedShareGenerated(keys::re_encrypt_local_share::ReEncryptedShareGenerated),
     Version(version::CliVersion),
 }
 
-/// Apply `$body` to the message carried by whichever variant `$self` is.
-macro_rules! with_message {
-    ($self:expr, |$msg:ident| $body:expr) => {
-        match $self {
-            Outcome::Login($msg) => $body,
-            Outcome::OperatorCreate($msg) => $body,
-            Outcome::ProfileDelete($msg) => $body,
-            Outcome::DeployApprove($msg) => $body,
-            Outcome::DeployGetStatus($msg) => $body,
-            Outcome::DeployProvisioningDetails($msg) => $body,
-            Outcome::DeployProvision($msg) => $body,
-            Outcome::DeployPostShare($msg) => $body,
-            Outcome::DeployStatus($msg) => $body,
-            Outcome::DeployCreate($msg) => $body,
-            Outcome::DeployInit($msg) => $body,
-            Outcome::DeployDebugLogs($msg) => $body,
-            Outcome::DeployDelete($msg) => $body,
-            Outcome::DeployRestore($msg) => $body,
-            Outcome::AppStatus($msg) => $body,
-            Outcome::AppList($msg) => $body,
-            Outcome::AppCreate($msg) => $body,
-            Outcome::AppInit($msg) => $body,
-            Outcome::AppSetLiveDeploy($msg) => $body,
-            Outcome::AppDelete($msg) => $body,
-            Outcome::KeysCreateQuorumKey($msg) => $body,
-            Outcome::KeysGenerateQuorumKey($msg) => $body,
-            Outcome::KeysInitQuorumKey($msg) => $body,
-            Outcome::KeysReEncryptShare($msg) => $body,
-            Outcome::Version($msg) => $body,
-        }
-    };
-}
-
-impl Serialize for Outcome {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        with_message!(self, |msg| msg.serialize(serializer))
-    }
-}
-
-impl Message for Outcome {
-    /// The single source of truth for the reason vocabulary. Every terminal
-    /// reason string is a literal in  this one match, so uniqueness is auditable
-    /// at a glance (and, in a follow-up, enforceable by a proc-macro).
-    fn reason(&self) -> &'static str {
+impl Display for Outcome {
+    /// Each payload renders itself; the terminal outcome just delegates. An
+    /// empty rendering means the outcome is machine-only.
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Outcome::Login(_) => "logged_in",
-            Outcome::OperatorCreate(_) => "operator_created",
-            Outcome::ProfileDelete(_) => "profile_deleted",
-            Outcome::DeployApprove(ApproveOutcome::Posted(_)) => "manifest_approval_posted",
-            Outcome::DeployApprove(ApproveOutcome::NotPosted(_)) => "manifest_approval_generated",
-            Outcome::DeployApprove(ApproveOutcome::DryRun(_)) => "manifest_approval_dry_run",
-            Outcome::DeployGetStatus(_) => "deployment_runtime_status",
-            Outcome::DeployProvisioningDetails(_) => "provisioning_details",
-            Outcome::DeployProvision(_) => "provisioning_share_created",
-            Outcome::DeployPostShare(_) => "quorum_key_share_posted",
-            Outcome::DeployStatus(_) => "deployment_status",
-            Outcome::DeployCreate(_) => "deployment_created",
-            Outcome::DeployInit(_) => "deployment_config_created",
-            Outcome::DeployDebugLogs(_) => "debug_logs_fetched",
-            Outcome::DeployDelete(_) => "deployment_deleted",
-            Outcome::DeployRestore(_) => "deployment_restored",
-            Outcome::AppStatus(_) => "app_status",
-            Outcome::AppList(_) => "apps_listed",
-            Outcome::AppCreate(_) => "app_created",
-            Outcome::AppInit(_) => "app_config_created",
-            Outcome::AppSetLiveDeploy(_) => "live_deployment_set",
-            Outcome::AppDelete(_) => "app_deleted",
-            Outcome::KeysCreateQuorumKey(_) => "quorum_key_created",
-            Outcome::KeysGenerateQuorumKey(_) => "quorum_key_generated",
-            Outcome::KeysInitQuorumKey(_) => "quorum_key_config_created",
-            Outcome::KeysReEncryptShare(_) => "re_encrypted_share_generated",
-            Outcome::Version(_) => "version",
+            Outcome::LoggedIn(msg) => msg.fmt(f),
+            Outcome::OperatorCreated(msg) => msg.fmt(f),
+            Outcome::ProfileDeleted(msg) => msg.fmt(f),
+            Outcome::ManifestApprovalPosted(msg) => msg.fmt(f),
+            Outcome::ManifestApprovalGenerated(msg) => msg.fmt(f),
+            Outcome::ManifestApprovalAlreadyPosted(msg) => msg.fmt(f),
+            Outcome::ManifestApprovalDryRun(msg) => msg.fmt(f),
+            Outcome::DeploymentRuntimeStatus(msg) => msg.fmt(f),
+            Outcome::ProvisioningDetails(msg) => msg.fmt(f),
+            Outcome::ProvisioningShareCreated(msg) => msg.fmt(f),
+            Outcome::QuorumKeySharePosted(msg) => msg.fmt(f),
+            Outcome::DeploymentStatus(msg) => msg.fmt(f),
+            Outcome::DeploymentCreated(msg) => msg.fmt(f),
+            Outcome::DeploymentConfigCreated(msg) => msg.fmt(f),
+            Outcome::DebugLogsFetched(msg) => msg.fmt(f),
+            Outcome::DeploymentDeleted(msg) => msg.fmt(f),
+            Outcome::DeploymentRestored(msg) => msg.fmt(f),
+            Outcome::AppStatus(msg) => msg.fmt(f),
+            Outcome::AppsListed(msg) => msg.fmt(f),
+            Outcome::AppCreated(msg) => msg.fmt(f),
+            Outcome::AppConfigCreated(msg) => msg.fmt(f),
+            Outcome::LiveDeploymentSet(msg) => msg.fmt(f),
+            Outcome::AppDeleted(msg) => msg.fmt(f),
+            Outcome::QuorumKeyCreated(msg) => msg.fmt(f),
+            Outcome::QuorumKeyGenerated(msg) => msg.fmt(f),
+            Outcome::QuorumKeyConfigCreated(msg) => msg.fmt(f),
+            Outcome::ReEncryptedShareGenerated(msg) => msg.fmt(f),
+            Outcome::Version(msg) => msg.fmt(f),
         }
-    }
-
-    fn human_message(&self) -> String {
-        // Each inner payload renders itself via `Display`; the terminal outcome
-        // just delegates. An empty rendering means the outcome is machine-only.
-        with_message!(self, |msg| msg.to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::deploy::approve::{
-        ApprovalDryRun, ApprovalGenerated, ApprovalPosted, ApproveOutcome,
-    };
-    use std::collections::HashSet;
-
-    /// One zero-value instance per terminal shape, in `Outcome`'s declaration
-    /// order (command-local shapes expanded in their own declaration order).
-    /// The registry tests only read reason strings, so `Default` fixtures
-    /// suffice; realistic payloads are exercised by each command's own tests.
-    fn all_terminal_shapes() -> Vec<Outcome> {
-        vec![
-            Outcome::Login(login::LoggedIn::default()),
-            Outcome::OperatorCreate(operator::create::OperatorCreated::default()),
-            Outcome::ProfileDelete(login::ProfileDeleted::default()),
-            Outcome::DeployApprove(ApproveOutcome::Posted(ApprovalPosted::default())),
-            Outcome::DeployApprove(ApproveOutcome::NotPosted(ApprovalGenerated::default())),
-            Outcome::DeployApprove(ApproveOutcome::DryRun(ApprovalDryRun::default())),
-            Outcome::DeployGetStatus(deploy::get_status::DeploymentRuntimeStatus::default()),
-            Outcome::DeployProvisioningDetails(
-                deploy::provisioning_details::ProvisioningDetails::default(),
-            ),
-            Outcome::DeployProvision(deploy::provision::ProvisioningShareCreated::default()),
-            Outcome::DeployPostShare(deploy::post_share::QuorumKeySharePosted::default()),
-            Outcome::DeployStatus(deploy::status::DeploymentStatusReport::default()),
-            Outcome::DeployCreate(deploy::create::DeploymentCreated::default()),
-            Outcome::DeployInit(deploy::init::DeploymentConfigCreated::default()),
-            Outcome::DeployDebugLogs(deploy::debug_logs::DebugLogsFetched::default()),
-            Outcome::DeployDelete(deploy::delete::DeploymentDeleted::default()),
-            Outcome::DeployRestore(deploy::restore::DeploymentRestored::default()),
-            Outcome::AppStatus(app::status::AppStatusReport::default()),
-            Outcome::AppList(app::list::AppsListed::default()),
-            Outcome::AppCreate(app::create::AppCreated::default()),
-            Outcome::AppInit(app::init::AppConfigCreated::default()),
-            Outcome::AppSetLiveDeploy(app::set_live_deploy::LiveDeploymentSet::default()),
-            Outcome::AppDelete(app::delete::AppDeleted::default()),
-            Outcome::KeysCreateQuorumKey(keys::create_quorum_key::QuorumKeyCreated::default()),
-            Outcome::KeysGenerateQuorumKey(
-                keys::generate_local_quorum_key::QuorumKeyGenerated::default(),
-            ),
-            Outcome::KeysInitQuorumKey(
-                keys::init_local_quorum_key::QuorumKeyConfigCreated::default(),
-            ),
-            Outcome::KeysReEncryptShare(
-                keys::re_encrypt_local_share::ReEncryptedShareGenerated::default(),
-            ),
-            Outcome::Version(version::CliVersion::default()),
-        ]
-    }
+    use strum::IntoEnumIterator;
 
     /// Reasons that live outside `Outcome`: the `deploy debug-logs` streaming
-    /// message and the error envelope reasons
+    /// message and the error envelope reasons.
     const NON_TERMINAL_REASONS: [&str; 3] =
         ["debug_log_line", "command_error", "missing_required_input"];
 
-    fn all_reasons() -> Vec<&'static str> {
-        let mut reasons: Vec<&str> = all_terminal_shapes().iter().map(Message::reason).collect();
-        reasons.extend(NON_TERMINAL_REASONS);
-        reasons
-    }
-
     // TODO - proc macro here
     #[test]
-    fn all_reasons_are_unique() {
-        let reasons = all_reasons();
+    fn terminal_reasons_do_not_collide_with_non_terminal_reasons() {
+        for outcome in Outcome::iter() {
+            let value = serde_json::to_value(&outcome)
+                .expect("every outcome payload must serialize as a JSON map");
+            let reason = value["reason"]
+                .as_str()
+                .expect("every serialized outcome must carry a `reason` tag");
 
-        let unique: HashSet<&str> = reasons.iter().copied().collect();
-        assert_eq!(
-            unique.len(),
-            reasons.len(),
-            "duplicate reason strings in: {reasons:?}"
-        );
+            assert!(
+                !NON_TERMINAL_REASONS.contains(&reason),
+                "terminal reason `{reason}` collides with a non-terminal reason"
+            );
+        }
     }
 
     #[test]
     fn reasons_are_snake_case() {
-        for reason in all_reasons() {
+        let terminal_reasons = Outcome::iter().map(|outcome| {
+            serde_json::to_value(outcome)
+                .expect("every outcome payload must serialize as a JSON map")["reason"]
+                .as_str()
+                .expect("every serialized outcome must carry a `reason` tag")
+                .to_string()
+        });
+
+        for reason in terminal_reasons.chain(NON_TERMINAL_REASONS.map(String::from)) {
             assert!(
                 !reason.is_empty()
                     && reason.split('_').all(|word| {

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -28,27 +28,6 @@ pub enum ColorChoice {
     Never,
 }
 
-pub trait Message: Serialize {
-    fn reason(&self) -> &'static str;
-
-    fn human_message(&self) -> String;
-
-    fn to_json_string(&self) -> String {
-        #[derive(Serialize)]
-        struct WithReason<'a, S: Serialize + ?Sized> {
-            reason: &'a str,
-            #[serde(flatten)]
-            msg: &'a S,
-        }
-
-        serde_json::to_string(&WithReason {
-            reason: self.reason(),
-            msg: self,
-        })
-        .expect("serializing TVC output message should not fail")
-    }
-}
-
 pub struct Shell<Out = Stdout, Err = Stderr> {
     stdout: Out,
     stderr: Err,
@@ -94,22 +73,27 @@ impl<W, W2> Shell<W, W2> {
 }
 
 impl<W: Write, W2: Write> Shell<W, W2> {
-    /// Emit a machine-consumable message: one JSON line in JSON mode, or the
-    /// message's `human_message()` in human mode.
+    /// Emit a machine-consumable message: one JSON line in JSON mode, or its
+    /// `Display` rendering in human mode.
     ///
-    /// An empty `human_message()` means the outcome is machine-only; human
-    /// mode prints nothing (JSON mode still emits the message).
-    pub fn emit<M: Message>(&mut self, message: &M) -> Result<()> {
+    /// An empty rendering means the message is machine-only; human mode
+    /// prints nothing (JSON mode still emits the message). Every message
+    /// carries its own `reason` discriminator in its serialized form —
+    /// `Outcome` via its serde tag, everything else as a field or
+    /// struct-level tag.
+    pub fn emit<M: Serialize + Display>(&mut self, message: &M) -> Result<()> {
         match self.message_format {
             MessageFormat::Human => {
-                let text = message.human_message();
+                let text = message.to_string();
+
                 if text.is_empty() {
                     return Ok(());
                 }
+
                 self.human().line(text)
             }
             MessageFormat::Json => {
-                writeln!(self.stdout, "{}", message.to_json_string())?;
+                writeln!(self.stdout, "{}", serde_json::to_string(message)?)?;
                 Ok(())
             }
         }
@@ -282,7 +266,6 @@ impl Error for MissingRequiredInput {}
 
 #[derive(Serialize)]
 pub struct ErrorMessage {
-    #[serde(skip)]
     reason: &'static str,
     code: ErrorCode,
     #[serde(rename = "httpStatus", skip_serializing_if = "Option::is_none")]
@@ -333,13 +316,9 @@ impl ErrorMessage {
     }
 }
 
-impl Message for ErrorMessage {
-    fn reason(&self) -> &'static str {
-        self.reason
-    }
-
-    fn human_message(&self) -> String {
-        self.message.clone()
+impl Display for ErrorMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
     }
 }
 
@@ -392,22 +371,19 @@ mod tests {
     }
 
     #[derive(Serialize)]
+    #[serde(tag = "reason", rename = "test_message")]
     struct TestMessage {
         value: &'static str,
     }
 
-    impl Message for TestMessage {
-        fn reason(&self) -> &'static str {
-            "test_message"
-        }
-
-        fn human_message(&self) -> String {
-            format!("value: {}", self.value)
+    impl Display for TestMessage {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write!(f, "value: {}", self.value)
         }
     }
 
     #[test]
-    fn shell_emit_json_flattens_reason_into_message() {
+    fn shell_emit_json_writes_one_self_tagged_line() {
         let mut shell = TestShell::with_json_formatter();
 
         shell.emit(&TestMessage { value: "ok" }).unwrap();
@@ -419,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn shell_emit_human_uses_human_message() {
+    fn shell_emit_human_uses_display() {
         let mut shell = TestShell::with_human_formatter();
 
         shell.emit(&TestMessage { value: "ok" }).unwrap();
@@ -432,18 +408,14 @@ mod tests {
         value: &'static str,
     }
 
-    impl Message for MachineOnlyMessage {
-        fn reason(&self) -> &'static str {
-            "machine_only_message"
-        }
-
-        fn human_message(&self) -> String {
-            String::new()
+    impl Display for MachineOnlyMessage {
+        fn fmt(&self, _: &mut Formatter<'_>) -> fmt::Result {
+            Ok(())
         }
     }
 
     #[test]
-    fn shell_emit_human_skips_empty_human_message() {
+    fn shell_emit_human_skips_empty_rendering() {
         let mut shell = TestShell::with_human_formatter();
 
         shell.emit(&MachineOnlyMessage { value: "ok" }).unwrap();
@@ -453,16 +425,13 @@ mod tests {
     }
 
     #[test]
-    fn shell_emit_json_still_emits_message_with_empty_human_message() {
+    fn shell_emit_json_still_emits_message_with_empty_rendering() {
         let mut shell = TestShell::with_json_formatter();
 
         shell.emit(&MachineOnlyMessage { value: "ok" }).unwrap();
 
         let output = String::from_utf8(shell.into_stdout()).unwrap();
-        assert_eq!(
-            output,
-            concat!(r#"{"reason":"machine_only_message","value":"ok"}"#, "\n")
-        );
+        assert_eq!(output, concat!(r#"{"value":"ok"}"#, "\n"));
     }
 
     use anyhow::anyhow;


### PR DESCRIPTION
## Serde-tagged `Outcome` + `Run` trait pilot

Follow-up to #188's outcome model. Two changes:

**The `reason` tag now comes from the type.** `Outcome` is internally tagged (`#[serde(tag = "reason", rename_all = "snake_case")]`), so the variant name *is* the wire reason: the vocabulary can't drift from the type, and two shapes can't share a reason without rustc rejecting the duplicate variant name. The hand-written `reason()` match and the `Message` trait are gone — `Shell::emit` takes `Serialize + Display`, and human rendering is each payload's `Display`.

**Commands migrate to a `Run` trait.** [`Run`](tvc/src/commands/mod.rs) consumes parsed `Args` and returns a command-local outcome type; `Into<Outcome>` is the whole contract. `deploy approve` is the pilot; everything else stays on the legacy free `run` functions and migrates incrementally.

Notes:

- Wire contract unchanged: the reason vocabulary is byte-identical to `main`; variant renames (`Login`→`LoggedIn`, `DeployStatus`→`DeploymentStatus`, …) track the reason strings that already existed. One addition: `manifest_approval_already_posted`, reserved for the duplicate-approval detection coming in ENG-4274 (payload type only; nothing produces it yet).
- This lands the compile-time reason uniqueness TVC-207 asks for — by construction rather than by proc-macro. The collision check against the 3 non-terminal reasons is still a runtime test, so the ticket stays open for that remainder.
- Toolchain 1.94 → 1.95; `strum` (dev) for the outcome vocabulary tests.

Part of TVC-207.