### PR TITLE
refactor(tvc): seal operator backends behind a Signer port

### DIFF
--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -231,8 +231,8 @@ fn offer_to_save_app_config(ctx: &mut StdCtx, path: &Path, config: &AppConfig) -
 /// so we can offer it as the default for new-operator prompts.
 async fn load_saved_operator_public_key() -> Option<String> {
     let config = turnkey::Config::load().await.ok()?;
-    let (alias, org_config) = config.active_org_config()?;
-    let local = org_config.select_local_record(alias).ok()?;
+    let (_, org_config) = config.active_org_config()?;
+    let (_, local) = org_config.select_local_operator().ok()?;
     let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
     Some(operator_key.public_key.to_string())
 }

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -109,8 +109,8 @@ async fn load_operator_public_key() -> Option<String> {
     let config = Config::load().await.ok()?;
 
     // Get active org config
-    let (alias, org_config) = config.active_org_config()?;
-    let local = org_config.select_local_record(alias).ok()?;
+    let (_, org_config) = config.active_org_config()?;
+    let (_, local) = org_config.select_local_operator().ok()?;
     let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
     Some(operator_key.public_key.to_string())
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -7,7 +7,7 @@ use crate::{
     config::turnkey::Config,
     errors::MissingResource,
     local_operator_key::LocalOperatorSeedSource,
-    operator::{OperatorCtx, ResolvedOperator, resolve_operator},
+    operator::{SignerRequirement, resolve_operator},
     outcome::Outcome,
     output::StdCtx,
     pair::HexSeed,
@@ -481,24 +481,22 @@ async fn run_with_resolved_inputs(
             }
         });
 
-    let operator = resolve_operator(inputs.operator_seed_source, inputs.operator_id).await?;
-    if inputs.skip_post && operator.is_hosted() {
-        bail!("--skip-post is only supported for local operators");
-    }
-    let auth = if operator.is_hosted() {
-        Some(build_client().await?)
+    let requirement = if inputs.skip_post {
+        SignerRequirement::OfflineApproval
     } else {
-        None
+        SignerRequirement::Any
     };
-    let approval = sign_and_write_approval(
-        &operator,
-        &OperatorCtx {
-            auth: auth.as_ref(),
-        },
-        inputs.approval_out.as_deref(),
-        &inputs.manifest,
-    )
-    .await?;
+    let operator =
+        resolve_operator(inputs.operator_seed_source, inputs.operator_id, requirement).await?;
+
+    let approval = operator.approve_manifest(&inputs.manifest).await?;
+
+    // Reporting the approval (inline payload or file path) is the terminal
+    // outcome's job; `--approval-out` additionally persists it here.
+    if let Some(path) = inputs.approval_out.as_deref() {
+        let json = serde_json::to_string_pretty(&approval)?;
+        write_file(path, &json).await?;
+    }
 
     match inputs.post_target {
         Some(target) => {
@@ -554,25 +552,6 @@ async fn load_manifest(
         }
         (None, None) => bail!("a manifest source is required"),
     }
-}
-
-/// Sign the manifest and, when `--approval-out` is set, write the approval to
-/// that file. Reporting the approval (inline payload or file path) is the
-/// terminal outcome's job.
-async fn sign_and_write_approval(
-    operator: &ResolvedOperator,
-    operator_ctx: &OperatorCtx<'_>,
-    approval_out: Option<&Path>,
-    manifest: &ValidatedManifest<'_>,
-) -> anyhow::Result<Approval> {
-    let approval = operator.approve_manifest(operator_ctx, manifest).await?;
-
-    if let Some(path) = approval_out {
-        let json = serde_json::to_string_pretty(&approval)?;
-        write_file(path, &json).await?;
-    }
-
-    Ok(approval)
 }
 
 #[instrument(skip_all, fields(manifest_id = %plan.manifest_id, operator_id = %plan.operator_id, deploy_id = ?plan.deploy_id))]

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -4,8 +4,7 @@ use crate::{
     client::{build_client, fetch_tvc_deployment},
     config::turnkey::Config,
     operator::{
-        ResolvedHostedOperator, ensure_authenticated_org, hosted_activity_error,
-        resolve_hosted_operator, timestamp_ms,
+        ResolvedHostedOperator, ensure_authenticated_org, hosted_activity_error, timestamp_ms,
     },
     outcome::Outcome,
     output::StdCtx,
@@ -78,7 +77,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     }
 
     let config = Config::load().await?;
-    let operator = resolve_hosted_operator(&config, &operator_id)?;
+    let operator = config.resolve_hosted_operator(&operator_id)?;
     let auth = build_client().await?;
     ensure_authenticated_org(&auth.org_id, operator.organization_id())?;
 
@@ -265,11 +264,9 @@ mod tests {
     }
 
     fn resolved_member(fixture: &ValidProvisioningDetailsFixture) -> ResolvedHostedOperator {
-        resolve_hosted_operator(
-            &config_for_member(fixture),
-            &Uuid::parse_str(OPERATOR_ID).unwrap(),
-        )
-        .unwrap()
+        config_for_member(fixture)
+            .resolve_hosted_operator(&Uuid::parse_str(OPERATOR_ID).unwrap())
+            .unwrap()
     }
 
     fn deployment_manifest_bytes(manifest_envelope: VersionedManifestEnvelope) -> Vec<u8> {

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -60,7 +60,10 @@ impl Run for Args {
                 .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?,
         };
 
-        let source = &org_config.select_local_record(alias)?.key_path;
+        let (_, local) = org_config
+            .select_local_operator()
+            .with_context(|| format!("org '{alias}'"))?;
+        let source = &local.key_path;
 
         let destination = match self.output {
             // --output is a CLI argument: validate it, honoring --overwrite

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -3,10 +3,7 @@
 use crate::{
     client::build_client,
     config::turnkey::Config,
-    operator::{
-        OperatorPublicKey, ensure_authenticated_org, hosted_activity_error,
-        resolve_hosted_operator_encrypt_key,
-    },
+    operator::{OperatorPublicKey, ensure_authenticated_org, hosted_activity_error},
     outcome::Outcome,
     output::StdCtx,
 };
@@ -171,14 +168,17 @@ fn resolve_operator_ids(
     let (_, org) = config
         .active_org_config()
         .context("No active organization. Run `tvc login` first.")?;
-    let configured_org_id = org.id.clone();
-    let mut keys = Vec::with_capacity(operator_ids.len());
 
-    for operator_id in operator_ids {
-        keys.push(resolve_hosted_operator_encrypt_key(config, operator_id)?);
-    }
+    let keys = operator_ids
+        .iter()
+        .map(|id| {
+            config
+                .resolve_hosted_operator_encrypt_key(id)
+                .map(OperatorPublicKey::from)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-    Ok((keys, Some(configured_org_id)))
+    Ok((keys, Some(org.id.clone())))
 }
 
 fn validate_operator_ids(operator_ids: &[Uuid]) -> Result<()> {

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -70,8 +70,8 @@ Edit the file to fill in your values, then run:
 /// Load the operator public key from the active org's config.
 async fn load_operator_public_key() -> Option<String> {
     let config = Config::load().await.ok()?;
-    let (alias, org_config) = config.active_org_config()?;
-    let local = org_config.select_local_record(alias).ok()?;
+    let (_, org_config) = config.active_org_config()?;
+    let (_, local) = org_config.select_local_operator().ok()?;
     let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
     Some(operator_key.public_key.to_string())
 }

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -3,7 +3,7 @@
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
-use crate::pair::{HexSeed, Pair};
+use crate::pair::{HexSeed, LocalPair, Signer};
 use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
 use crate::shell_eprintln;
@@ -129,7 +129,9 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
 async fn build_re_encrypted_share_output(
     quorum_key_metadata: &QuorumKeyMetadata,
     provision_bundle: &ProvisionBundle,
-    operator_pair: &dyn Pair,
+    // Concretely local: re-encryption decrypts the share, and decryption
+    // needs local key material.
+    operator_pair: &LocalPair,
     dangerous_skip_verification: bool,
 ) -> anyhow::Result<ReEncryptedShareOutput> {
     ensure_quorum_key_matches_manifest(quorum_key_metadata, provision_bundle)?;
@@ -142,8 +144,7 @@ async fn build_re_encrypted_share_output(
 
     let re_encrypted_share = {
         let plaintext_share = operator_pair
-            .decrypt(encrypted_share)
-            .await
+            .decrypt(&encrypted_share)
             .context("failed to decrypt share with operator key")?;
 
         ephemeral_public_key
@@ -152,12 +153,7 @@ async fn build_re_encrypted_share_output(
     };
 
     let signature = operator_pair
-        .sign(
-            provision_bundle
-                .manifest_envelope()
-                .manifest_hash()
-                .to_vec(),
-        )
+        .sign(&provision_bundle.manifest_envelope().manifest_hash())
         .await
         .context("failed to sign share approval with operator key")?;
     let share_approval = Approval { signature, member };

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -366,11 +366,10 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     // Operator key path now lives in the org's local operator record (the
     // versioned registry), not on `OrgConfig` directly. Resolve it before the
     // struct literal so `alias` is still available (the struct moves it).
-    let operator_key_path = org_config
-        .select_local_record(&alias)?
-        .key_path
-        .display()
-        .to_string();
+    let (_, local) = org_config
+        .select_local_operator()
+        .with_context(|| format!("org '{alias}'"))?;
+    let operator_key_path = local.key_path.display().to_string();
 
     Ok(Outcome::LoggedIn(LoggedIn {
         organization_name: whoami.organization_name,
@@ -563,7 +562,9 @@ async fn find_or_generate_operator_key(
     org_alias: &str,
     org_config: &OrgConfig,
 ) -> Result<StoredQosOperatorKey> {
-    let local = org_config.select_local_record(org_alias)?;
+    let (_, local) = org_config
+        .select_local_operator()
+        .with_context(|| format!("org '{org_alias}'"))?;
     debug!(operator_key_path = %local.key_path.display(), "resolving operator key");
 
     if let Some(operator_key) = StoredQosOperatorKey::load(&local.key_path).await? {

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -4,8 +4,8 @@ use crate::{
     client::build_client,
     config::turnkey::{Config, OperatorRecord, OperatorRecordKind},
     operator::{
-        DEFAULT_HOSTED_OPERATOR_BASE_PATH, HostedOperatorSpec, HostedOperatorWallet,
-        create_hosted_operator, ensure_authenticated_org,
+        DEFAULT_HOSTED_OPERATOR_BASE_PATH, ensure_authenticated_org,
+        hosted::CreateOperatorRequestResult, hosted_activity_error, timestamp_ms,
     },
     outcome::Outcome,
     output::StdCtx,
@@ -15,6 +15,7 @@ use clap::{ArgGroup, Args as ClapArgs, builder::NonEmptyStringValueParser};
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use tracing::instrument;
+use turnkey_client::generated::CreateTvcOperatorIntent;
 use uuid::Uuid;
 
 const DEFAULT_OPERATOR_NAME: &str = "tvc-operator";
@@ -108,15 +109,45 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     let auth = build_client().await?;
     ensure_authenticated_org(&auth.org_id, configured_org_id)?;
 
-    let record = create_hosted_operator(&auth, hosted_operator_spec(args)).await?;
-    let output = output_from_record(record.clone())?;
+    let HostedOperatorSpec { name, wallet, path } = args.into();
+
+    let (wallet_name, wallet_id) = match wallet {
+        HostedOperatorWallet::New(name) => (Some(name), None),
+        HostedOperatorWallet::Existing(id) => (None, Some(id.to_string())),
+    };
+
+    let intent = CreateTvcOperatorIntent {
+        wallet_name,
+        wallet_id,
+        path: path.clone(),
+        operator_name: name.clone(),
+    };
+
+    let result = auth
+        .client
+        .create_tvc_operator(auth.org_id.clone(), timestamp_ms()?, intent)
+        .await
+        .map_err(|error| hosted_activity_error("create hosted TVC operator", error))?;
+
+    let result = CreateOperatorRequestResult {
+        name,
+        path,
+        result: result.result,
+    };
+
+    let record = OperatorRecord::try_from(result)?;
 
     config
         .orgs
         .get_mut(&alias)
         .with_context(|| format!("active organization '{alias}' disappeared from config"))?
         .operators
-        .push(record);
+        .push(record.clone());
+
+    let OperatorRecord { name, kind } = record;
+    let OperatorRecordKind::Hosted(hosted) = kind else {
+        return Err(anyhow!("hosted operator creation returned a local record"));
+    };
 
     if let Err(save_error) = config.save().await {
         let record = config
@@ -132,38 +163,53 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
 Do not retry creation blindly; doing so would create another remote operator. Restore this record under the active organization in tvc.config.toml:
 
 {recovery}"#,
-            output.operator_id
+            hosted.operator_id
         ));
     }
 
-    Ok(Outcome::OperatorCreated(output))
-}
-
-fn hosted_operator_spec(args: Args) -> HostedOperatorSpec {
-    let wallet = match args.wallet_id {
-        Some(id) => HostedOperatorWallet::Existing(id),
-        None => HostedOperatorWallet::New(args.wallet_name),
-    };
-
-    HostedOperatorSpec::new(args.name, wallet, args.account_path)
-}
-
-fn output_from_record(record: OperatorRecord) -> Result<OperatorCreated> {
-    let OperatorRecord { name, kind } = record;
-    let OperatorRecordKind::Hosted(hosted) = kind else {
-        return Err(anyhow!("hosted operator creation returned a local record"));
-    };
-    let composite_public_key = format!("{}{}", hosted.encrypt_public_key, hosted.sign_public_key);
-
-    Ok(OperatorCreated {
+    let output = OperatorCreated {
         name,
+        composite_public_key: format!("{}{}", hosted.encrypt_public_key, hosted.sign_public_key),
         operator_id: hosted.operator_id,
         wallet_id: hosted.wallet_id,
         encrypt_public_key: hosted.encrypt_public_key,
         sign_public_key: hosted.sign_public_key,
-        composite_public_key,
         saved: true,
-    })
+    };
+
+    Ok(Outcome::OperatorCreated(output))
+}
+
+/// Inputs for creating one hosted TVC operator.
+#[derive(Debug, PartialEq, Eq)]
+struct HostedOperatorSpec {
+    name: String,
+    wallet: HostedOperatorWallet,
+    path: String,
+}
+
+/// Valid wallet selections for hosted operator creation.
+#[derive(Debug, PartialEq, Eq)]
+enum HostedOperatorWallet {
+    /// Create a new wallet with this name to hold the operator accounts.
+    New(String),
+    /// Add the operator accounts to the existing wallet with this ID.
+    Existing(Uuid),
+}
+
+impl From<Args> for HostedOperatorSpec {
+    fn from(args: Args) -> Self {
+        let wallet = match args.wallet_id {
+            Some(id) => HostedOperatorWallet::Existing(id),
+            None => HostedOperatorWallet::New(args.wallet_name),
+        };
+
+        HostedOperatorSpec {
+            name: args.name,
+            wallet,
+            path: args.account_path,
+        }
+    }
 }
 
 fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
@@ -213,25 +259,5 @@ mod tests {
             toml::from_str(&recovery_toml("default", &expected).unwrap()).unwrap();
 
         assert_eq!(recovery.orgs["default"].operators, vec![expected]);
-    }
-
-    #[test]
-    fn operator_created_serializes_expected_json() {
-        let output = output_from_record(hosted_record()).unwrap();
-        let value = serde_json::to_value(Outcome::OperatorCreated(output)).unwrap();
-
-        assert_eq!(
-            value,
-            serde_json::json!({
-                "reason": "operator_created",
-                "name": "tvc-operator",
-                "operatorId": "11111111-1111-4111-8111-111111111111",
-                "walletId": "22222222-2222-4222-8222-222222222222",
-                "encryptPublicKey": format!("04{}", "11".repeat(64)),
-                "signPublicKey": format!("04{}", "22".repeat(64)),
-                "compositePublicKey": format!("04{}04{}", "11".repeat(64), "22".repeat(64)),
-                "saved": true,
-            })
-        );
     }
 }

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::path::PathBuf;
+use thiserror::Error;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -330,38 +331,36 @@ pub struct OrgConfig {
     pub extra: toml::Table,
 }
 
-impl OrgConfig {
-    /// Return the sole active local operator registry entry.
-    pub(crate) fn select_local_operator(&self, org_alias: &str) -> Result<&OperatorRecord> {
-        if self.default_operator_kind != OperatorKind::Local {
-            bail!(
-                "the active operator kind for org '{org_alias}' is {}",
-                self.default_operator_kind
-            )
-        }
+/// Failure modes of selecting the sole local operator of an organization.
+/// Which organization it was is the caller's context to add.
+#[derive(Debug, Error)]
+pub enum SelectLocalOperatorError {
+    #[error("no local operator is configured")]
+    NoLocalOperator,
+    #[error("multiple local operators are configured")]
+    MultipleLocalOperators,
+}
 
-        let candidates: Vec<_> = self
+impl OrgConfig {
+    /// Select the sole local operator registry entry, with its kind-specific
+    /// record. Purely a registry query: whether local is the organization's
+    /// default backend is resolution policy, decided elsewhere.
+    pub(crate) fn select_local_operator(
+        &self,
+    ) -> Result<(&OperatorRecord, &LocalOperatorRecord), SelectLocalOperatorError> {
+        let mut locals = self
             .operators
             .iter()
-            .filter(|operator| matches!(operator.kind, OperatorRecordKind::Local(_)))
-            .collect();
+            .filter_map(|operator| match &operator.kind {
+                OperatorRecordKind::Local(local) => Some((operator, local)),
+                OperatorRecordKind::Hosted(_) => None,
+            });
 
-        // TODO: Decouple this function from its org_alias callsite so it is more
-        // flexible to be used anywhere else.
-        match candidates.as_slice() {
-            [] => bail!("No local operator configured for org '{org_alias}'"),
-            [operator] => Ok(*operator),
-            _ => bail!("Multiple local operators are configured for org '{org_alias}'"),
+        match (locals.next(), locals.next()) {
+            (Some(sole), None) => Ok(sole),
+            (None, _) => Err(SelectLocalOperatorError::NoLocalOperator),
+            (Some(_), Some(_)) => Err(SelectLocalOperatorError::MultipleLocalOperators),
         }
-    }
-
-    /// Return the kind-specific record for the sole active local operator.
-    pub fn select_local_record(&self, org_alias: &str) -> Result<&LocalOperatorRecord> {
-        let operator = self.select_local_operator(org_alias)?;
-        let OperatorRecordKind::Local(local) = &operator.kind else {
-            bail!("selected operator is not local");
-        };
-        Ok(local)
     }
 }
 

--- a/tvc/src/local_operator_key.rs
+++ b/tvc/src/local_operator_key.rs
@@ -57,7 +57,9 @@ pub async fn resolve_local_operator(
                      --operator-seed or --operator-seed-path."
                 )
             })?;
-            let local = org_config.select_local_record(alias)?;
+            let (_, local) = org_config
+                .select_local_operator()
+                .with_context(|| format!("org '{alias}'"))?;
             return resolve_registered_local_operator(local.key_path.clone()).await;
         }
     };
@@ -102,7 +104,7 @@ async fn resolve_local_credential(source: LocalCredentialSource) -> anyhow::Resu
 mod tests {
     use super::*;
     use crate::config::turnkey::{QosOperatorPublicKey, StoredQosOperatorKey};
-    use crate::pair::Pair;
+    use crate::pair::Signer;
     use std::fs;
     use tempfile::TempDir;
 
@@ -147,7 +149,6 @@ mod tests {
         fs::write(
             &path,
             serde_json::to_string(&StoredQosOperatorKey {
-                // The resolve path only reads the seed; a nil key stands in.
                 public_key: QosOperatorPublicKey::default(),
                 private_key: private_key.clone(),
             })

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -1,15 +1,26 @@
-//! TVC operator creation and manifest approval.
+//! TVC operator resolution and manifest approval.
+//!
+//! Operator semantics are isolated here: resolution decides which backend an
+//! operator uses and seals that decision behind the [`Signer`] port, so
+//! everything downstream treats an operator as identity plus a signing
+//! capability. Hosted-specific behavior lives in [`hosted`].
 
-use crate::approvals::ValidatedManifest;
-use crate::client::AuthenticatedClient;
-use crate::config::turnkey::{
-    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind,
+pub(crate) mod hosted;
+
+pub use hosted::DEFAULT_HOSTED_OPERATOR_BASE_PATH;
+pub(crate) use hosted::{ResolvedHostedOperator, hosted_activity_error};
+
+use crate::{
+    approvals::ValidatedManifest,
+    client::build_client,
+    config::turnkey::{Config, OperatorKind},
+    local_operator_key::{
+        LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
+    },
+    pair::Signer,
 };
-use crate::local_operator_key::{
-    LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
-};
-use crate::pair::{LocalPair, Pair};
 use anyhow::{Context, Result, anyhow, bail, ensure};
+use hosted::HostedSigner;
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
 use qos_core::protocol::services::boot::{Approval, VersionedManifest};
 use std::{
@@ -18,37 +29,19 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
-use turnkey_client::{
-    TurnkeyClientError,
-    generated::{
-        CreateTvcOperatorIntent, CreateTvcOperatorResult, SignRawPayloadIntentV2,
-        SignRawPayloadResult,
-        immutable::common::v1::{HashFunction, PayloadEncoding},
-    },
-};
 use uuid::Uuid;
-
-/// Default base derivation path for hosted TVC operator accounts.
-///
-/// `5527107` is `0x545643` (the ASCII bytes for `TVC`) and reserves a
-/// TVC-specific hardened BIP32 namespace. The next component is the path
-/// version (`0`) and the final component is the operator index (`0`). The
-/// Turnkey signer appends `/0` for the encryption account and `/1` for the
-/// signing account. Callers creating more than one operator in the same wallet
-/// must currently provide a different base path themselves.
-pub const DEFAULT_HOSTED_OPERATOR_BASE_PATH: &str = "m/5527107'/0'/0'";
 
 /// A validated, uncompressed P-256 operator public key.
 ///
 /// String parsing accepts bare hexadecimal input with surrounding whitespace.
 /// Display always emits canonical lowercase hexadecimal.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct OperatorPublicKey(PublicKey);
+pub struct OperatorPublicKey(PublicKey);
 
 /// Error returned when parsing an [`OperatorPublicKey`].
 #[derive(Debug, Error)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-pub(crate) enum OperatorPublicKeyParseError {
+pub enum OperatorPublicKeyParseError {
     /// The input was empty after trimming surrounding whitespace.
     #[error("must not be empty")]
     Empty,
@@ -89,233 +82,14 @@ impl Display for OperatorPublicKey {
     }
 }
 
-/// Inputs for creating one hosted TVC operator.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct HostedOperatorSpec {
-    name: String,
-    wallet: HostedOperatorWallet,
-    path: String,
-}
-
-/// Valid wallet selections for hosted operator creation.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum HostedOperatorWallet {
-    New(String),
-    Existing(Uuid),
-}
-
-impl HostedOperatorSpec {
-    pub(crate) fn new(name: String, wallet: HostedOperatorWallet, path: String) -> Self {
-        Self { name, wallet, path }
-    }
-}
-
-/// Create one Turnkey-hosted TVC operator and return a registry-ready record.
-pub(crate) async fn create_hosted_operator(
-    auth: &AuthenticatedClient,
-    spec: HostedOperatorSpec,
-) -> Result<OperatorRecord> {
-    let HostedOperatorSpec { name, wallet, path } = spec;
-    let (wallet_name, wallet_id) = match wallet {
-        HostedOperatorWallet::New(name) => (Some(name), None),
-        HostedOperatorWallet::Existing(id) => (None, Some(id.to_string())),
-    };
-
-    let intent = CreateTvcOperatorIntent {
-        wallet_name,
-        wallet_id,
-        path: path.clone(),
-        operator_name: name.clone(),
-    };
-    let result = auth
-        .client
-        .create_tvc_operator(auth.org_id.clone(), timestamp_ms()?, intent)
-        .await
-        .map_err(|error| hosted_activity_error("create hosted TVC operator", error))?;
-
-    operator_record_from_result(name, path, result.result)
-}
-
-fn operator_record_from_result(
-    name: String,
-    path: String,
-    result: CreateTvcOperatorResult,
-) -> Result<OperatorRecord> {
-    let CreateTvcOperatorResult {
-        wallet_id,
-        operator_id,
-        encrypt_public_key,
-        sign_public_key,
-    } = result;
-    let wallet_id = parse_uuid(&wallet_id, "created wallet ID")?;
-    let operator_id = parse_uuid(&operator_id, "created operator ID")?;
-    let encrypt_public_key = normalize_public_key(
-        &encrypt_public_key,
-        "created operator encryption public key",
-    )?;
-    let sign_public_key =
-        normalize_public_key(&sign_public_key, "created operator signing public key")?;
-    ensure!(
-        encrypt_public_key != sign_public_key,
-        "created operator encryption and signing public keys must be distinct"
-    );
-
-    Ok(OperatorRecord {
-        name,
-        kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
-            operator_id,
-            wallet_id,
-            path,
-            encrypt_public_key,
-            sign_public_key,
-            extra: toml::Table::new(),
-        }),
-    })
-}
-
-fn parse_uuid(value: &str, field: &str) -> Result<Uuid> {
-    Uuid::parse_str(value).map_err(|_| anyhow!("{field} must be a UUID"))
-}
-
-fn parse_public_key(value: &str, field: &str) -> Result<OperatorPublicKey> {
-    value
-        .parse()
-        .map_err(|error: OperatorPublicKeyParseError| anyhow!("{field} {error}"))
-}
-
-fn normalize_public_key(value: &str, field: &str) -> Result<String> {
-    Ok(parse_public_key(value, field)?.to_string())
-}
-
-fn composite_public_key(record: &HostedOperatorRecord) -> Result<Vec<u8>> {
-    let encrypt = parse_public_key(
-        &record.encrypt_public_key,
-        "hosted operator encryption public key",
-    )?;
-    let sign = parse_public_key(
-        &record.sign_public_key,
-        "hosted operator signing public key",
-    )?;
-    ensure!(
-        encrypt != sign,
-        "hosted operator encryption and signing public keys must be distinct"
-    );
-
-    let mut composite = Vec::with_capacity(130);
-    composite.extend_from_slice(encrypt.0.to_encoded_point(false).as_bytes());
-    composite.extend_from_slice(sign.0.to_encoded_point(false).as_bytes());
-    Ok(composite)
-}
-
-fn validate_hosted_record(
-    name: &str,
-    record: HostedOperatorRecord,
-) -> Result<ValidatedHostedOperatorRecord> {
-    let HostedOperatorRecord {
-        operator_id,
-        wallet_id,
-        path,
-        encrypt_public_key,
-        sign_public_key,
-        extra,
-    } = record;
-    ensure!(
-        !name.trim().is_empty(),
-        "hosted operator name must not be empty"
-    );
-    ensure!(
-        !path.trim().is_empty(),
-        "hosted operator account path must not be empty"
-    );
-
-    let encrypt_public_key =
-        parse_public_key(&encrypt_public_key, "hosted operator encryption public key")?;
-    let sign_public_key = parse_public_key(&sign_public_key, "hosted operator signing public key")?;
-    ensure!(
-        encrypt_public_key != sign_public_key,
-        "hosted operator encryption and signing public keys must be distinct"
-    );
-
-    let record = HostedOperatorRecord {
-        operator_id,
-        wallet_id,
-        path,
-        encrypt_public_key: encrypt_public_key.to_string(),
-        sign_public_key: sign_public_key.to_string(),
-        extra,
-    };
-    Ok(ValidatedHostedOperatorRecord {
-        record,
-        encrypt_public_key,
-        sign_public_key,
-    })
-}
-
-/// A non-serializable operator with its credentials resolved for use.
+/// A non-serializable operator with its credentials resolved for use: common
+/// identity plus the signing capability sealed behind the [`Signer`] port.
 pub(crate) struct ResolvedOperator {
     /// Absent for an ad-hoc local seed override.
     name: Option<String>,
     /// Always present for hosted operators and optional for local operators.
     operator_id: Option<Uuid>,
-    /// Organization from which a registered operator was resolved.
-    organization_id: Option<String>,
-    pub(crate) kind: ResolvedOperatorKind,
-}
-
-/// Kind-specific runtime capability held by a [`ResolvedOperator`].
-pub(crate) enum ResolvedOperatorKind {
-    Local(LocalPair),
-    Hosted(HostedOperatorRecord),
-}
-
-/// Shared dependencies for operator-level workflows.
-pub(crate) struct OperatorCtx<'a> {
-    pub(crate) auth: Option<&'a AuthenticatedClient>,
-}
-
-struct ValidatedHostedOperatorRecord {
-    record: HostedOperatorRecord,
-    encrypt_public_key: OperatorPublicKey,
-    sign_public_key: OperatorPublicKey,
-}
-
-/// One validated hosted operator resolved from the active organization.
-#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-pub(crate) struct ResolvedHostedOperator {
-    organization_id: String,
-    name: String,
-    operator_id: Uuid,
-    encrypt_public_key: OperatorPublicKey,
-    sign_public_key: OperatorPublicKey,
-}
-
-impl ResolvedHostedOperator {
-    pub(crate) fn organization_id(&self) -> &str {
-        &self.organization_id
-    }
-
-    pub(crate) fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub(crate) fn operator_id(&self) -> Uuid {
-        self.operator_id
-    }
-
-    pub(crate) fn encrypt_public_key(&self) -> &OperatorPublicKey {
-        &self.encrypt_public_key
-    }
-
-    pub(crate) fn sign_public_key(&self) -> &OperatorPublicKey {
-        &self.sign_public_key
-    }
-
-    pub(crate) fn composite_public_key(&self) -> Vec<u8> {
-        let mut composite = Vec::with_capacity(130);
-        composite.extend_from_slice(self.encrypt_public_key.0.to_encoded_point(false).as_bytes());
-        composite.extend_from_slice(self.sign_public_key.0.to_encoded_point(false).as_bytes());
-        composite
-    }
+    signer: Box<dyn Signer>,
 }
 
 impl ResolvedOperator {
@@ -327,41 +101,13 @@ impl ResolvedOperator {
         self.operator_id
     }
 
-    pub(crate) fn is_hosted(&self) -> bool {
-        matches!(self.kind, ResolvedOperatorKind::Hosted(_))
-    }
-
-    pub(crate) fn public_key(&self) -> Result<Vec<u8>> {
-        match &self.kind {
-            ResolvedOperatorKind::Local(pair) => Ok(pair.public_key()),
-            ResolvedOperatorKind::Hosted(record) => composite_public_key(record),
-        }
-    }
-
     pub(crate) async fn approve_manifest(
         &self,
-        ctx: &OperatorCtx<'_>,
         manifest: &ValidatedManifest<'_>,
     ) -> Result<Approval> {
-        let public_key = self.public_key()?;
+        let public_key = self.signer.public_key();
         let member = manifest_member(manifest, &public_key, self.name())?;
-        let signature = match &self.kind {
-            ResolvedOperatorKind::Local(pair) => {
-                pair.sign(manifest.manifest_hash().to_vec()).await?
-            }
-            ResolvedOperatorKind::Hosted(record) => {
-                let auth = ctx
-                    .auth
-                    .context("authenticated client required for hosted operator approval")?;
-                let organization_id = self
-                    .organization_id
-                    .as_deref()
-                    .context("configured organization required for hosted operator approval")?;
-                ensure_authenticated_org(&auth.org_id, organization_id)?;
-                sign_hosted_manifest(auth, record, manifest).await?
-            }
-        };
-
+        let signature = self.signer.sign(&manifest.manifest_hash()).await?;
         let approval = Approval { signature, member };
 
         // Membership is already proven — `member` came out of the manifest
@@ -406,39 +152,71 @@ pub(crate) fn ensure_authenticated_org(
     Ok(())
 }
 
+/// What the caller requires of the operator being resolved.
+///
+/// Checked during resolution, so an unsatisfiable requirement is rejected
+/// before any backend dependencies (credentials, API clients) are acquired —
+/// a machine with no credentials at all still gets the real refusal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SignerRequirement {
+    Any,
+    /// The approval must be producible without the network (`--skip-post`).
+    OfflineApproval,
+}
+
+/// Resolve the operator for an approval. The precedence is deliberate and
+/// preserved exactly; there is no fallback between backends:
+///
+/// 1. An explicit seed is a local operator, always. A hosted `--operator-id`
+///    alongside it is rejected.
+/// 2. An operator ID naming a hosted registry record selects that hosted
+///    operator — even when the org's default operator kind is local.
+/// 3. Otherwise the active org's `default_operator_kind` decides, and never
+///    crosses over: `local` resolves the sole local record (reconciling a
+///    given ID against its configured one); `hosted` refuses — an ID is
+///    required, and resolution never falls back to the local key.
 pub(crate) async fn resolve_operator(
     explicit: Option<LocalOperatorSeedSource>,
     operator_id: Option<Uuid>,
+    requirement: SignerRequirement,
 ) -> Result<ResolvedOperator> {
     if let Some(explicit) = explicit {
         if let Some(id) = operator_id {
             let config = Config::load().await?;
             ensure!(
-                find_hosted_operator(&config, &id)?.is_none(),
+                config.find_hosted_operator(&id)?.is_none(),
                 "explicit local operator seed cannot be used with a hosted operator ID"
             );
         }
+
         return Ok(ResolvedOperator {
             name: None,
             operator_id,
-            organization_id: None,
-            kind: ResolvedOperatorKind::Local(resolve_local_operator(Some(explicit)).await?),
+            signer: Box::new(resolve_local_operator(Some(explicit)).await?),
         });
     }
 
     let config = Config::load().await?;
-    let hosted = match operator_id {
-        Some(id) => find_hosted_operator(&config, &id)?,
-        None => None,
-    };
 
-    if let Some((organization_id, name, validated)) = hosted {
-        let record = validated.record;
+    let hosted = operator_id
+        .map(|id| config.find_hosted_operator(&id))
+        .transpose()?
+        .flatten();
+
+    if let Some(hosted) = hosted {
+        // Hosted operators sign through the API, so an offline requirement
+        // is unsatisfiable; refuse before touching credentials.
+        if requirement == SignerRequirement::OfflineApproval {
+            bail!("--skip-post is only supported for local operators");
+        }
+
+        let auth = build_client().await?;
+        ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
+
         return Ok(ResolvedOperator {
-            name: Some(name),
-            operator_id: Some(record.operator_id),
-            organization_id: Some(organization_id),
-            kind: ResolvedOperatorKind::Hosted(record),
+            name: Some(hosted.name().to_string()),
+            operator_id: Some(hosted.operator_id()),
+            signer: Box::new(HostedSigner::new(hosted, auth)),
         });
     }
 
@@ -448,6 +226,7 @@ pub(crate) async fn resolve_operator(
              --operator-seed or --operator-seed-path."
         )
     })?;
+
     if org.default_operator_kind == OperatorKind::Hosted {
         match operator_id {
             Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
@@ -455,16 +234,18 @@ pub(crate) async fn resolve_operator(
         }
     }
 
-    let operator = org.select_local_operator(alias)?;
-    let OperatorRecordKind::Local(local) = &operator.kind else {
-        return Err(anyhow!("selected operator is not local"));
-    };
+    let (operator, local) = org
+        .select_local_operator()
+        .with_context(|| format!("org '{alias}'"))?;
 
     let configured_operator_id = local
         .operator_id
         .as_deref()
-        .map(|id| parse_uuid(id, "configured local operator ID"))
+        .map(|id| {
+            Uuid::parse_str(id).map_err(|_| anyhow!("configured local operator ID must be a UUID"))
+        })
         .transpose()?;
+
     let resolved_operator_id = match (configured_operator_id, operator_id) {
         (Some(configured), Some(requested)) => {
             ensure!(
@@ -479,127 +260,8 @@ pub(crate) async fn resolve_operator(
     Ok(ResolvedOperator {
         name: Some(operator.name.clone()),
         operator_id: resolved_operator_id,
-        organization_id: Some(org.id.clone()),
-        kind: ResolvedOperatorKind::Local(
-            resolve_registered_local_operator(local.key_path.clone()).await?,
-        ),
+        signer: Box::new(resolve_registered_local_operator(local.key_path.clone()).await?),
     })
-}
-
-fn find_hosted_operator(
-    config: &Config,
-    operator_id: &Uuid,
-) -> Result<Option<(String, String, ValidatedHostedOperatorRecord)>> {
-    let Some((_, org)) = config.active_org_config() else {
-        return Ok(None);
-    };
-    let matches: Vec<_> = org
-        .operators
-        .iter()
-        .filter_map(|operator| match &operator.kind {
-            OperatorRecordKind::Hosted(hosted) => {
-                (hosted.operator_id == *operator_id).then_some((operator.name.as_str(), hosted))
-            }
-            OperatorRecordKind::Local(_) => None,
-        })
-        .collect();
-
-    match matches.as_slice() {
-        [] => Ok(None),
-        [(name, record)] => Ok(Some((
-            org.id.clone(),
-            (*name).to_string(),
-            validate_hosted_record(name, (**record).clone())?,
-        ))),
-        _ => bail!("multiple hosted operators have ID {operator_id}"),
-    }
-}
-
-/// Resolve one validated hosted operator from the active organization.
-pub(crate) fn resolve_hosted_operator(
-    config: &Config,
-    operator_id: &Uuid,
-) -> Result<ResolvedHostedOperator> {
-    let (alias, _) = config
-        .active_org_config()
-        .context("No active organization. Run `tvc login` first.")?;
-    let (organization_id, name, validated) = find_hosted_operator(config, operator_id)?
-        .ok_or_else(|| {
-            anyhow!("hosted operator ID '{operator_id}' was not found in org '{alias}'")
-        })?;
-    let ValidatedHostedOperatorRecord {
-        record,
-        encrypt_public_key,
-        sign_public_key,
-    } = validated;
-
-    Ok(ResolvedHostedOperator {
-        organization_id,
-        name,
-        operator_id: record.operator_id,
-        encrypt_public_key,
-        sign_public_key,
-    })
-}
-
-/// Resolve a hosted operator's encryption public key from the active organization.
-pub(crate) fn resolve_hosted_operator_encrypt_key(
-    config: &Config,
-    operator_id: &Uuid,
-) -> Result<OperatorPublicKey> {
-    Ok(resolve_hosted_operator(config, operator_id)?.encrypt_public_key)
-}
-
-async fn sign_hosted_manifest(
-    auth: &AuthenticatedClient,
-    record: &HostedOperatorRecord,
-    manifest: &VersionedManifest,
-) -> Result<Vec<u8>> {
-    let intent = hosted_signing_intent(record.sign_public_key.clone(), &manifest.manifest_hash());
-    let result = auth
-        .client
-        .sign_raw_payload(auth.org_id.clone(), timestamp_ms()?, intent)
-        .await
-        .map_err(|error| hosted_activity_error("sign manifest with hosted operator", error))?;
-
-    signature_bytes(result.result)
-}
-
-fn hosted_signing_intent(sign_with: String, manifest_hash: &[u8]) -> SignRawPayloadIntentV2 {
-    SignRawPayloadIntentV2 {
-        sign_with,
-        payload: hex::encode(manifest_hash),
-        encoding: PayloadEncoding::Hexadecimal,
-        hash_function: HashFunction::Sha256,
-    }
-}
-
-fn signature_bytes(result: SignRawPayloadResult) -> Result<Vec<u8>> {
-    let SignRawPayloadResult { r, s, v: _ } = result;
-    let r = signature_component(&r, "r")?;
-    let s = signature_component(&s, "s")?;
-    Ok(r.into_iter().chain(s).collect())
-}
-
-fn signature_component(value: &str, component: &str) -> Result<Vec<u8>> {
-    let bytes = hex::decode(value)
-        .with_context(|| format!("hosted signature component {component} must be hex encoded"))?;
-    ensure!(
-        bytes.len() == 32,
-        "hosted signature component {component} must be exactly 32 bytes"
-    );
-    Ok(bytes)
-}
-
-pub(crate) fn hosted_activity_error(operation: &str, error: TurnkeyClientError) -> anyhow::Error {
-    let context = match &error {
-        TurnkeyClientError::ActivityRequiresApproval(activity_id) => format!(
-            "failed to {operation}: activity {activity_id} requires additional approvals or authentication"
-        ),
-        _ => format!("failed to {operation}"),
-    };
-
-    anyhow::Error::new(error).context(context)
 }
 
 pub(crate) fn timestamp_ms() -> Result<u128> {
@@ -612,55 +274,12 @@ pub(crate) fn timestamp_ms() -> Result<u128> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::turnkey::{LocalOperatorRecord, OrgConfig};
     use qos_p256::P256Pair;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-
-    const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
-    const WALLET_ID: &str = "22222222-2222-4222-8222-222222222222";
 
     fn public_keys() -> (String, String) {
         let first = P256Pair::generate().unwrap().public_key().to_bytes();
         let second = P256Pair::generate().unwrap().public_key().to_bytes();
         (hex::encode(&first[..65]), hex::encode(&second[65..]))
-    }
-
-    fn hosted_record() -> HostedOperatorRecord {
-        let (encrypt_public_key, sign_public_key) = public_keys();
-        HostedOperatorRecord {
-            operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
-            wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
-            path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
-            encrypt_public_key,
-            sign_public_key,
-            extra: toml::Table::new(),
-        }
-    }
-
-    fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
-        Config {
-            active_org: Some("active".to_string()),
-            orgs: HashMap::from([(
-                "active".to_string(),
-                OrgConfig {
-                    id: "org-id".to_string(),
-                    api_key_path: PathBuf::from("api-key.json"),
-                    api_base_url: "https://api.turnkey.com".to_string(),
-                    default_operator_kind: OperatorKind::Local,
-                    operators,
-                    extra: toml::Table::new(),
-                },
-            )]),
-            ..Config::default()
-        }
-    }
-
-    fn hosted_operator(name: &str, record: HostedOperatorRecord) -> OperatorRecord {
-        OperatorRecord {
-            name: name.to_string(),
-            kind: OperatorRecordKind::Hosted(record),
-        }
     }
 
     #[test]
@@ -702,104 +321,6 @@ mod tests {
     }
 
     #[test]
-    fn resolves_hosted_operator_encrypt_key_from_active_org() {
-        let record = hosted_record();
-        let expected = record.encrypt_public_key.parse().unwrap();
-        let config = config_with_operators(vec![hosted_operator("hosted", record)]);
-        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
-
-        let resolved = resolve_hosted_operator_encrypt_key(&config, &operator_id).unwrap();
-
-        assert_eq!(resolved, expected);
-    }
-
-    #[test]
-    fn resolves_complete_hosted_operator_from_active_org() {
-        let record = hosted_record();
-        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
-        let expected = ResolvedHostedOperator {
-            organization_id: "org-id".to_string(),
-            name: "hosted".to_string(),
-            operator_id,
-            encrypt_public_key: record.encrypt_public_key.parse().unwrap(),
-            sign_public_key: record.sign_public_key.parse().unwrap(),
-        };
-        let expected_composite = expected.composite_public_key();
-        let config = config_with_operators(vec![hosted_operator("hosted", record)]);
-
-        let resolved = resolve_hosted_operator(&config, &operator_id).unwrap();
-
-        assert_eq!(resolved, expected);
-        assert_eq!(resolved.composite_public_key(), expected_composite);
-    }
-
-    #[test]
-    fn hosted_operator_resolution_requires_active_org_and_matching_hosted_record() {
-        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
-        let no_active = Config::default();
-        assert_eq!(
-            resolve_hosted_operator_encrypt_key(&no_active, &operator_id)
-                .unwrap_err()
-                .to_string(),
-            "No active organization. Run `tvc login` first."
-        );
-
-        let local = OperatorRecord {
-            name: "local".to_string(),
-            kind: OperatorRecordKind::Local(LocalOperatorRecord {
-                key_path: PathBuf::from("operator.json"),
-                operator_id: Some(OPERATOR_ID.to_string()),
-                extra: toml::Table::new(),
-            }),
-        };
-        let config = config_with_operators(vec![local]);
-        assert_eq!(
-            resolve_hosted_operator_encrypt_key(&config, &operator_id)
-                .unwrap_err()
-                .to_string(),
-            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
-        );
-
-        let mut cross_org = config_with_operators(Vec::new());
-        let mut inactive_org = cross_org.orgs["active"].clone();
-        inactive_org.id = "inactive-org-id".to_string();
-        inactive_org.operators = vec![hosted_operator("hosted", hosted_record())];
-        cross_org.orgs.insert("inactive".to_string(), inactive_org);
-        assert_eq!(
-            resolve_hosted_operator_encrypt_key(&cross_org, &operator_id)
-                .unwrap_err()
-                .to_string(),
-            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
-        );
-    }
-
-    #[test]
-    fn hosted_operator_resolution_rejects_duplicate_and_malformed_records() {
-        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
-        let record = hosted_record();
-        let duplicate = config_with_operators(vec![
-            hosted_operator("first", record.clone()),
-            hosted_operator("second", record.clone()),
-        ]);
-        assert_eq!(
-            resolve_hosted_operator_encrypt_key(&duplicate, &operator_id)
-                .unwrap_err()
-                .to_string(),
-            "multiple hosted operators have ID 11111111-1111-4111-8111-111111111111"
-        );
-
-        let mut malformed = record;
-        malformed.encrypt_public_key = "not-hex".to_string();
-        let malformed = config_with_operators(vec![hosted_operator("hosted", malformed)]);
-        assert_eq!(
-            resolve_hosted_operator_encrypt_key(&malformed, &operator_id)
-                .unwrap_err()
-                .to_string(),
-            "hosted operator encryption public key must be bare hex encoded"
-        );
-    }
-
-    #[test]
     fn authenticated_org_must_match_configured_org() {
         assert_eq!(
             ensure_authenticated_org("authenticated", "configured")
@@ -807,158 +328,5 @@ mod tests {
                 .to_string(),
             "authenticated organization (authenticated) does not match configured organization (configured)"
         );
-    }
-
-    #[test]
-    fn resolved_hosted_operator_exposes_common_identity() {
-        let record = hosted_record();
-        let operator = ResolvedOperator {
-            name: Some("operator".to_string()),
-            operator_id: Some(record.operator_id),
-            organization_id: Some("org-id".to_string()),
-            kind: ResolvedOperatorKind::Hosted(record.clone()),
-        };
-
-        assert_eq!(operator.name(), Some("operator"));
-        assert_eq!(operator.id(), Some(Uuid::parse_str(OPERATOR_ID).unwrap()));
-        assert!(matches!(
-            &operator.kind,
-            ResolvedOperatorKind::Hosted(actual) if actual == &record
-        ));
-        assert_eq!(
-            operator.public_key().unwrap(),
-            composite_public_key(&record).unwrap()
-        );
-    }
-
-    #[test]
-    fn hosted_operator_lookup_is_scoped_to_active_organization() {
-        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
-        let config = Config {
-            active_org: Some("active".to_string()),
-            orgs: std::collections::HashMap::from([
-                (
-                    "active".to_string(),
-                    crate::config::turnkey::OrgConfig {
-                        id: "active-org".to_string(),
-                        api_key_path: "active-api.json".into(),
-                        api_base_url: "https://api.turnkey.com".to_string(),
-                        default_operator_kind: OperatorKind::Local,
-                        operators: Vec::new(),
-                        extra: toml::Table::new(),
-                    },
-                ),
-                (
-                    "inactive".to_string(),
-                    crate::config::turnkey::OrgConfig {
-                        id: "inactive-org".to_string(),
-                        api_key_path: "inactive-api.json".into(),
-                        api_base_url: "https://api.turnkey.com".to_string(),
-                        default_operator_kind: OperatorKind::Hosted,
-                        operators: vec![OperatorRecord {
-                            name: "hosted".to_string(),
-                            kind: OperatorRecordKind::Hosted(hosted_record()),
-                        }],
-                        extra: toml::Table::new(),
-                    },
-                ),
-            ]),
-            ..Config::default()
-        };
-
-        assert!(
-            find_hosted_operator(&config, &operator_id)
-                .unwrap()
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn validates_and_normalizes_creation_result() {
-        let (encrypt_public_key, sign_public_key) = public_keys();
-        let record = operator_record_from_result(
-            "operator".to_string(),
-            DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
-            CreateTvcOperatorResult {
-                wallet_id: WALLET_ID.to_uppercase(),
-                operator_id: OPERATOR_ID.to_uppercase(),
-                encrypt_public_key: encrypt_public_key.to_uppercase(),
-                sign_public_key: sign_public_key.to_uppercase(),
-            },
-        )
-        .unwrap();
-
-        assert_eq!(
-            record,
-            OperatorRecord {
-                name: "operator".to_string(),
-                kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
-                    operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
-                    wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
-                    path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
-                    encrypt_public_key,
-                    sign_public_key,
-                    extra: toml::Table::new(),
-                }),
-            }
-        );
-    }
-
-    #[test]
-    fn rejects_malformed_operator_id_from_creation_result() {
-        let (encrypt_public_key, sign_public_key) = public_keys();
-        let error = operator_record_from_result(
-            "operator".to_string(),
-            DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
-            CreateTvcOperatorResult {
-                wallet_id: WALLET_ID.to_string(),
-                operator_id: "not-a-uuid".to_string(),
-                encrypt_public_key,
-                sign_public_key,
-            },
-        )
-        .unwrap_err();
-
-        assert_eq!(error.to_string(), "created operator ID must be a UUID");
-    }
-
-    #[test]
-    fn policy_error_includes_activity_id_and_operation() {
-        let error = hosted_activity_error(
-            "sign manifest with hosted operator",
-            TurnkeyClientError::ActivityRequiresApproval("activity-id".to_string()),
-        );
-
-        assert_eq!(
-            error.to_string(),
-            "failed to sign manifest with hosted operator: activity activity-id requires additional approvals or authentication"
-        );
-        assert!(matches!(
-            error.downcast_ref::<TurnkeyClientError>(),
-            Some(TurnkeyClientError::ActivityRequiresApproval(activity_id))
-                if activity_id == "activity-id"
-        ));
-    }
-
-    #[test]
-    fn hosted_activity_error_preserves_client_error_source() {
-        let error = hosted_activity_error(
-            "create hosted TVC operator",
-            TurnkeyClientError::UnexpectedHttpStatus(403, "forbidden".to_string()),
-        );
-
-        assert_eq!(error.to_string(), "failed to create hosted TVC operator");
-        assert_eq!(
-            crate::errors::render_error_chain(&error),
-            "failed to create hosted TVC operator: HTTP response was not successful: 403 (forbidden)"
-        );
-        let classification = crate::errors::classify(&error);
-        assert_eq!(classification.code, crate::errors::ErrorCode::Unauthorized);
-        assert_eq!(classification.http_status, Some(403));
-        assert!(matches!(
-            error.downcast_ref::<TurnkeyClientError>(),
-            Some(TurnkeyClientError::UnexpectedHttpStatus(403, body))
-                if body == "forbidden"
-        ));
     }
 }

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -22,7 +22,7 @@ use crate::{
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hosted::HostedSigner;
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
-use qos_core::protocol::services::boot::{Approval, VersionedManifest};
+use qos_core::protocol::services::boot::Approval;
 use std::{
     fmt::{self, Display, Formatter},
     str::FromStr,
@@ -93,10 +93,6 @@ pub(crate) struct ResolvedOperator {
 }
 
 impl ResolvedOperator {
-    pub(crate) fn name(&self) -> Option<&str> {
-        self.name.as_deref()
-    }
-
     pub(crate) fn id(&self) -> Option<Uuid> {
         self.operator_id
     }
@@ -106,7 +102,24 @@ impl ResolvedOperator {
         manifest: &ValidatedManifest<'_>,
     ) -> Result<Approval> {
         let public_key = self.signer.public_key();
-        let member = manifest_member(manifest, &public_key, self.name())?;
+        let member = {
+            manifest
+                .manifest_set()
+                .members
+                .iter()
+                .find(|member| member.pub_key == public_key)
+                .cloned()
+                .ok_or_else(|| match &self.name {
+                    Some(name) => anyhow!(
+                        "operator '{name}' ({}) not part of manifest set",
+                        hex::encode(public_key)
+                    ),
+                    None => anyhow!(
+                        "operator ({}) not part of manifest set",
+                        hex::encode(public_key)
+                    ),
+                })
+        }?;
         let signature = self.signer.sign(&manifest.manifest_hash()).await?;
         let approval = Approval { signature, member };
 
@@ -116,29 +129,6 @@ impl ResolvedOperator {
 
         Ok(approval)
     }
-}
-
-fn manifest_member(
-    manifest: &VersionedManifest,
-    public_key: &[u8],
-    operator_name: Option<&str>,
-) -> Result<qos_core::protocol::services::boot::QuorumMember> {
-    manifest
-        .manifest_set()
-        .members
-        .iter()
-        .find(|member| member.pub_key == public_key)
-        .cloned()
-        .ok_or_else(|| match operator_name {
-            Some(name) => anyhow!(
-                "operator '{name}' ({}) not part of manifest set",
-                hex::encode(public_key)
-            ),
-            None => anyhow!(
-                "operator ({}) not part of manifest set",
-                hex::encode(public_key)
-            ),
-        })
 }
 
 pub(crate) fn ensure_authenticated_org(

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -1,0 +1,663 @@
+//! Turnkey-hosted operators: creation, registry resolution, and the
+//! API-signing [`Signer`] adapter.
+
+use super::{OperatorPublicKey, timestamp_ms};
+use crate::client::AuthenticatedClient;
+use crate::config::turnkey::{Config, HostedOperatorRecord, OperatorRecord, OperatorRecordKind};
+use crate::pair::{Signer, SignerFuture};
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use std::ops::Deref;
+use std::str::FromStr;
+use turnkey_client::{
+    TurnkeyClientError,
+    generated::{
+        CreateTvcOperatorResult, SignRawPayloadIntentV2, SignRawPayloadResult,
+        immutable::common::v1::{HashFunction, PayloadEncoding},
+    },
+};
+use uuid::Uuid;
+
+/// Default base derivation path for hosted TVC operator accounts.
+///
+/// `5527107` is `0x545643` (the ASCII bytes for `TVC`) and reserves a
+/// TVC-specific hardened BIP32 namespace. The next component is the path
+/// version (`0`) and the final component is the operator index (`0`). The
+/// Turnkey signer appends `/0` for the encryption account and `/1` for the
+/// signing account. Callers creating more than one operator in the same wallet
+/// must currently provide a different base path themselves.
+pub const DEFAULT_HOSTED_OPERATOR_BASE_PATH: &str = "m/5527107'/0'/0'";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EncryptPubKey(OperatorPublicKey);
+#[derive(Debug, PartialEq, Eq)]
+pub struct SignPubKey(OperatorPublicKey);
+
+impl From<EncryptPubKey> for OperatorPublicKey {
+    fn from(key: EncryptPubKey) -> Self {
+        key.0
+    }
+}
+
+impl From<SignPubKey> for OperatorPublicKey {
+    fn from(key: SignPubKey) -> Self {
+        key.0
+    }
+}
+
+impl FromStr for EncryptPubKey {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::prelude::v1::Result<Self, Self::Err> {
+        Ok(Self(s.parse().context("encrypt public key parsing error")?))
+    }
+}
+
+impl FromStr for SignPubKey {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::prelude::v1::Result<Self, Self::Err> {
+        Ok(Self(s.parse().context("sign public key parsing error")?))
+    }
+}
+
+impl Deref for EncryptPubKey {
+    type Target = OperatorPublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Deref for SignPubKey {
+    type Target = OperatorPublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A hosted operator's encryption and signing keys: two distinct P-256
+/// points, together forming the qos composite public key. `R` is the role
+/// whose keys these are; its `Display` form prefixes parse errors.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+struct OperatorKeyPair {
+    encrypt: EncryptPubKey,
+    sign: SignPubKey,
+}
+
+impl OperatorKeyPair {
+    /// Parse each key and require the pair to be distinct; the role's
+    /// `Display` form says whose keys these are in errors.
+    fn try_new(encrypt: EncryptPubKey, sign: SignPubKey) -> Result<Self> {
+        ensure!(
+            encrypt.0 != sign.0,
+            "encryption and signing public keys must be distinct"
+        );
+
+        Ok(Self { encrypt, sign })
+    }
+
+    /// The qos composite public key: `encrypt ‖ sign`, both as uncompressed
+    /// SEC1 points.
+    fn composite(&self) -> Vec<u8> {
+        // Two 65-byte uncompressed SEC1 points.
+        const COMPOSITE_PUBLIC_KEY_LEN: usize = 130;
+
+        let mut composite = Vec::with_capacity(COMPOSITE_PUBLIC_KEY_LEN);
+        composite.extend_from_slice(self.encrypt.deref().0.to_encoded_point(false).as_bytes());
+        composite.extend_from_slice(self.sign.deref().0.to_encoded_point(false).as_bytes());
+        composite
+    }
+}
+
+/// The context of a create-operator request coupled with its API result,
+/// ready to parse into a registry-ready record.
+pub(crate) struct CreateOperatorRequestResult {
+    pub(crate) name: String,
+    pub(crate) path: String,
+    pub(crate) result: CreateTvcOperatorResult,
+}
+
+impl TryFrom<CreateOperatorRequestResult> for OperatorRecord {
+    type Error = anyhow::Error;
+
+    fn try_from(result: CreateOperatorRequestResult) -> Result<Self> {
+        let CreateOperatorRequestResult { name, path, result } = result;
+
+        let CreateTvcOperatorResult {
+            wallet_id,
+            operator_id,
+            encrypt_public_key,
+            sign_public_key,
+        } = result;
+
+        let wallet_id =
+            Uuid::parse_str(&wallet_id).map_err(|_| anyhow!("created wallet ID must be a UUID"))?;
+        let operator_id = Uuid::parse_str(&operator_id)
+            .map_err(|_| anyhow!("created operator ID must be a UUID"))?;
+        let encrypt_public_key = encrypt_public_key
+            .parse()
+            .context("create operator key parsing error")?;
+        let sign_public_key = sign_public_key
+            .parse()
+            .context("create operator key parsing error")?;
+        let keys = OperatorKeyPair::try_new(encrypt_public_key, sign_public_key)?;
+
+        Ok(Self {
+            name,
+            kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                operator_id,
+                wallet_id,
+                path,
+                encrypt_public_key: keys.encrypt.to_string(),
+                sign_public_key: keys.sign.to_string(),
+                extra: toml::Table::new(),
+            }),
+        })
+    }
+}
+
+/// One validated hosted operator resolved from the active organization.
+/// Its keys are parsed exactly once, at resolution.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub(crate) struct ResolvedHostedOperator {
+    organization_id: String,
+    name: String,
+    operator_id: Uuid,
+    keys: OperatorKeyPair,
+}
+
+impl ResolvedHostedOperator {
+    /// Parse and validate a hosted registry record into a resolved operator.
+    fn from_registry(
+        organization_id: String,
+        name: &str,
+        record: &HostedOperatorRecord,
+    ) -> Result<Self> {
+        let HostedOperatorRecord {
+            operator_id,
+            wallet_id: _,
+            path,
+            encrypt_public_key,
+            sign_public_key,
+            extra: _,
+        } = record;
+
+        ensure!(
+            !name.trim().is_empty(),
+            "hosted operator name must not be empty"
+        );
+        ensure!(
+            !path.trim().is_empty(),
+            "hosted operator account path must not be empty"
+        );
+
+        let encrypt_public_key = encrypt_public_key
+            .parse()
+            .context("hosted operator key parsing error")?;
+        let sign_public_key = sign_public_key
+            .parse()
+            .context("hosted operator key parsing error")?;
+
+        let keys = OperatorKeyPair::try_new(encrypt_public_key, sign_public_key)?;
+
+        Ok(Self {
+            organization_id,
+            name: name.to_string(),
+            operator_id: *operator_id,
+            keys,
+        })
+    }
+
+    pub(crate) fn organization_id(&self) -> &str {
+        &self.organization_id
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn operator_id(&self) -> Uuid {
+        self.operator_id
+    }
+
+    pub(crate) fn encrypt_public_key(&self) -> &EncryptPubKey {
+        &self.keys.encrypt
+    }
+
+    pub(crate) fn sign_public_key(&self) -> &SignPubKey {
+        &self.keys.sign
+    }
+
+    pub(crate) fn composite_public_key(&self) -> Vec<u8> {
+        self.keys.composite()
+    }
+}
+
+impl Config {
+    /// Find the hosted registry record with `operator_id` in the active
+    /// organization, if any, validated for use.
+    pub(super) fn find_hosted_operator(
+        &self,
+        operator_id: &Uuid,
+    ) -> Result<Option<ResolvedHostedOperator>> {
+        let Some((_, org)) = self.active_org_config() else {
+            return Ok(None);
+        };
+
+        let mut matches =
+            org.operators
+                .iter()
+                .filter_map(|operator| match &operator.kind {
+                    OperatorRecordKind::Hosted(hosted) => (hosted.operator_id == *operator_id)
+                        .then_some((operator.name.as_str(), hosted)),
+                    OperatorRecordKind::Local(_) => None,
+                });
+
+        match (matches.next(), matches.next()) {
+            (None, _) => Ok(None),
+            (Some((name, record)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
+                org.id.clone(),
+                name,
+                record,
+            )?)),
+            (Some(_), Some(_)) => bail!("multiple hosted operators have ID {operator_id}"),
+        }
+    }
+
+    /// Resolve one validated hosted operator from the active organization.
+    pub(crate) fn resolve_hosted_operator(
+        &self,
+        operator_id: &Uuid,
+    ) -> Result<ResolvedHostedOperator> {
+        let (alias, _) = self
+            .active_org_config()
+            .context("No active organization. Run `tvc login` first.")?;
+
+        self.find_hosted_operator(operator_id)?.ok_or_else(|| {
+            anyhow!("hosted operator ID '{operator_id}' was not found in org '{alias}'")
+        })
+    }
+
+    /// Resolve a hosted operator's encryption public key from the active
+    /// organization.
+    pub(crate) fn resolve_hosted_operator_encrypt_key(
+        &self,
+        operator_id: &Uuid,
+    ) -> Result<EncryptPubKey> {
+        Ok(self.resolve_hosted_operator(operator_id)?.keys.encrypt)
+    }
+}
+
+/// A Turnkey-hosted operator signing through the API with an owned
+/// authenticated client.
+pub(super) struct HostedSigner {
+    operator: ResolvedHostedOperator,
+    auth: AuthenticatedClient,
+}
+
+impl HostedSigner {
+    /// Assemble a hosted signer from its finished dependencies. The caller
+    /// has already verified that `auth` is authenticated against the
+    /// operator's organization.
+    pub(super) fn new(operator: ResolvedHostedOperator, auth: AuthenticatedClient) -> Self {
+        Self { operator, auth }
+    }
+}
+
+impl Signer for HostedSigner {
+    fn sign(&self, message: &[u8]) -> SignerFuture<'_, Result<Vec<u8>>> {
+        let intent = {
+            let sign_with = self.operator.sign_public_key().to_string();
+
+            SignRawPayloadIntentV2 {
+                sign_with,
+                payload: hex::encode(message),
+                encoding: PayloadEncoding::Hexadecimal,
+                hash_function: HashFunction::Sha256,
+            }
+        };
+
+        Box::pin(async move {
+            let result = self
+                .auth
+                .client
+                .sign_raw_payload(self.auth.org_id.clone(), timestamp_ms()?, intent)
+                .await
+                .map_err(|error| {
+                    hosted_activity_error("sign manifest with hosted operator", error)
+                })?;
+
+            let SignRawPayloadResult { r, s, v: _ } = result.result;
+
+            [('r', r), ('s', s)]
+                .into_iter()
+                .map(|(component, val)| {
+                    let bytes = hex::decode(val).context(format!(
+                        "hosted signature component {component} must be hex encoded"
+                    ))?;
+
+                    ensure!(
+                        bytes.len() == 32,
+                        "hosted signature component {component} must be exactly 32 bytes"
+                    );
+
+                    Ok(bytes)
+                })
+                .try_fold(Vec::with_capacity(64), |mut combined, val| {
+                    combined.extend(val?);
+                    Ok(combined)
+                })
+        })
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        self.operator.composite_public_key()
+    }
+}
+
+pub(crate) fn hosted_activity_error(operation: &str, error: TurnkeyClientError) -> anyhow::Error {
+    let context = match &error {
+        TurnkeyClientError::ActivityRequiresApproval(activity_id) => format!(
+            "failed to {operation}: activity {activity_id} requires additional approvals or authentication"
+        ),
+        _ => format!("failed to {operation}"),
+    };
+
+    anyhow::Error::new(error).context(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::turnkey::{LocalOperatorRecord, OperatorKind, OrgConfig};
+    use crate::operator::OperatorPublicKeyParseError;
+    use qos_p256::P256Pair;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const WALLET_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn public_keys() -> (String, String) {
+        let first = P256Pair::generate().unwrap().public_key().to_bytes();
+        let second = P256Pair::generate().unwrap().public_key().to_bytes();
+        (hex::encode(&first[..65]), hex::encode(&second[65..]))
+    }
+
+    fn hosted_record() -> HostedOperatorRecord {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        HostedOperatorRecord {
+            operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
+            wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
+            path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+            encrypt_public_key,
+            sign_public_key,
+            extra: toml::Table::new(),
+        }
+    }
+
+    fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
+        Config {
+            active_org: Some("active".to_string()),
+            orgs: HashMap::from([(
+                "active".to_string(),
+                OrgConfig {
+                    id: "org-id".to_string(),
+                    api_key_path: PathBuf::from("api-key.json"),
+                    api_base_url: "https://api.turnkey.com".to_string(),
+                    default_operator_kind: OperatorKind::Local,
+                    operators,
+                    extra: toml::Table::new(),
+                },
+            )]),
+            ..Config::default()
+        }
+    }
+
+    fn hosted_operator(name: &str, record: HostedOperatorRecord) -> OperatorRecord {
+        OperatorRecord {
+            name: name.to_string(),
+            kind: OperatorRecordKind::Hosted(record),
+        }
+    }
+
+    #[test]
+    fn resolves_hosted_operator_encrypt_key_from_active_org() {
+        let record = hosted_record();
+        let expected = record.encrypt_public_key.parse().unwrap();
+        let config = config_with_operators(vec![hosted_operator("hosted", record)]);
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+
+        let resolved = config
+            .resolve_hosted_operator_encrypt_key(&operator_id)
+            .unwrap();
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolves_complete_hosted_operator_from_active_org() {
+        let record = hosted_record();
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let expected = ResolvedHostedOperator {
+            organization_id: "org-id".to_string(),
+            name: "hosted".to_string(),
+            operator_id,
+            keys: OperatorKeyPair {
+                encrypt: record.encrypt_public_key.parse().unwrap(),
+                sign: record.sign_public_key.parse().unwrap(),
+            },
+        };
+        let expected_composite = expected.composite_public_key();
+        let config = config_with_operators(vec![hosted_operator("hosted", record)]);
+
+        let resolved = config.resolve_hosted_operator(&operator_id).unwrap();
+
+        assert_eq!(resolved, expected);
+        assert_eq!(resolved.composite_public_key(), expected_composite);
+    }
+
+    #[test]
+    fn hosted_operator_resolution_requires_active_org_and_matching_hosted_record() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let no_active = Config::default();
+        assert_eq!(
+            no_active
+                .resolve_hosted_operator_encrypt_key(&operator_id)
+                .unwrap_err()
+                .to_string(),
+            "No active organization. Run `tvc login` first."
+        );
+
+        let local = OperatorRecord {
+            name: "local".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path: PathBuf::from("operator.json"),
+                operator_id: Some(OPERATOR_ID.to_string()),
+                extra: toml::Table::new(),
+            }),
+        };
+        let config = config_with_operators(vec![local]);
+        assert_eq!(
+            config
+                .resolve_hosted_operator_encrypt_key(&operator_id)
+                .unwrap_err()
+                .to_string(),
+            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
+        );
+
+        let mut cross_org = config_with_operators(Vec::new());
+        let mut inactive_org = cross_org.orgs["active"].clone();
+        inactive_org.id = "inactive-org-id".to_string();
+        inactive_org.operators = vec![hosted_operator("hosted", hosted_record())];
+        cross_org.orgs.insert("inactive".to_string(), inactive_org);
+        assert_eq!(
+            cross_org
+                .resolve_hosted_operator_encrypt_key(&operator_id)
+                .unwrap_err()
+                .to_string(),
+            "hosted operator ID '11111111-1111-4111-8111-111111111111' was not found in org 'active'"
+        );
+    }
+
+    #[test]
+    fn hosted_operator_resolution_rejects_duplicate_and_malformed_records() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let record = hosted_record();
+        let duplicate = config_with_operators(vec![
+            hosted_operator("first", record.clone()),
+            hosted_operator("second", record.clone()),
+        ]);
+        assert_eq!(
+            duplicate
+                .resolve_hosted_operator_encrypt_key(&operator_id)
+                .unwrap_err()
+                .to_string(),
+            "multiple hosted operators have ID 11111111-1111-4111-8111-111111111111"
+        );
+
+        let mut malformed = record;
+        malformed.encrypt_public_key = "not-hex".to_string();
+        let malformed = config_with_operators(vec![hosted_operator("hosted", malformed)]);
+        let error = malformed
+            .resolve_hosted_operator_encrypt_key(&operator_id)
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<OperatorPublicKeyParseError>(),
+            Some(&OperatorPublicKeyParseError::InvalidHex)
+        );
+    }
+
+    #[test]
+    fn hosted_operator_lookup_is_scoped_to_active_organization() {
+        let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
+        let config = Config {
+            active_org: Some("active".to_string()),
+            orgs: HashMap::from([
+                (
+                    "active".to_string(),
+                    OrgConfig {
+                        id: "active-org".to_string(),
+                        api_key_path: "active-api.json".into(),
+                        api_base_url: "https://api.turnkey.com".to_string(),
+                        default_operator_kind: OperatorKind::Local,
+                        operators: Vec::new(),
+                        extra: toml::Table::new(),
+                    },
+                ),
+                (
+                    "inactive".to_string(),
+                    OrgConfig {
+                        id: "inactive-org".to_string(),
+                        api_key_path: "inactive-api.json".into(),
+                        api_base_url: "https://api.turnkey.com".to_string(),
+                        default_operator_kind: OperatorKind::Hosted,
+                        operators: vec![OperatorRecord {
+                            name: "hosted".to_string(),
+                            kind: OperatorRecordKind::Hosted(hosted_record()),
+                        }],
+                        extra: toml::Table::new(),
+                    },
+                ),
+            ]),
+            ..Config::default()
+        };
+
+        assert!(config.find_hosted_operator(&operator_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn validates_and_normalizes_creation_result() {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        let result = CreateTvcOperatorResult {
+            wallet_id: WALLET_ID.to_uppercase(),
+            operator_id: OPERATOR_ID.to_uppercase(),
+            encrypt_public_key: encrypt_public_key.to_uppercase(),
+            sign_public_key: sign_public_key.to_uppercase(),
+        };
+
+        let result = CreateOperatorRequestResult {
+            name: "operator".into(),
+            path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.into(),
+            result,
+        };
+
+        let record = OperatorRecord::try_from(result).unwrap();
+
+        assert_eq!(
+            record,
+            OperatorRecord {
+                name: "operator".to_string(),
+                kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                    operator_id: Uuid::parse_str(OPERATOR_ID).unwrap(),
+                    wallet_id: Uuid::parse_str(WALLET_ID).unwrap(),
+                    path: DEFAULT_HOSTED_OPERATOR_BASE_PATH.to_string(),
+                    encrypt_public_key,
+                    sign_public_key,
+                    extra: toml::Table::new(),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_operator_id_from_creation_result() {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        let name = "operator".into();
+        let path = DEFAULT_HOSTED_OPERATOR_BASE_PATH.into();
+
+        let result = CreateTvcOperatorResult {
+            wallet_id: WALLET_ID.to_string(),
+            operator_id: "not-a-uuid".to_string(),
+            encrypt_public_key,
+            sign_public_key,
+        };
+
+        let result = CreateOperatorRequestResult { name, path, result };
+        let error = OperatorRecord::try_from(result).unwrap_err();
+
+        assert_eq!(error.to_string(), "created operator ID must be a UUID");
+    }
+
+    #[test]
+    fn policy_error_includes_activity_id_and_operation() {
+        let error = hosted_activity_error(
+            "sign manifest with hosted operator",
+            TurnkeyClientError::ActivityRequiresApproval("activity-id".to_string()),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "failed to sign manifest with hosted operator: activity activity-id requires additional approvals or authentication"
+        );
+        assert!(matches!(
+            error.downcast_ref::<TurnkeyClientError>(),
+            Some(TurnkeyClientError::ActivityRequiresApproval(activity_id))
+                if activity_id == "activity-id"
+        ));
+    }
+
+    #[test]
+    fn hosted_activity_error_preserves_client_error_source() {
+        let error = hosted_activity_error(
+            "create hosted TVC operator",
+            TurnkeyClientError::UnexpectedHttpStatus(403, "forbidden".to_string()),
+        );
+
+        assert_eq!(error.to_string(), "failed to create hosted TVC operator");
+        assert_eq!(
+            crate::errors::render_error_chain(&error),
+            "failed to create hosted TVC operator: HTTP response was not successful: 403 (forbidden)"
+        );
+        let classification = crate::errors::classify(&error);
+        assert_eq!(classification.code, crate::errors::ErrorCode::Unauthorized);
+        assert_eq!(classification.http_status, Some(403));
+        assert!(matches!(
+            error.downcast_ref::<TurnkeyClientError>(),
+            Some(TurnkeyClientError::UnexpectedHttpStatus(403, body))
+                if body == "forbidden"
+        ));
+    }
+}

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -9,18 +9,20 @@ use std::str::FromStr;
 use std::sync::Arc;
 use zeroize::Zeroizing;
 
-/// Boxed future returned by key pair operations.
-pub type PairFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+/// Boxed future returned by signing operations.
+pub type SignerFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Something that can do key pair operations with the QOS p256 scheme.
-pub trait Pair: Send + Sync {
+/// A signer for the QOS p256 operator scheme.
+///
+/// Implementations differ in where the key material lives — a local key
+/// pair, or a Turnkey-hosted operator signing through the API — and callers
+/// cannot tell them apart.
+pub trait Signer: Send + Sync {
     /// Sign the given message.
-    fn sign(&self, message: Vec<u8>) -> PairFuture<'_, anyhow::Result<Vec<u8>>>;
+    fn sign(&self, message: &[u8]) -> SignerFuture<'_, anyhow::Result<Vec<u8>>>;
 
-    /// Decrypt the given ciphertext.
-    fn decrypt(&self, ciphertext: Vec<u8>) -> PairFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>>;
-
-    /// The public key for this pair.
+    /// The operator public key in the qos composite form
+    /// (encryption point ‖ signing point).
     fn public_key(&self) -> Vec<u8>;
 }
 
@@ -53,6 +55,7 @@ impl Debug for HexSeed {
 /// A local QOS P256 key pair.
 #[derive(Clone)]
 pub struct LocalPair {
+    /// The actual pair is a singleton
     pair: Arc<P256Pair>,
 }
 
@@ -77,37 +80,30 @@ impl LocalPair {
             pair: Arc::new(pair),
         })
     }
+
+    /// Decrypt the given ciphertext. Decryption needs the private key
+    /// material, so it lives on the concrete local pair rather than
+    /// [`Signer`].
+    pub fn decrypt(&self, ciphertext: &[u8]) -> anyhow::Result<Zeroizing<Vec<u8>>> {
+        self.pair
+            .decrypt(ciphertext)
+            .map_err(|_| anyhow!("failed to decrypt with local signer"))
+    }
 }
 
-impl Pair for LocalPair {
-    fn sign(&self, message: Vec<u8>) -> PairFuture<'_, anyhow::Result<Vec<u8>>> {
-        let pair2 = Arc::clone(&self.pair);
+impl Signer for LocalPair {
+    fn sign(&self, message: &[u8]) -> SignerFuture<'_, anyhow::Result<Vec<u8>>> {
+        // should be fine to "block" the executor here as the cli is essentially single-threaded anyway
+        let signature = self
+            .pair
+            .sign(message)
+            .map_err(|_| anyhow!("failed to sign with local signer"));
 
-        Box::pin(async move {
-            tokio::task::spawn_blocking(move || {
-                pair2
-                    .sign(&message)
-                    .map_err(|_| anyhow!("failed to sign with local signer"))
-            })
-            .await?
-        })
+        Box::pin(async move { signature })
     }
 
     fn public_key(&self) -> Vec<u8> {
         self.pair.public_key().to_bytes()
-    }
-
-    fn decrypt(&self, ciphertext: Vec<u8>) -> PairFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>> {
-        let pair2 = Arc::clone(&self.pair);
-
-        Box::pin(async move {
-            tokio::task::spawn_blocking(move || {
-                pair2
-                    .decrypt(&ciphertext)
-                    .map_err(|_| anyhow!("failed to decrypt with local signer"))
-            })
-            .await?
-        })
     }
 }
 

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -1,8 +1,4 @@
 //! Fixtures shared across the tvc integration-test binaries.
-//!
-//! Each test binary that declares `mod common;` compiles its own copy and
-//! uses a subset of these helpers, so unused items are expected in every
-//! build of this file; the crate-level allow keeps those builds quiet.
 
 use std::{
     collections::HashMap,


### PR DESCRIPTION
Second in the stack, extracted from #224 — based on #236; retarget to main when it merges.

- Operator semantics move behind one seam: `trait Signer { sign, public_key }` in `pair.rs`, with `LocalPair` and `HostedSigner` adapters (the hosted signer owns its `AuthenticatedClient` and signs via `sign_raw_payload`).
- `operator.rs` splits into `operator/mod.rs` (resolution, `ResolvedOperator`, manifest approval) and `operator/hosted.rs` (creation, registry resolution, the API-signing adapter).
- `approve_manifest` no longer takes a ctx or matches on kind — `OperatorCtx`, `ResolvedOperatorKind`, `is_hosted()`, and `ValidatedHostedOperatorRecord` are gone (the latter absorbed into `ResolvedHostedOperator`, keys parsed once at resolution).
- `resolve_operator` preserves main's precedence exactly (rustdoc-documented, no crossover between backends) and now takes a `SignerRequirement { Any, OfflineApproval }`, so `--skip-post` with a hosted operator is refused before any credentials load — pinned by the existing `hosted_operator_rejects_skip_post_before_api_activity` test.
- Local operator selection becomes `OrgConfig::select_local_operator`, returning the `(record, local)` pair with a typed `SelectLocalOperatorError`; callers add org context via `with_context`.
- `OrgConfig::select_local_record` and the default-kind gate are gone — file-management commands no longer check the org's default backend, an accepted behavior change.
- Known message-level deviations (outcomes identical): selector errors are reworded with call-site org context, and `--skip-post` + hosted ID + broken credentials now surfaces the credential error.
