### PR TITLE
tvc: propagate Vivosuite trace context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2559,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "powerfmt"
@@ -4223,6 +4270,9 @@ dependencies = [
  "hex",
  "hpke",
  "inquire",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
  "p256 0.13.2",
  "predicates",
  "qos_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ thiserror = { version = "2.0.12", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 tracing = { version = "0.1.41", default-features = false, features = ["attributes", "std"] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry-http = { version = "0.32", default-features = false }
 
 # Web/HTTP
 mime = { version = "0.3.17", default-features = false }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -28,6 +28,9 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 hex = { workspace = true }
 inquire = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry-http = { workspace = true }
+opentelemetry_sdk = { workspace = true }
 p256 = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -3,7 +3,11 @@
 use crate::config::turnkey::{Config, StoredApiKey};
 use crate::errors::MissingResource;
 use anyhow::{Context, Result, anyhow, bail};
-use reqwest::header::{HeaderMap, HeaderValue};
+use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
+use opentelemetry_http::{HeaderExtractor, HeaderInjector};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue};
+use thiserror::Error;
 use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::{
@@ -21,6 +25,8 @@ const ENV_ORG_ID: &str = "TVC_ORG_ID";
 const ENV_API_BASE_URL: &str = "TVC_API_BASE_URL";
 const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
 const ENV_API_KEY_PRIVATE: &str = "TVC_API_KEY_PRIVATE";
+const ENV_TRACEPARENT: &str = "TVC_OTEL_TRACEPARENT";
+const ENV_TRACESTATE: &str = "TVC_OTEL_TRACESTATE";
 const DEFAULT_API_BASE_URL: &str = "https://api.turnkey.com";
 
 /// An authenticated Turnkey client with organization context.
@@ -129,23 +135,143 @@ async fn load_credentials_from_config() -> Result<(String, String, String, Strin
 /// enforces a minimum-version floor on it (enforce-when-present) to retire
 /// known-defective releases with an upgrade prompt.
 const TVC_CLIENT_VERSION_HEADER: &str = "X-TVC-CLIENT-VERSION";
+const TRACEPARENT_HEADER: HeaderName = HeaderName::from_static("traceparent");
+const TRACESTATE_HEADER: HeaderName = HeaderName::from_static("tracestate");
+const MAX_TRACE_CONTEXT_HEADER_LEN: usize = 512;
 
-/// Build the Turnkey API client used for all tvc requests.
-///
-/// Every tvc client must be constructed here: this is the single place that
-/// stamps [`TVC_CLIENT_VERSION_HEADER`] with this crate's release version, and
-/// the backend's version gate relies on it riding every request.
-#[instrument(skip_all)]
-pub(crate) fn build_turnkey_client(
-    stamper: TurnkeyP256ApiKey,
-    api_base_url: &str,
-) -> Result<TurnkeyClient<TurnkeyP256ApiKey>> {
+#[derive(Debug, Error)]
+enum BoundedHeaderValueError {
+    #[error("header value exceeds its maximum length")]
+    TooLong,
+    #[error("invalid HTTP header value: {0}")]
+    Invalid(#[source] InvalidHeaderValue),
+}
+
+/// An HTTP header value whose encoded length is bounded at construction.
+struct BoundedHeaderValue<const MAX_LEN: usize>(HeaderValue);
+
+impl<const MAX_LEN: usize> TryFrom<&str> for BoundedHeaderValue<MAX_LEN> {
+    type Error = BoundedHeaderValueError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() > MAX_LEN {
+            return Err(BoundedHeaderValueError::TooLong);
+        }
+
+        HeaderValue::from_str(value)
+            .map(Self)
+            .map_err(BoundedHeaderValueError::Invalid)
+    }
+}
+
+impl<const MAX_LEN: usize> From<BoundedHeaderValue<MAX_LEN>> for HeaderValue {
+    fn from(value: BoundedHeaderValue<MAX_LEN>) -> Self {
+        value.0
+    }
+}
+
+type TraceContextHeaderValue = BoundedHeaderValue<MAX_TRACE_CONTEXT_HEADER_LEN>;
+
+fn parse_trace_context_header(name: &str, value: &str) -> Option<TraceContextHeaderValue> {
+    match TraceContextHeaderValue::try_from(value) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            debug!(name, %error, "ignoring propagated trace header");
+            None
+        }
+    }
+}
+
+/// Round-trips trace headers through the official W3C propagator.
+fn normalize_trace_context_headers(carrier: HeaderMap) -> Option<HeaderMap> {
+    let propagator = TraceContextPropagator::new();
+    let context = propagator.extract(&HeaderExtractor(&carrier));
+    if !context.span().span_context().is_valid() {
+        debug!("ignoring invalid propagated trace context");
+        return None;
+    }
+
+    let had_tracestate = carrier.contains_key(TRACESTATE_HEADER);
+    let mut headers = HeaderMap::new();
+    propagator.inject_context(&context, &mut HeaderInjector(&mut headers));
+
+    // The propagator injects an empty `tracestate` when no valid state survived
+    // extraction. Remove that placeholder and log when supplied state was rejected.
+    if headers
+        .get(TRACESTATE_HEADER)
+        .is_some_and(|value| value.is_empty())
+    {
+        headers.remove(TRACESTATE_HEADER);
+    }
+    if had_tracestate && !headers.contains_key(TRACESTATE_HEADER) {
+        debug!("ignoring invalid propagated tracestate");
+    }
+
+    Some(headers)
+}
+
+/// Builds the default headers, normalizing optional W3C trace context through
+/// OpenTelemetry's official propagator. Trace propagation is deliberately
+/// best-effort so malformed telemetry can never block an API request.
+fn tvc_client_headers(traceparent: Option<&str>, tracestate: Option<&str>) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(
         TVC_CLIENT_VERSION_HEADER,
         HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
     );
 
+    let tracestate = tracestate.filter(|value| !value.is_empty());
+    let (traceparent, tracestate) = match (traceparent, tracestate) {
+        (Some(traceparent), tracestate) => {
+            let Some(traceparent) =
+                parse_trace_context_header(TRACEPARENT_HEADER.as_str(), traceparent)
+            else {
+                return headers;
+            };
+
+            (
+                traceparent,
+                tracestate.and_then(|tracestate| {
+                    parse_trace_context_header(TRACESTATE_HEADER.as_str(), tracestate)
+                }),
+            )
+        }
+        (None, Some(_)) => {
+            debug!("ignoring propagated tracestate without traceparent");
+            return headers;
+        }
+        (None, None) => return headers,
+    };
+
+    let mut carrier = HeaderMap::new();
+    carrier.insert(TRACEPARENT_HEADER, traceparent.into());
+
+    if let Some(tracestate) = tracestate {
+        carrier.insert(TRACESTATE_HEADER, tracestate.into());
+    }
+
+    if let Some(trace_context) = normalize_trace_context_headers(carrier) {
+        headers.extend(trace_context);
+    }
+
+    headers
+}
+
+/// Acquires the complete default header set for a tvc API client.
+pub(crate) fn tvc_client_headers_from_env() -> HeaderMap {
+    let traceparent = read_env_var(ENV_TRACEPARENT);
+    let tracestate = read_env_var(ENV_TRACESTATE);
+
+    tvc_client_headers(traceparent.as_deref(), tracestate.as_deref())
+}
+
+/// Build a Turnkey API client from provided deps
+#[instrument(skip_all)]
+pub(crate) fn build_turnkey_client(
+    stamper: TurnkeyP256ApiKey,
+    api_base_url: &str,
+    headers: HeaderMap,
+) -> Result<TurnkeyClient<TurnkeyP256ApiKey>> {
     TurnkeyClient::builder()
         .api_key(stamper)
         .base_url(api_base_url)
@@ -166,7 +292,8 @@ fn build_authed_client(
         .context("failed to load API key")?;
 
     debug!(%api_base_url, "building Turnkey API client");
-    let client = build_turnkey_client(stamper, api_base_url)?;
+    let headers = tvc_client_headers_from_env();
+    let client = build_turnkey_client(stamper, api_base_url, headers)?;
 
     debug!("authenticated Turnkey client ready");
 
@@ -248,6 +375,57 @@ mod tests {
     use wiremock::matchers::{header, method};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    const VALID_TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const VALID_TRACESTATE: &str = "vendor=value";
+
+    #[test]
+    fn parse_trace_context_header_accepts_only_bounded_http_values() {
+        let maximum_length = "a".repeat(MAX_TRACE_CONTEXT_HEADER_LEN);
+        let oversized = "a".repeat(MAX_TRACE_CONTEXT_HEADER_LEN + 1);
+
+        let parsed =
+            parse_trace_context_header(TRACEPARENT_HEADER.as_str(), maximum_length.as_str())
+                .expect("maximum-length HTTP header value should parse");
+        let parsed: HeaderValue = parsed.into();
+
+        assert_eq!(parsed, maximum_length);
+        assert!(
+            parse_trace_context_header(TRACEPARENT_HEADER.as_str(), oversized.as_str()).is_none()
+        );
+        assert!(
+            parse_trace_context_header(TRACEPARENT_HEADER.as_str(), "invalid\r\nheader").is_none()
+        );
+    }
+
+    #[test]
+    fn normalize_trace_context_headers_preserves_only_valid_state() {
+        for (tracestate, expected_tracestate) in [
+            (Some(VALID_TRACESTATE), Some(VALID_TRACESTATE)),
+            (None, None),
+            (Some("Vendor=uppercase-keys-are-invalid"), None),
+        ] {
+            let mut carrier = HeaderMap::new();
+            carrier.insert(
+                TRACEPARENT_HEADER,
+                HeaderValue::from_static(VALID_TRACEPARENT),
+            );
+            if let Some(tracestate) = tracestate {
+                carrier.insert(TRACESTATE_HEADER, HeaderValue::from_static(tracestate));
+            }
+
+            let headers = normalize_trace_context_headers(carrier)
+                .expect("valid traceparent should produce normalized headers");
+
+            assert_eq!(headers.get(TRACEPARENT_HEADER).unwrap(), VALID_TRACEPARENT);
+            assert_eq!(
+                headers
+                    .get(TRACESTATE_HEADER)
+                    .map(|value| value.to_str().unwrap()),
+                expected_tracestate
+            );
+        }
+    }
+
     #[tokio::test]
     async fn built_clients_stamp_the_tvc_release_version_on_every_request() {
         let server = MockServer::start().await;
@@ -259,7 +437,8 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = build_turnkey_client(TurnkeyP256ApiKey::generate(), &server.uri())
+        let headers = tvc_client_headers(None, None);
+        let client = build_turnkey_client(TurnkeyP256ApiKey::generate(), &server.uri(), headers)
             .expect("client builds");
         let response: serde_json::Value = client
             .process_request(&serde_json::json!({}), "/any/path".to_string())
@@ -268,5 +447,116 @@ mod tests {
 
         assert_eq!(response, serde_json::json!({}));
         server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn built_clients_forward_vivosuite_trace_context_on_the_request() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(header("traceparent", VALID_TRACEPARENT))
+            .and(header("tracestate", VALID_TRACESTATE))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let headers = tvc_client_headers(Some(VALID_TRACEPARENT), Some(VALID_TRACESTATE));
+        let client = build_turnkey_client(TurnkeyP256ApiKey::generate(), &server.uri(), headers)
+            .expect("client builds");
+        let response: serde_json::Value = client
+            .process_request(&serde_json::json!({}), "/any/path".to_string())
+            .await
+            .expect("request carrying trace context matches the mock");
+
+        assert_eq!(response, serde_json::json!({}));
+        server.verify().await;
+    }
+
+    #[test]
+    fn client_headers_forward_vivosuite_trace_context() {
+        let headers = tvc_client_headers(Some(VALID_TRACEPARENT), Some(VALID_TRACESTATE));
+
+        assert_eq!(headers.get(TRACEPARENT_HEADER).unwrap(), VALID_TRACEPARENT);
+        assert_eq!(headers.get(TRACESTATE_HEADER).unwrap(), VALID_TRACESTATE);
+    }
+
+    #[test]
+    fn malformed_traceparent_fails_open_and_drops_the_trace_context() {
+        let headers = tvc_client_headers(Some("not-a-w3c-traceparent\r\n"), Some(VALID_TRACESTATE));
+
+        assert_eq!(
+            headers.get(TVC_CLIENT_VERSION_HEADER).unwrap(),
+            env!("CARGO_PKG_VERSION")
+        );
+        assert!(!headers.contains_key(TRACEPARENT_HEADER));
+        assert!(!headers.contains_key(TRACESTATE_HEADER));
+
+        build_turnkey_client(TurnkeyP256ApiKey::generate(), "http://localhost", headers)
+            .expect("invalid optional trace context must not prevent client construction");
+    }
+
+    #[test]
+    fn malformed_tracestate_is_dropped_without_dropping_traceparent() {
+        let headers = tvc_client_headers(
+            Some(VALID_TRACEPARENT),
+            Some("Vendor=uppercase-keys-are-invalid"),
+        );
+
+        assert_eq!(headers.get(TRACEPARENT_HEADER).unwrap(), VALID_TRACEPARENT);
+        assert!(!headers.contains_key(TRACESTATE_HEADER));
+    }
+
+    #[test]
+    fn tracestate_without_traceparent_is_not_forwarded() {
+        let headers = tvc_client_headers(None, Some(VALID_TRACESTATE));
+
+        assert!(!headers.contains_key(TRACEPARENT_HEADER));
+        assert!(!headers.contains_key(TRACESTATE_HEADER));
+    }
+
+    #[test]
+    fn empty_tracestate_is_not_forwarded() {
+        for tracestate in ["", " \t "] {
+            let headers = tvc_client_headers(Some(VALID_TRACEPARENT), Some(tracestate));
+
+            assert_eq!(headers.get(TRACEPARENT_HEADER).unwrap(), VALID_TRACEPARENT);
+            assert!(!headers.contains_key(TRACESTATE_HEADER));
+        }
+    }
+
+    #[test]
+    fn oversized_tracestate_is_dropped_without_dropping_traceparent() {
+        let oversized_tracestate = "a".repeat(MAX_TRACE_CONTEXT_HEADER_LEN + 1);
+        let headers = tvc_client_headers(Some(VALID_TRACEPARENT), Some(&oversized_tracestate));
+
+        assert_eq!(headers.get(TRACEPARENT_HEADER).unwrap(), VALID_TRACEPARENT);
+        assert!(!headers.contains_key(TRACESTATE_HEADER));
+    }
+
+    #[test]
+    fn oversized_traceparent_fails_open_and_drops_the_trace_context() {
+        let oversized_traceparent = "a".repeat(MAX_TRACE_CONTEXT_HEADER_LEN + 1);
+        let headers = tvc_client_headers(Some(&oversized_traceparent), Some(VALID_TRACESTATE));
+
+        assert_eq!(
+            headers.get(TVC_CLIENT_VERSION_HEADER).unwrap(),
+            env!("CARGO_PKG_VERSION")
+        );
+        assert!(!headers.contains_key(TRACEPARENT_HEADER));
+        assert!(!headers.contains_key(TRACESTATE_HEADER));
+    }
+
+    #[test]
+    fn invalid_w3c_identifiers_are_not_forwarded() {
+        for traceparent in [
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",
+        ] {
+            let headers = tvc_client_headers(Some(traceparent), None);
+
+            assert!(!headers.contains_key(TRACEPARENT_HEADER));
+        }
     }
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -1,6 +1,6 @@
 //! Login command for authenticating with Turnkey.
 
-use crate::client::build_turnkey_client;
+use crate::client::{build_turnkey_client, tvc_client_headers_from_env};
 use crate::commands::keys::backup_operator_key::{
     OperatorKeyBackedUp, back_up, prompt_for_backup_destination,
 };
@@ -672,7 +672,8 @@ async fn verify_credentials(
     let stamper = TurnkeyP256ApiKey::from_strings(&api_key.private_key, Some(&api_key.public_key))
         .context("failed to load API key")?;
 
-    let client = build_turnkey_client(stamper, api_base_url)?;
+    let headers = tvc_client_headers_from_env();
+    let client = build_turnkey_client(stamper, api_base_url, headers)?;
 
     let request = GetWhoamiRequest {
         organization_id: org_id.to_string(),


### PR DESCRIPTION
## Summary

- Propagates upstream W3C trace context onto TVC API requests.
- Connects Vivosuite test, phase, and command spans to Coordinator request spans.
- Uses the official OpenTelemetry propagator with bounded header inputs.
- Fails open: missing or malformed trace context is omitted and never blocks a request.

Supports TVC-265 and tkhq/mono#7539.