### PR TITLE
feat(tvc): show a clear upgrade hint when the backend rejects an outdated client

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -117,6 +117,11 @@ impl Cli {
                 ExitCode::SUCCESS
             }
             Err(error) => {
+                // Log the full cause chain (including any raw HTTP body the
+                // human line collapses) before rendering, so `RUST_LOG=tvc=debug`
+                // recovers it in both output modes.
+                debug!(error = ?error, "command failed");
+
                 let shell = ctx.shell();
                 let emit_result = if shell.message_format().is_json() {
                     shell.emit(&ErrorMessage::from_error(&error))

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -4,7 +4,7 @@ use crate::config::turnkey::{Config, StoredApiKey};
 use crate::errors::MissingResource;
 use anyhow::{Context, Result, anyhow, bail};
 use reqwest::header::{HeaderMap, HeaderValue};
-use tracing::debug;
+use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::{
     TurnkeyClient,
@@ -43,6 +43,7 @@ pub struct AuthenticatedClient {
 ///
 /// If only some of the three required env vars are set, errors with the list of
 /// missing names — no merged resolve between env and disk vars.
+#[instrument(skip_all)]
 pub async fn build_client() -> Result<AuthenticatedClient> {
     debug!("building authenticated Turnkey client");
 
@@ -61,6 +62,7 @@ pub async fn build_client() -> Result<AuthenticatedClient> {
     build_authed_client(&org_id, &api_base_url, &api_key_public, &api_key_private)
 }
 
+#[instrument(skip_all)]
 pub async fn fetch_tvc_app(auth: &AuthenticatedClient, app_id: &str) -> Result<TvcApp> {
     let response = auth
         .client
@@ -76,6 +78,7 @@ pub async fn fetch_tvc_app(auth: &AuthenticatedClient, app_id: &str) -> Result<T
         .ok_or_else(|| MissingResource::new("app", app_id).into())
 }
 
+#[instrument(skip_all)]
 pub async fn fetch_tvc_deployment(
     auth: &AuthenticatedClient,
     organization_id: String,
@@ -95,6 +98,7 @@ pub async fn fetch_tvc_deployment(
         .ok_or_else(|| MissingResource::new("deployment", deployment_id).into())
 }
 
+#[instrument(skip_all)]
 async fn load_credentials_from_config() -> Result<(String, String, String, String)> {
     let config = Config::load().await?;
 
@@ -131,6 +135,7 @@ const TVC_CLIENT_VERSION_HEADER: &str = "X-TVC-CLIENT-VERSION";
 /// Every tvc client must be constructed here: this is the single place that
 /// stamps [`TVC_CLIENT_VERSION_HEADER`] with this crate's release version, and
 /// the backend's version gate relies on it riding every request.
+#[instrument(skip_all)]
 pub(crate) fn build_turnkey_client(
     stamper: TurnkeyP256ApiKey,
     api_base_url: &str,
@@ -149,6 +154,7 @@ pub(crate) fn build_turnkey_client(
         .context("failed to build Turnkey client")
 }
 
+#[instrument(skip_all)]
 fn build_authed_client(
     org_id: &str,
     api_base_url: &str,
@@ -183,6 +189,7 @@ fn read_env_var(name: &str) -> Option<String> {
 /// - `Ok(Some((org_id, api_base_url, api_key_public, api_key_private)))`: all three
 ///   required vars set; `api_base_url` falls back to the default if unset.
 /// - `Err`: only some of the required vars are set; the error names which.
+#[instrument(skip_all)]
 fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, String)>> {
     let org_id = read_env_var(ENV_ORG_ID);
     let api_key_public = read_env_var(ENV_API_KEY_PUBLIC);

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -19,7 +19,7 @@ use std::{
     io,
     path::{Path, PathBuf},
 };
-use tracing::debug;
+use tracing::{debug, instrument};
 use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperatorSetParams};
 
 /// Create a new TVC application from a config file.
@@ -54,6 +54,7 @@ struct Overrides {
     pub dangerous_enable_debug_mode_deployments: bool,
 }
 
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let config = if ctx.is_non_interactive() {
         build_app_config_non_interactive(&args).await?

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -8,6 +8,7 @@ use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::instrument;
 use turnkey_client::generated::{ActivityStatus, DeleteTvcAppAndDeploymentsIntent};
 use uuid::Uuid;
 
@@ -21,6 +22,7 @@ pub struct Args {
 }
 
 /// Run the app delete command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -9,6 +9,8 @@ use turnkey_client::generated::external::data::v1::TvcApp;
 
 use crate::commands::display::{format_egress_enabled, yes_no};
 use crate::outcome::Outcome;
+use tracing::instrument;
+
 use crate::output::StdCtx;
 
 const SEPARATOR_WIDTH: usize = 40;
@@ -23,6 +25,7 @@ pub struct Args {
 }
 
 /// Run the app list command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -8,6 +8,7 @@ use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::instrument;
 use turnkey_client::generated::{ActivityStatus, UpdateTvcAppLiveDeploymentIntent};
 use uuid::Uuid;
 
@@ -21,6 +22,7 @@ pub struct Args {
 }
 
 /// Run the app set-live-deploy command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -14,6 +14,8 @@ use crate::commands::app_status::{
 };
 use crate::commands::display::format_egress_enabled;
 use crate::outcome::Outcome;
+use tracing::instrument;
+
 use crate::output::StdCtx;
 
 /// Get the live status of an app from the cluster.
@@ -26,6 +28,7 @@ pub struct Args {
 }
 
 /// Run the app status command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -112,6 +112,7 @@ pub struct Args {
 impl Run for Args {
     type Outcome = ApproveOutcome;
 
+    #[instrument(skip_all)]
     async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<Self::Outcome> {
         let args = ArgsWithResolvedOperatorSeedSource::try_from(self)?;
 

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
+use tracing::instrument;
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
 
 pub(crate) const LONG_ABOUT: &str = r#"
@@ -149,6 +150,7 @@ struct ResolvedDeployInputs {
     pivot_pull_secret: Option<String>,
 }
 
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let inputs = if ctx.is_non_interactive() {
         build_inputs_non_interactive(args).await?

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -12,6 +12,7 @@ use std::collections::{HashSet, VecDeque};
 use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use std::time::Duration;
+use tracing::instrument;
 use turnkey_client::TurnkeyP256ApiKey;
 use turnkey_client::generated::external::data::v1::{LogLine, Timestamp};
 use turnkey_client::generated::{
@@ -124,6 +125,7 @@ pub struct Args {
 }
 
 /// Run the `deploy debug-logs` command.
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -8,6 +8,7 @@ use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::instrument;
 use turnkey_client::generated::{ActivityStatus, DeleteTvcDeploymentIntent};
 use uuid::Uuid;
 
@@ -21,6 +22,7 @@ pub struct Args {
 }
 
 /// Run the deploy delete command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
 

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
+use tracing::instrument;
 use turnkey_client::generated::{
     GetAppStatusRequest,
     external::data::v1::{AppStatus, DeploymentStatus},
@@ -28,6 +29,7 @@ pub struct Args {
 }
 
 /// Run the deploy get-status command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let deployment_id = args.deploy_id.to_string();
 

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -14,6 +14,7 @@ use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
+use tracing::instrument;
 
 pub(crate) const LONG_ABOUT: &str = r#"
 Generate a deployment config file to edit, then pass to `tvc deploy create`.
@@ -47,6 +48,7 @@ pub struct Args {
 }
 
 /// Run the deploy init command.
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     if args.interactive {
         if ctx.is_non_interactive() {

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::instrument;
 use turnkey_client::generated::{PostTvcQuorumKeyShareIntent, QuorumKeyShareApprovalBundle};
 use uuid::Uuid;
 
@@ -27,6 +28,7 @@ pub struct Args {
 }
 
 /// Run the deploy post-share command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let re_encrypted_share: ReEncryptedShareOutput =
         read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -20,6 +20,7 @@ use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::VersionedManifest;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
+use tracing::instrument;
 use turnkey_client::generated::{
     ReEncryptTvcQuorumKeyShareIntent, ReEncryptTvcQuorumKeyShareResult,
     external::data::v1::TvcManifest,
@@ -61,6 +62,7 @@ impl Display for ProvisioningShareCreated {
 }
 
 /// Run the hosted deploy provision command.
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let Args {
         deploy_id,

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 use std::fmt::Write;
 use std::fmt::{self, Display, Formatter};
 use std::path::{Path, PathBuf};
+use tracing::instrument;
 use uuid::Uuid;
 
 /// Get provisioning details for a deployment.
@@ -59,6 +60,7 @@ struct AttestationSummary {
 const SUMMARY_PCR_MAX_INDEX: usize = 17;
 
 /// Run the deploy provisioning-details command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
     let details = fetch_provisioning_details(&auth, &args.deploy_id).await?;

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -9,6 +9,8 @@ use turnkey_client::generated::{ActivityStatus, RestoreTvcDeploymentIntent};
 use uuid::Uuid;
 
 use crate::outcome::Outcome;
+use tracing::instrument;
+
 use crate::output::StdCtx;
 
 /// Restore a deleted deployment.
@@ -21,6 +23,7 @@ pub struct Args {
 }
 
 /// Run the deploy restore command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
 

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -16,6 +16,8 @@ use crate::commands::app_status::TimestampPayload;
 use crate::commands::display::{OrUnknown, format_egress_enabled, yes_no};
 use crate::errors::MissingResource;
 use crate::outcome::Outcome;
+use tracing::instrument;
+
 use crate::output::StdCtx;
 
 /// Get the status of a deployment.
@@ -28,6 +30,7 @@ pub struct Args {
 }
 
 /// Run the deploy status command.
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
     let auth = crate::client::build_client().await?;
     let deploy_id = args.deploy_id.to_string();

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -18,6 +18,7 @@ use std::{
     fmt::{self, Display, Formatter},
     time::{SystemTime, UNIX_EPOCH},
 };
+use tracing::instrument;
 use turnkey_client::generated::{CreateTvcQuorumKeyIntent, CreateTvcQuorumKeyResult};
 use uuid::Uuid;
 
@@ -104,6 +105,7 @@ impl OperatorSource {
 }
 
 /// Run the hosted quorum-key creation command.
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let Args {
         threshold,

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 use std::io::BufRead;
-use tracing::debug;
+use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
 
@@ -64,6 +64,7 @@ struct LoginPlan {
     api_key_policy: ApiKeyPolicy,
 }
 
+#[instrument(skip_all)]
 pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     debug!(
         non_interactive = ctx.is_non_interactive(),

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result, anyhow};
 use clap::{ArgGroup, Args as ClapArgs, builder::NonEmptyStringValueParser};
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
+use tracing::instrument;
 use uuid::Uuid;
 
 const DEFAULT_OPERATOR_NAME: &str = "tvc-operator";
@@ -96,6 +97,7 @@ Saved: true"#,
     }
 }
 
+#[instrument(skip_all)]
 pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let mut config = Config::load().await?;
     let (alias, configured_org_id) = config

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -9,7 +9,7 @@
 //! before they cross the CLI output boundary.
 
 use reqwest::StatusCode;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use turnkey_client::TurnkeyClientError;
 
 /// Cap on rendered error messages. Large enough for any real API error body
@@ -59,6 +59,9 @@ pub enum ErrorCode {
     NotFound,
     /// Any other non-success HTTP status, or a failed/unexpected activity.
     ApiError,
+    /// The backend rejected this tvc release as older than the minimum
+    /// version it supports. Remediation: upgrade tvc.
+    ClientVersionTooOld,
     /// An activity needs more approvals.
     ApprovalRequired,
     /// A connect/timeout/DNS failure — the request never reached the server.
@@ -98,6 +101,25 @@ pub fn classify(error: &anyhow::Error) -> Classification {
     Classification::new(ErrorCode::CommandError, None)
 }
 
+/// A remediation hint for recognized error causes, rendered by the human
+/// output layer beneath the error line. Today only the backend's
+/// client-version rejection produces one: the hint is the server's own
+/// message (it names the running and minimum versions), so the reader does
+/// not have to dig it out of the raw response body in the chain.
+pub fn hint(error: &anyhow::Error) -> Option<String> {
+    error.chain().find_map(|cause| {
+        let envelope = client_version_rejection(cause.downcast_ref::<TurnkeyClientError>()?)?;
+
+        Some(if envelope.message.is_empty() {
+            "this tvc release is older than the minimum version the backend supports; \
+             upgrade tvc to the latest release"
+                .to_string()
+        } else {
+            envelope.message
+        })
+    })
+}
+
 /// Render an error's complete cause chain like anyhow's alternate
 /// `{error:#}` display (links joined with `": "`), then truncate the result to
 /// [`MAX_ERROR_MESSAGE_CHARS`].
@@ -133,6 +155,37 @@ fn truncate_message(message: String) -> String {
     )
 }
 
+/// The `turnkeyErrorCode` the backend attaches when it rejects a tvc release
+/// older than the minimum version it supports (the client-version gate).
+/// Must match the `TurnkeyErrorCode` enum value name in Turnkey's public
+/// error proto.
+const TVC_CLIENT_VERSION_TOO_OLD: &str = "TVC_CLIENT_VERSION_TOO_OLD";
+
+/// The subset of the Turnkey public API error envelope (grpc-gateway's JSON
+/// rendering of a gRPC status, plus Turnkey's machine-readable code) that
+/// classification reads.
+#[derive(Deserialize)]
+struct ApiErrorEnvelope {
+    #[serde(default)]
+    message: String,
+    #[serde(default, rename = "turnkeyErrorCode")]
+    turnkey_error_code: String,
+}
+
+/// Parse the backend's client-version rejection out of a client error, if
+/// that is what it is: an HTTP failure whose body is a Turnkey error envelope
+/// carrying [`TVC_CLIENT_VERSION_TOO_OLD`]. Shared by [`classify`] and
+/// [`hint`] so they cannot disagree on what counts as one.
+fn client_version_rejection(error: &TurnkeyClientError) -> Option<ApiErrorEnvelope> {
+    let TurnkeyClientError::UnexpectedHttpStatus(_, body) = error else {
+        return None;
+    };
+
+    serde_json::from_str::<ApiErrorEnvelope>(body)
+        .ok()
+        .filter(|envelope| envelope.turnkey_error_code == TVC_CLIENT_VERSION_TOO_OLD)
+}
+
 /// Map a [`TurnkeyClientError`] to its taxonomy code and optional HTTP status.
 ///
 /// NOTE: this may fail to compile when new errors are introduced in upstream Turnkey code, which is good.
@@ -140,11 +193,16 @@ fn truncate_message(message: String) -> String {
 fn classify_turnkey_client_error(error: &TurnkeyClientError) -> Classification {
     match error {
         TurnkeyClientError::UnexpectedHttpStatus(status, _) => {
-            let code = match StatusCode::from_u16(*status) {
-                Ok(StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => ErrorCode::Unauthorized,
-                Ok(StatusCode::NOT_FOUND) => ErrorCode::NotFound,
-                _ => ErrorCode::ApiError,
+            let code = if client_version_rejection(error).is_some() {
+                ErrorCode::ClientVersionTooOld
+            } else {
+                match StatusCode::from_u16(*status) {
+                    Ok(StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => ErrorCode::Unauthorized,
+                    Ok(StatusCode::NOT_FOUND) => ErrorCode::NotFound,
+                    _ => ErrorCode::ApiError,
+                }
             };
+
             Classification::new(code, Some(*status))
         }
         // A connect/timeout/DNS failure means the request never reached the
@@ -268,6 +326,77 @@ mod tests {
                 Classification::new(ErrorCode::Unauthorized, Some(status)),
                 "status {status}"
             );
+        }
+    }
+
+    const TOO_OLD_BODY: &str = r#"{"code":3,"message":"tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); upgrade tvc to the latest release","details":[],"turnkeyErrorCode":"TVC_CLIENT_VERSION_TOO_OLD"}"#;
+
+    #[test]
+    fn client_version_rejection_maps_to_client_version_too_old() {
+        let error = client_error(TurnkeyClientError::UnexpectedHttpStatus(
+            400,
+            TOO_OLD_BODY.to_string(),
+        ));
+
+        assert_eq!(
+            classify(&error),
+            Classification::new(ErrorCode::ClientVersionTooOld, Some(400))
+        );
+    }
+
+    #[test]
+    fn client_version_rejection_hint_is_the_server_message() {
+        let error = client_error(TurnkeyClientError::UnexpectedHttpStatus(
+            400,
+            TOO_OLD_BODY.to_string(),
+        ))
+        .context("failed to create TVC deployment");
+
+        assert_eq!(
+            hint(&error).as_deref(),
+            Some(
+                "tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); \
+                 upgrade tvc to the latest release"
+            )
+        );
+    }
+
+    #[test]
+    fn client_version_rejection_without_server_message_still_hints() {
+        let error = client_error(TurnkeyClientError::UnexpectedHttpStatus(
+            400,
+            r#"{"turnkeyErrorCode":"TVC_CLIENT_VERSION_TOO_OLD"}"#.to_string(),
+        ));
+
+        assert_eq!(
+            hint(&error).as_deref(),
+            Some(
+                "this tvc release is older than the minimum version the backend supports; \
+                 upgrade tvc to the latest release"
+            )
+        );
+    }
+
+    #[test]
+    fn other_api_errors_do_not_hint_or_reclassify() {
+        let bodies = [
+            r#"{"code":3,"message":"bad request","details":[],"turnkeyErrorCode":""}"#,
+            r#"{"code":3,"message":"bad request","details":[],"turnkeyErrorCode":"REQUEST_INVALID"}"#,
+            "not json at all",
+        ];
+
+        for body in bodies {
+            let error = client_error(TurnkeyClientError::UnexpectedHttpStatus(
+                400,
+                body.to_string(),
+            ));
+
+            assert_eq!(
+                classify(&error),
+                Classification::new(ErrorCode::ApiError, Some(400)),
+                "body {body:?}"
+            );
+            assert_eq!(hint(&error), None, "body {body:?}");
         }
     }
 

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -10,6 +10,7 @@
 
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use turnkey_client::TurnkeyClientError;
 
 /// Cap on rendered error messages. Large enough for any real API error body
@@ -108,16 +109,28 @@ pub fn classify(error: &anyhow::Error) -> Classification {
 /// not have to dig it out of the raw response body in the chain.
 pub fn hint(error: &anyhow::Error) -> Option<String> {
     error.chain().find_map(|cause| {
-        let envelope = client_version_rejection(cause.downcast_ref::<TurnkeyClientError>()?)?;
+        let _envelope = client_version_rejection(cause.downcast_ref::<TurnkeyClientError>()?)?;
+        let name = binary_name();
 
-        Some(if envelope.message.is_empty() {
-            "this tvc release is older than the minimum version the backend supports; \
-             upgrade tvc to the latest release"
-                .to_string()
-        } else {
-            envelope.message
-        })
+        format!(
+            "`{name}` is older than the minimum version the backend supports; \
+             upgrade `{name}` to the latest release"
+        )
+        .into()
     })
+}
+
+/// The invoked binary's name for user-facing version messaging: argv[0]'s file
+/// stem (so `/usr/local/bin/tvc` and `./tvc` both read as `tvc`), falling back
+/// to `tvc` when argv is empty.
+pub(crate) fn binary_name() -> String {
+    let arg0 = std::env::args().next();
+
+    arg0.as_deref()
+        .map(Path::new)
+        .and_then(Path::file_stem)
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "tvc".to_string())
 }
 
 /// Render an error's complete cause chain like anyhow's alternate
@@ -159,6 +172,8 @@ fn truncate_message(message: String) -> String {
 /// older than the minimum version it supports (the client-version gate).
 /// Must match the `TurnkeyErrorCode` enum value name in Turnkey's public
 /// error proto.
+// TODO(TVC-269): generate `TurnkeyErrorCode` from the synced errors.proto and
+// match on the enum variant instead of this string.
 const TVC_CLIENT_VERSION_TOO_OLD: &str = "TVC_CLIENT_VERSION_TOO_OLD";
 
 /// The subset of the Turnkey public API error envelope (grpc-gateway's JSON
@@ -166,8 +181,12 @@ const TVC_CLIENT_VERSION_TOO_OLD: &str = "TVC_CLIENT_VERSION_TOO_OLD";
 /// classification reads.
 #[derive(Deserialize)]
 struct ApiErrorEnvelope {
+    // The server's human-readable message. Not consumed today — `hint` templates
+    // its own text off the binary name — but kept parsed so we can surface the
+    // backend's wording (e.g. the concrete running/minimum versions) once we
+    // decide to.
     #[serde(default)]
-    message: String,
+    _message: String,
     #[serde(default, rename = "turnkeyErrorCode")]
     turnkey_error_code: String,
 }
@@ -353,11 +372,9 @@ mod tests {
         .context("failed to create TVC deployment");
 
         assert_eq!(
-            hint(&error).as_deref(),
-            Some(
-                "tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); \
-                 upgrade tvc to the latest release"
-            )
+            hint(&error).as_deref().map(|message| message
+                .contains("is older than the minimum version the backend supports")),
+            Some(true)
         );
     }
 
@@ -369,11 +386,10 @@ mod tests {
         ));
 
         assert_eq!(
-            hint(&error).as_deref(),
-            Some(
-                "this tvc release is older than the minimum version the backend supports; \
-                 upgrade tvc to the latest release"
-            )
+            hint(&error)
+                .as_deref()
+                .map(|msg| msg.contains("is older than the minimum version the backend supports")),
+            Some(true)
         );
     }
 

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -1,6 +1,6 @@
 //! User-facing output primitives for TVC.
 
-use crate::errors::{Classification, ErrorCode, classify, render_error_chain};
+use crate::errors::{Classification, ErrorCode, classify, hint, render_error_chain};
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::Result;
 use clap::ValueEnum;
@@ -161,6 +161,11 @@ impl<W: Write, W2: Write> Human<'_, W, W2> {
             let style = self.0.style(AnsiColor::Red);
             let message = render_error_chain(error);
             writeln!(self.0.stderr, "{style}error{style:#}: {message}")?;
+
+            if let Some(hint) = hint(error) {
+                let style = self.0.style(AnsiColor::Cyan);
+                writeln!(self.0.stderr, "{style}hint{style:#}: {hint}")?;
+            }
         }
         Ok(())
     }

--- a/tvc/src/output.rs
+++ b/tvc/src/output.rs
@@ -1,6 +1,6 @@
 //! User-facing output primitives for TVC.
 
-use crate::errors::{Classification, ErrorCode, classify, hint, render_error_chain};
+use crate::errors::{Classification, ErrorCode, binary_name, classify, hint, render_error_chain};
 use anstyle::{AnsiColor, Color, Style};
 use anyhow::Result;
 use clap::ValueEnum;
@@ -159,7 +159,16 @@ impl<W: Write, W2: Write> Human<'_, W, W2> {
     pub fn error(&mut self, error: &anyhow::Error) -> Result<()> {
         if matches!(self.0.message_format, MessageFormat::Human) {
             let style = self.0.style(AnsiColor::Red);
-            let message = render_error_chain(error);
+
+            // The backend's client-version rejection collapses to a terse line;
+            // its raw HTTP detail rides the `debug!` log at the CLI boundary and
+            // the JSON `message`. The remediation `hint:` below carries the
+            // actionable text. Everything else renders the full cause chain.
+            let message = match classify(error).code {
+                ErrorCode::ClientVersionTooOld => format!("`{}` version too old", binary_name()),
+                _ => render_error_chain(error),
+            };
+
             writeln!(self.0.stderr, "{style}error{style:#}: {message}")?;
 
             if let Some(hint) = hint(error) {

--- a/tvc/tests/error_output.rs
+++ b/tvc/tests/error_output.rs
@@ -292,3 +292,47 @@ fn human_and_json_runtime_errors_render_identical_message_text() {
         )
     );
 }
+
+const CLIENT_VERSION_TOO_OLD_BODY: &str = r#"{"code":3,"message":"tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); upgrade tvc to the latest release","details":[],"turnkeyErrorCode":"TVC_CLIENT_VERSION_TOO_OLD"}"#;
+
+#[test]
+fn client_version_rejection_emits_dedicated_code() {
+    let (api_base_url, server) = spawn_json_server(
+        400,
+        CLIENT_VERSION_TOO_OLD_BODY.to_string(),
+        GET_DEPLOYMENT_PATH,
+    );
+    let output = command_output(deploy_status_command(&api_base_url, Some("json")), 1);
+    server.join().unwrap();
+
+    let message = single_json_message(&output);
+    assert_eq!(message["reason"], "command_error");
+    assert_eq!(message["code"], "client_version_too_old");
+    assert_eq!(message["httpStatus"], 400);
+}
+
+#[test]
+fn client_version_rejection_renders_human_hint() {
+    let (api_base_url, server) = spawn_json_server(
+        400,
+        CLIENT_VERSION_TOO_OLD_BODY.to_string(),
+        GET_DEPLOYMENT_PATH,
+    );
+    let output = command_output(deploy_status_command(&api_base_url, None), 1);
+    server.join().unwrap();
+
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr.clone()).unwrap();
+    assert!(
+        stderr.starts_with(&format!(
+            "error: failed to fetch deployment {DEPLOYMENT_ID}"
+        )),
+        "{stderr:?}"
+    );
+    assert!(
+        stderr.ends_with(
+            "hint: tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); upgrade tvc to the latest release\n"
+        ),
+        "{stderr:?}"
+    );
+}

--- a/tvc/tests/error_output.rs
+++ b/tvc/tests/error_output.rs
@@ -322,17 +322,11 @@ fn client_version_rejection_renders_human_hint() {
     server.join().unwrap();
 
     assert!(output.stdout.is_empty());
-    let stderr = String::from_utf8(output.stderr.clone()).unwrap();
+    // The client-version rejection collapses the error line to a terse message;
+    // the server's own text rides the unchanged `hint:` line.
     assert!(
-        stderr.starts_with(&format!(
-            "error: failed to fetch deployment {DEPLOYMENT_ID}"
-        )),
-        "{stderr:?}"
-    );
-    assert!(
-        stderr.ends_with(
-            "hint: tvc 0.12.0 is older than the minimum version this backend supports (0.12.2); upgrade tvc to the latest release\n"
-        ),
-        "{stderr:?}"
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("is older than the minimum version the backend supports"),
     );
 }


### PR DESCRIPTION
Follows #218 (X-TVC-CLIENT-VERSION stamping + `version` subcommand). Handles the backend's rejection of an outdated client:

- Classifies the `TVC_CLIENT_VERSION_TOO_OLD` rejection as `client_version_too_old` and renders a terse `error: `tvc` version too old` with an upgrade `hint:`.
- Moves the raw HTTP detail to a `debug!` at the CLI boundary (recoverable via `RUST_LOG=tvc=debug`), keeping it out of the human error line.
- Adds `#[instrument(skip_all)]` spans across the client boundary and API-hitting commands for a clean debug call path.

Closes ENG-4082.
