### PR TITLE
feat(tvc): offer operator key backup during login onboarding

### DIFF
--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -1,6 +1,7 @@
 //! Login command for authenticating with Turnkey.
 
 use crate::client::build_turnkey_client;
+use crate::commands::keys::backup_operator_key;
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, OperatorRecordKind, OrgConfig, StoredApiKey,
     StoredQosOperatorKey, dashboard_base_url, default_api_key_path, default_operator_key_path,
@@ -17,6 +18,7 @@ use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 use std::io::BufRead;
+use std::path::PathBuf;
 use tracing::debug;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
@@ -954,6 +956,7 @@ async fn find_or_generate_operator_key(
     if let Some(operator_key) = StoredQosOperatorKey::load(&local.key_path).await? {
         debug!("using existing operator key");
         shell_println!(ctx, "Using existing operator key.")?;
+        shell_println!(ctx, "Tip: back it up with `tvc keys backup-operator-key`.")?;
         return Ok(operator_key);
     }
 
@@ -986,6 +989,56 @@ async fn find_or_generate_operator_key(
         ctx,
         "Make sure to register this as an operator in your organization."
     )?;
+
+    // Onboarding nudge for the freshly generated key. JSON mode already
+    // forces non-interactive; the TTY check keeps piped runs from hanging on
+    // the prompt.
+    if !ctx.is_non_interactive() && prompts::stdin_can_prompt() {
+        shell_println!(ctx)?;
+        shell_println!(
+            ctx,
+            "This key exists only on this machine; if it's lost you cannot \
+             approve deployments with it."
+        )?;
+
+        let mut backed_up = false;
+
+        if prompts::confirm("Back up your operator key now?", true)? {
+            let destination = PathBuf::from(prompts::text(
+                "Backup file path",
+                Some(&format!("operator-{org_alias}-backup.json")),
+            )?);
+
+            // Declining the overwrite skips the backup rather than failing:
+            // login has already succeeded and must not die here.
+            let proceed = !destination.exists()
+                || prompts::confirm(&format!("Overwrite {}?", destination.display()), false)?;
+
+            if proceed {
+                match backup_operator_key::back_up_key(org_alias, &local.key_path, &destination)
+                    .await
+                {
+                    Ok(backed_up_key) => {
+                        shell_println!(ctx)?;
+                        shell_println!(ctx, "{backed_up_key}")?;
+                        backed_up = true;
+                    }
+                    Err(error) => {
+                        // Deliberately swallowed at this endpoint: the backup
+                        // is advisory and the login outcome must still land.
+                        shell_eprintln!(ctx, "WARNING: backup failed: {error:#}")?;
+                    }
+                }
+            }
+        }
+
+        if !backed_up {
+            shell_println!(
+                ctx,
+                "You can back up any time with `tvc keys backup-operator-key`."
+            )?;
+        }
+    }
 
     Ok(operator_key)
 }

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -11,8 +11,11 @@
 mod common;
 
 use rexpect::session::PtySession;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
+use std::thread::{self, JoinHandle};
 
 /// Default per-step timeout. Generous enough for CI-runner cold cargo builds
 /// of the binary; tight enough to fail fast if an `exp_string` mismatches.
@@ -40,6 +43,56 @@ fn spawn_with_home(home: &Path, args: &[&str]) -> PtySession {
 
     rexpect::session::spawn_command(cmd, Some(TIMEOUT_MS))
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {bin} {}", args.join(" ")))
+}
+
+/// One-shot mock Turnkey API that answers the whoami query, enough to carry
+/// login past its credential verification and into the operator-key flow.
+/// Same shape as `tests/error_output.rs::spawn_json_server`.
+fn spawn_whoami_server() -> (String, JoinHandle<()>) {
+    // Port 0 requests an available ephemeral port instead of sharing a fixed
+    // test port that could collide with another process or parallel test.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).unwrap();
+        let actual_path = request_line
+            .split_whitespace()
+            .nth(1)
+            .expect("request line should contain a path");
+        assert_eq!(actual_path, "/public/v1/query/whoami");
+
+        let mut content_length = 0;
+        loop {
+            let mut header = String::new();
+            reader.read_line(&mut header).unwrap();
+            if header == "\r\n" {
+                break;
+            }
+            if let Some(value) = header
+                .strip_prefix("content-length:")
+                .or_else(|| header.strip_prefix("Content-Length:"))
+            {
+                content_length = value.trim().parse().unwrap();
+            }
+        }
+        let mut request_body = vec![0; content_length];
+        reader.read_exact(&mut request_body).unwrap();
+        drop(reader);
+
+        let body = r#"{"organizationId":"org-e2e","organizationName":"E2E Org","userId":"user-1","username":"e2e"}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+        stream.flush().unwrap();
+    });
+
+    (format!("http://{address}"), handle)
 }
 
 /// Drive `tvc login` through the interactive new-org flow (empty config, so
@@ -328,6 +381,109 @@ fn login_new_org_refuses_already_configured_org_id() {
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert_eq!(saved.matches(r#"id = "org-dup-test""#).count(), 1);
+}
+
+/// TVC-53: generating a fresh operator key during login offers a backup;
+/// accepting prompts for a destination, writes the copy, and login still
+/// succeeds. The mock whoami server carries login past its network step.
+#[test]
+fn login_fresh_operator_key_offers_backup() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    std::fs::remove_file(
+        temp.path()
+            .join(".config/turnkey/orgs/alias-a/operator.json"),
+    )
+    .unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+    let destination = temp.path().join("operator-backup.json");
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    session.exp_string("Verifying credentials...").unwrap();
+    session.exp_string("Operator Key Generated!").unwrap();
+    session
+        .exp_string("Back up your operator key now?")
+        .unwrap();
+    session.send_line("y").unwrap();
+    session.exp_string("Backup file path").unwrap();
+    session.send_line(destination.to_str().unwrap()).unwrap();
+
+    session.exp_string("Operator key backed up!").unwrap();
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert_eq!(
+        std::fs::read(&destination).unwrap(),
+        std::fs::read(
+            temp.path()
+                .join(".config/turnkey/orgs/alias-a/operator.json")
+        )
+        .unwrap()
+    );
+}
+
+/// TVC-53: declining the backup nudge points at the standalone command and
+/// login still succeeds.
+#[test]
+fn login_backup_decline_points_at_command() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    std::fs::remove_file(
+        temp.path()
+            .join(".config/turnkey/orgs/alias-a/operator.json"),
+    )
+    .unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    session
+        .exp_string("Back up your operator key now?")
+        .unwrap();
+    session.send_line("n").unwrap();
+
+    session
+        .exp_string("You can back up any time with `tvc keys backup-operator-key`.")
+        .unwrap();
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+}
+
+/// TVC-53: re-logins with an existing operator key get a single backup tip,
+/// no prompts.
+#[test]
+fn login_existing_operator_key_prints_backup_tip() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    session.exp_string("Using existing operator key.").unwrap();
+    session
+        .exp_string("Tip: back it up with `tvc keys backup-operator-key`.")
+        .unwrap();
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
 }
 
 /// Interactive `keys backup-operator-key` prompts for the destination and


### PR DESCRIPTION
## Backup nudge for fresh operator keys

Stacked on #225. When login generates a fresh operator key interactively, it now explains the key exists only on this machine and offers a backup (default Yes) via the shared `back_up_key` core — destination prompt, overwrite confirm (decline skips, doesn't fail login), and the full backed-up report. Backup errors degrade to a warning: login has already succeeded and must not die here. Declining (or any skip) prints the pointer to `tvc keys backup-operator-key`; re-logins with an existing key get a single tip line, no prompts.

The plan's "login hook isn't e2e-testable" gap turned out to be closable: a one-shot mock whoami server (the `error_output.rs` pattern) carries PTY login past credential verification, so the accept path (byte-identical backup on disk), decline path, and existing-key tip are all covered end-to-end.

Closes TVC-53.