### PR TITLE
feat(tvc): hosted-operator parity for login, create defaults, and approvals

### DIFF
--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -86,13 +86,18 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         OperatorReuse::KeepConfig => {}
         OperatorReuse::Reuse(operator) => apply_operator_reuse(ctx, &mut app_config, operator)?,
         OperatorReuse::MultipleCandidates(operators) => {
-            if ctx.is_non_interactive() {
+            // Picking a candidate needs a prompt, which is impossible under
+            // --non-interactive, JSON mode, or a non-TTY stdin.
+            let can_prompt = !ctx.is_non_interactive() && prompts::stdin_can_prompt();
+
+            if !can_prompt {
                 bail!(
                     "multiple operator IDs are known for the active org; \
                      set manifestSetParams.existingOperatorIds in your config to reuse one, \
                      or pass --no-operator-reuse to create a new operator"
                 );
             }
+
             let operator = prompts::select("Select operator to reuse", operators)?;
             apply_operator_reuse(ctx, &mut app_config, operator)?;
         }

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -4,8 +4,9 @@ use crate::{
     client::build_client,
     config::{
         app::{AppConfig, AppConfigValidationErrors, OperatorSetParams},
-        turnkey::{self, StoredQosOperatorKey},
+        turnkey,
     },
+    operator::OperatorCandidate,
     outcome::Outcome,
     output::{Ctx, StdCtx},
     prompts, shell_println,
@@ -31,11 +32,12 @@ pub struct Args {
     #[arg(short = 'c', long, value_name = "PATH", env = "TVC_APP_CONFIG")]
     pub config_file: PathBuf,
 
-    /// Create a new operator instead of reusing the most recently created one.
+    /// Create a new operator instead of reusing a known one.
     ///
-    /// By default `app create` reuses the operator from your last `app create`
-    /// (the same local operator key) rather than minting a new operator ID each
-    /// time. Pass this to force creating a new operator.
+    /// By default `app create` reuses a known operator — a registered hosted
+    /// operator, or the one from your last `app create` — rather than minting
+    /// a new operator ID each time. Pass this to force creating a new
+    /// operator.
     #[arg(long, env = "TVC_NO_OPERATOR_REUSE")]
     pub no_operator_reuse: bool,
 
@@ -64,28 +66,35 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
 
     let mut app_config = apply_overrides(config, &args.overrides);
 
-    // Reuse the previously-created operator by default so repeated `app create`
-    // runs don't mint a fresh operator ID for the same local key. The decision
-    // itself is pure (`decide_operator_reuse`); this endpoint does the I/O
-    // (loading saved IDs) and adapts multi-candidate handling to the mode.
-    let saved_ids = load_saved_operator_ids().await;
+    // Reuse a known operator by default so repeated `app create` runs don't
+    // mint a fresh operator ID for the same key. The decision itself is pure
+    // (`decide_operator_reuse`); this endpoint does the I/O — collecting
+    // candidates best-effort, since reuse is a convenience: a failed config
+    // load falls back to no reuse and the real error surfaces when
+    // `run_with_config` reloads the config — and adapts multi-candidate
+    // handling to the mode.
+    let candidates = match turnkey::Config::load().await {
+        Ok(config) => config.known_operator_candidates(),
+        Err(_) => Vec::new(),
+    };
+
     match decide_operator_reuse(
         args.no_operator_reuse,
         app_config.manifest_set_params.as_ref(),
-        &saved_ids,
+        &candidates,
     ) {
         OperatorReuse::KeepConfig => {}
-        OperatorReuse::Reuse(id) => apply_operator_reuse(ctx, &mut app_config, id)?,
-        OperatorReuse::MultipleCandidates(ids) => {
+        OperatorReuse::Reuse(operator) => apply_operator_reuse(ctx, &mut app_config, operator)?,
+        OperatorReuse::MultipleCandidates(operators) => {
             if ctx.is_non_interactive() {
                 bail!(
-                    "multiple saved operator IDs for the active org; \
+                    "multiple operator IDs are known for the active org; \
                      set manifestSetParams.existingOperatorIds in your config to reuse one, \
                      or pass --no-operator-reuse to create a new operator"
                 );
             }
-            let id = prompts::select("Select operator to reuse", ids)?;
-            apply_operator_reuse(ctx, &mut app_config, id)?;
+            let operator = prompts::select("Select operator to reuse", operators)?;
+            apply_operator_reuse(ctx, &mut app_config, operator)?;
         }
     }
 
@@ -97,13 +106,13 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
 enum OperatorReuse {
     /// Leave the config as-is: create new operators, or honor an explicit config.
     KeepConfig,
-    /// Reuse exactly this saved operator ID.
-    Reuse(String),
-    /// Several saved operator IDs are candidates; the caller picks one.
-    MultipleCandidates(Vec<String>),
+    /// Reuse exactly this known operator.
+    Reuse(OperatorCandidate),
+    /// Several known operators are candidates; the caller picks one.
+    MultipleCandidates(Vec<OperatorCandidate>),
 }
 
-/// Decide whether to reuse a previously-created operator for the manifest set.
+/// Decide whether to reuse a known operator for the manifest set.
 ///
 /// Pure and mode-agnostic: it performs no I/O and knows nothing about
 /// interactivity. The caller resolves [`OperatorReuse::MultipleCandidates`] by
@@ -111,7 +120,7 @@ enum OperatorReuse {
 fn decide_operator_reuse(
     no_reuse: bool,
     manifest_set_params: Option<&OperatorSetParams>,
-    saved_ids: &[String],
+    candidates: &[OperatorCandidate],
 ) -> OperatorReuse {
     // Opt-out: the user explicitly wants a fresh operator.
     if no_reuse {
@@ -126,40 +135,32 @@ fn decide_operator_reuse(
     if !params.existing_operator_ids.is_empty() {
         return OperatorReuse::KeepConfig;
     }
-    match saved_ids {
+    match candidates {
         [] => OperatorReuse::KeepConfig,
-        [id] => OperatorReuse::Reuse(id.clone()),
-        _ => OperatorReuse::MultipleCandidates(saved_ids.to_vec()),
+        [sole] => OperatorReuse::Reuse(sole.clone()),
+        _ => OperatorReuse::MultipleCandidates(candidates.to_vec()),
     }
 }
 
-/// Swap the manifest set from creating new operators to reusing `operator_id`.
+/// Swap the manifest set from creating new operators to reusing `operator`.
 fn apply_operator_reuse<Out: io::Write, Err: io::Write>(
     ctx: &mut Ctx<Out, Err>,
     config: &mut AppConfig,
-    operator_id: String,
+    operator: OperatorCandidate,
 ) -> anyhow::Result<()> {
-    if let Some(params) = config.manifest_set_params.as_mut() {
-        params.new_operators.clear();
-        params.existing_operator_ids = vec![operator_id.clone()];
-    }
-
-    debug!(operator_id = %operator_id, "reusing existing operator");
+    debug!(operator_id = %operator.id, "reusing existing operator");
 
     shell_println!(
         ctx,
-        "Reusing operator {operator_id} (pass --no-operator-reuse to create a new one)"
-    )
-}
+        "Reusing operator {operator} (pass --no-operator-reuse to create a new one)"
+    )?;
 
-/// Best-effort load of the active org's most recently created operator IDs.
-/// Reuse is a convenience, so config-load failures fall back to no reuse; the
-/// real error surfaces later when `run_with_config` reloads the config.
-async fn load_saved_operator_ids() -> Vec<String> {
-    match turnkey::Config::load().await {
-        Ok(config) => config.get_last_operator_ids().unwrap_or_default(),
-        Err(_) => Vec::new(),
+    if let Some(params) = config.manifest_set_params.as_mut() {
+        params.new_operators.clear();
+        params.existing_operator_ids = vec![operator.id];
     }
+
+    Ok(())
 }
 
 async fn build_app_config_interactive(ctx: &mut StdCtx, args: &Args) -> Result<AppConfig> {
@@ -177,7 +178,10 @@ async fn build_app_config_interactive(ctx: &mut StdCtx, args: &Args) -> Result<A
             }
             _ => {
                 changed = true;
-                let saved_operator_public_key = load_saved_operator_public_key().await;
+                let saved_operator_public_key = match turnkey::Config::load().await {
+                    Ok(config) => config.default_operator_public_key().await,
+                    Err(_) => None,
+                };
                 config.fill_interactively(saved_operator_public_key.as_deref())?;
             }
         }
@@ -225,16 +229,6 @@ fn offer_to_save_app_config(ctx: &mut StdCtx, path: &Path, config: &AppConfig) -
         shell_println!(ctx, "Wrote {}", path.display())?;
     }
     Ok(())
-}
-
-/// Best-effort load of the operator public key from the active org's config
-/// so we can offer it as the default for new-operator prompts.
-async fn load_saved_operator_public_key() -> Option<String> {
-    let config = turnkey::Config::load().await.ok()?;
-    let (_, org_config) = config.active_org_config()?;
-    let (_, local) = org_config.select_local_operator().ok()?;
-    let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
-    Some(operator_key.public_key.to_string())
 }
 
 async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) -> Result<Outcome> {
@@ -540,20 +534,26 @@ mod tests {
         }
     }
 
-    /// The opt-out flag always wins: never reuse, even with a single saved id.
+    fn candidate(id: &str) -> OperatorCandidate {
+        OperatorCandidate {
+            id: id.to_string(),
+            name: None,
+        }
+    }
+
+    /// The opt-out flag always wins: never reuse, even with a single candidate.
     #[test]
     fn decide_reuse_keeps_config_when_flag_set() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(true, Some(&params), &saved),
+            decide_operator_reuse(true, Some(&params), &[candidate("op-1")]),
             OperatorReuse::KeepConfig
         );
     }
 
-    /// First run (nothing created yet) has nothing to reuse -> create new.
+    /// First run (nothing created or registered yet) has nothing to reuse -> create new.
     #[test]
-    fn decide_reuse_keeps_config_without_saved_ids() {
+    fn decide_reuse_keeps_config_without_candidates() {
         let params = manifest_params_with_new_operator();
         assert_eq!(
             decide_operator_reuse(false, Some(&params), &[]),
@@ -566,9 +566,12 @@ mod tests {
     fn decide_reuse_keeps_config_when_config_pins_existing_ids() {
         let mut params = manifest_params_with_new_operator();
         params.existing_operator_ids = vec!["explicit-op".to_string()];
-        let saved = vec!["op-1".to_string(), "op-2".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
+            decide_operator_reuse(
+                false,
+                Some(&params),
+                &[candidate("op-1"), candidate("op-2")]
+            ),
             OperatorReuse::KeepConfig
         );
     }
@@ -576,32 +579,30 @@ mod tests {
     /// No manifest_set_params (e.g. reusing a whole set via manifestSetId) -> nothing to do.
     #[test]
     fn decide_reuse_keeps_config_without_manifest_params() {
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, None, &saved),
+            decide_operator_reuse(false, None, &[candidate("op-1")]),
             OperatorReuse::KeepConfig
         );
     }
 
-    /// The common case: exactly one saved operator -> reuse it.
+    /// The common case: exactly one known operator -> reuse it.
     #[test]
-    fn decide_reuse_reuses_single_saved_id() {
+    fn decide_reuse_reuses_the_sole_candidate() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string()];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
-            OperatorReuse::Reuse("op-1".to_string())
+            decide_operator_reuse(false, Some(&params), &[candidate("op-1")]),
+            OperatorReuse::Reuse(candidate("op-1"))
         );
     }
 
-    /// Multiple saved operators are surfaced for the endpoint to prompt/bail on.
+    /// Multiple known operators are surfaced for the endpoint to prompt/bail on.
     #[test]
-    fn decide_reuse_returns_candidates_for_multiple_saved_ids() {
+    fn decide_reuse_returns_candidates_for_multiple_known_operators() {
         let params = manifest_params_with_new_operator();
-        let saved = vec!["op-1".to_string(), "op-2".to_string()];
+        let candidates = [candidate("op-1"), candidate("op-2")];
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &saved),
-            OperatorReuse::MultipleCandidates(saved.clone())
+            decide_operator_reuse(false, Some(&params), &candidates),
+            OperatorReuse::MultipleCandidates(candidates.to_vec())
         );
     }
 
@@ -610,7 +611,7 @@ mod tests {
     fn apply_operator_reuse_swaps_new_operators_for_existing_id() {
         let mut ctx = Ctx::new(EmptyShell::default(), true);
         let mut config = valid_config();
-        apply_operator_reuse(&mut ctx, &mut config, "op-1".to_string()).unwrap();
+        apply_operator_reuse(&mut ctx, &mut config, candidate("op-1")).unwrap();
 
         let params = config.manifest_set_params.unwrap();
         assert!(params.new_operators.is_empty());

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -1,7 +1,7 @@
 //! App init command - generates a template config file.
 
 use crate::config::app::AppConfig;
-use crate::config::turnkey::{Config, StoredQosOperatorKey};
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use crate::prompts::{bail_interactive_conflicts_with_non_interactive, ensure_stdin_is_tty};
@@ -49,8 +49,11 @@ async fn execute(args: Args) -> Result<Outcome> {
         bail!("File already exists: {}", args.output.display());
     }
 
-    // Try to load operator public key from config
-    let operator_public_key = load_operator_public_key().await;
+    // Try to load the operator public key from config, best-effort.
+    let operator_public_key = match Config::load().await {
+        Ok(config) => config.default_operator_public_key().await,
+        Err(_) => None,
+    };
 
     // Generate template (optionally walking prompts to fill it in)
     let mut config = AppConfig::template(operator_public_key.as_deref());
@@ -101,16 +104,4 @@ Edit the file to fill in your values, then run:
             )
         }
     }
-}
-
-/// Load the operator public key from the active org's config
-async fn load_operator_public_key() -> Option<String> {
-    // Load config (return None on error)
-    let config = Config::load().await.ok()?;
-
-    // Get active org config
-    let (_, org_config) = config.active_org_config()?;
-    let (_, local) = org_config.select_local_operator().ok()?;
-    let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
-    Some(operator_key.public_key.to_string())
 }

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -403,9 +403,26 @@ impl TryFrom<Args> for ArgsWithResolvedOperatorSeedSource {
     }
 }
 
+/// A candidate for posting without `--operator-id`: the parsed ID that
+/// resolution needs, displayed with its registry name when it has one.
+struct ApprovingOperator {
+    id: Uuid,
+    name: Option<String>,
+}
+
+impl fmt::Display for ApprovingOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self.name {
+            Some(name) => write!(f, "{name} ({})", self.id),
+            None => fmt::Display::fmt(&self.id, f),
+        }
+    }
+}
+
 /// Resolve where to post and which operator approves. No post target is
 /// built for `--dry-run` or `--skip-post`; without `--operator-id`, a lone
-/// saved operator ID is used and multiple prompt for a choice when possible.
+/// known operator (registered hosted or saved from the last `app create`)
+/// is used and multiple prompt for a choice when possible.
 async fn build_post_target(
     args: BuildPostTargetArgs,
     fetched_manifest_id: Option<Uuid>,
@@ -424,27 +441,32 @@ async fn build_post_target(
     } else {
         let config = Config::load().await?;
 
-        let saved_ids = config
-            .get_last_operator_ids()
-            .unwrap_or_default()
+        let candidates = config
+            .known_operator_candidates()
             .into_iter()
-            .map(|id| {
-                Uuid::parse_str(&id)
-                    .with_context(|| format!("saved operator ID '{id}' is not a UUID"))
+            .map(|candidate| {
+                let id = Uuid::parse_str(&candidate.id).with_context(|| {
+                    format!("saved operator ID '{}' is not a UUID", candidate.id)
+                })?;
+
+                Ok(ApprovingOperator {
+                    id,
+                    name: candidate.name,
+                })
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        match saved_ids.len() {
-            0 => bail!(
+        match candidates.as_slice() {
+            [] => bail!(
                 "--operator-id is required to post approval to API. \
-                 No saved operator IDs found. \
+                 No registered or saved operator IDs found. \
                  Use --skip-post to only generate the approval locally."
             ),
-            1 => saved_ids[0],
+            [candidate] => candidate.id,
             _ if non_interactive || !stdin_can_prompt() => bail!(
-                "--operator-id is required to post approval to API when multiple saved operator IDs are available"
+                "--operator-id is required to post approval to API when multiple operator IDs are available"
             ),
-            _ => prompts::select("Select approving operator", saved_ids)?,
+            _ => prompts::select("Select approving operator", candidates)?.id,
         }
     };
 

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     commands::{Run, login::find_org},
-    config::turnkey::{Config, QosOperatorPublicKey, StoredQosOperatorKey},
+    config::turnkey::{
+        Config, QosOperatorPublicKey, SelectLocalOperatorError, StoredQosOperatorKey,
+    },
     outcome::Outcome,
     output::StdCtx,
     prompts::{self, error_required_in_non_interactive},
@@ -62,7 +64,19 @@ impl Run for Args {
 
         let (_, local) = org_config
             .select_local_operator()
-            .with_context(|| format!("org '{alias}'"))?;
+            .map_err(|error| match error {
+                // Nothing exportable exists for a hosted-only org; explain
+                // that instead of leaving a bare missing-operator error.
+                SelectLocalOperatorError::NoLocalOperator => {
+                    anyhow::Error::new(error).context(format!(
+                        "org '{alias}' has no local operator key file to back up; hosted \
+                         operators' private keys are held by Turnkey and cannot be exported"
+                    ))
+                }
+                SelectLocalOperatorError::MultipleLocalOperators => {
+                    anyhow::Error::new(error).context(format!("org '{alias}'"))
+                }
+            })?;
         let source = &local.key_path;
 
         let destination = match self.output {

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -1,7 +1,7 @@
 //! Local quorum key init command - generates a template quorum key config file.
 
 use crate::config::quorum_key::{MAX_SHARES, MIN_THRESHOLD, QuorumKeyConfig};
-use crate::config::turnkey::{Config, StoredQosOperatorKey};
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use anyhow::{Context, Result};
@@ -31,7 +31,10 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         anyhow::bail!("File already exists: {}", args.output.display());
     }
 
-    let operator_public_key = load_operator_public_key().await;
+    let operator_public_key = match Config::load().await {
+        Ok(config) => config.default_operator_public_key().await,
+        Err(_) => None,
+    };
 
     let config = QuorumKeyConfig::template(operator_public_key.as_deref());
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
@@ -65,13 +68,4 @@ Edit the file to fill in your values, then run:
             self.path, self.path
         )
     }
-}
-
-/// Load the operator public key from the active org's config.
-async fn load_operator_public_key() -> Option<String> {
-    let config = Config::load().await.ok()?;
-    let (_, org_config) = config.active_org_config()?;
-    let (_, local) = org_config.select_local_operator().ok()?;
-    let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
-    Some(operator_key.public_key.to_string())
 }

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -1,5 +1,6 @@
 //! Re-encrypt local share command.
 
+use crate::config::turnkey::SelectLocalOperatorError;
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
@@ -113,7 +114,20 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         read_json_file(&args.quorum_key_metadata, "quorum key metadata file").await?;
     let provision_bundle: ProvisionBundle =
         read_json_file(&args.provision_bundle, "provision bundle").await?;
-    let operator_pair = resolve_local_operator(operator_seed_source).await?;
+    let operator_pair = resolve_local_operator(operator_seed_source)
+        .await
+        .map_err(|error| {
+            // Decryption needs local key material a hosted-only org does not
+            // have; point at the hosted counterpart of this operation.
+            match error.downcast_ref::<SelectLocalOperatorError>() {
+                Some(SelectLocalOperatorError::NoLocalOperator) => error.context(
+                    "re-encrypting a local share needs the local operator key the share was \
+                     encrypted to; hosted operators re-encrypt through Turnkey with \
+                     `tvc deploy provision`",
+                ),
+                _ => error,
+            }
+        })?;
 
     let output = build_re_encrypted_share_output(
         &quorum_key_metadata,

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -380,18 +380,18 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
             }
         }
         OperatorKind::Hosted => {
-            let (record, hosted) = org_config
+            let (name, hosted) = org_config
                 .select_hosted_operator()
                 .with_context(|| format!("org '{alias}'"))?;
             shell_println!(
                 ctx,
                 "Using hosted operator '{}' ({}).",
-                record.name,
+                name,
                 hosted.operator_id
             )?;
 
             LoggedInOperator::Hosted {
-                operator_name: record.name.clone(),
+                operator_name: name.to_owned(),
                 operator_id: hosted.operator_id,
                 operator_public_key: format!(
                     "{}{}",

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -5,9 +5,9 @@ use crate::commands::keys::backup_operator_key::{
     OperatorKeyBackedUp, back_up, prompt_for_backup_destination,
 };
 use crate::config::turnkey::{
-    API_BASE_URL_PROD, Config, KeyCurve, OperatorRecordKind, OrgConfig, QosOperatorPublicKey,
-    StoredApiKey, StoredQosOperatorKey, dashboard_base_url, default_api_key_path,
-    default_operator_key_path, default_org_dir,
+    API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, OperatorKind, OperatorRecordKind,
+    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey, dashboard_base_url,
+    default_api_key_path, default_operator_key_path, default_org_dir,
 };
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
@@ -23,6 +23,7 @@ use std::io::BufRead;
 use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
+use uuid::Uuid;
 
 /// Authenticate with Turnkey and set up local credentials.
 #[derive(Debug, ClapArgs)]
@@ -361,15 +362,44 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     shell_println!(ctx, "Verifying credentials...")?;
 
     let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url).await?;
-    let operator_key = find_or_generate_operator_key(ctx, &alias, &org_config).await?;
 
-    // Operator key path now lives in the org's local operator record (the
-    // versioned registry), not on `OrgConfig` directly. Resolve it before the
-    // struct literal so `alias` is still available (the struct moves it).
-    let (_, local) = org_config
-        .select_local_operator()
-        .with_context(|| format!("org '{alias}'"))?;
-    let operator_key_path = local.key_path.display().to_string();
+    // Login ensures the org's default backend is usable, and never crosses
+    // over: a local default finds or generates the registered key file; a
+    // hosted default requires the registered hosted operator and has no key
+    // material to generate.
+    let operator = match org_config.default_operator_kind {
+        OperatorKind::Local => {
+            let (_, local) = org_config
+                .select_local_operator()
+                .with_context(|| format!("org '{alias}'"))?;
+            let operator_key = find_or_generate_operator_key(ctx, &alias, local).await?;
+
+            LoggedInOperator::Local {
+                operator_public_key: operator_key.public_key,
+                operator_key_path: local.key_path.display().to_string(),
+            }
+        }
+        OperatorKind::Hosted => {
+            let (record, hosted) = org_config
+                .select_hosted_operator()
+                .with_context(|| format!("org '{alias}'"))?;
+            shell_println!(
+                ctx,
+                "Using hosted operator '{}' ({}).",
+                record.name,
+                hosted.operator_id
+            )?;
+
+            LoggedInOperator::Hosted {
+                operator_name: record.name.clone(),
+                operator_id: hosted.operator_id,
+                operator_public_key: format!(
+                    "{}{}",
+                    hosted.encrypt_public_key, hosted.sign_public_key
+                ),
+            }
+        }
+    };
 
     Ok(Outcome::LoggedIn(LoggedIn {
         organization_name: whoami.organization_name,
@@ -378,12 +408,11 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         user_id: whoami.user_id,
         alias,
         api_public_key: api_key.public_key.clone(),
-        operator_public_key: operator_key.public_key,
         config_file_path: crate::config::turnkey::config_file_path()?
             .display()
             .to_string(),
         api_key_path: org_config.api_key_path.display().to_string(),
-        operator_key_path,
+        operator,
     }))
 }
 
@@ -560,11 +589,8 @@ fn wait_for_dashboard_registration(ctx: &mut StdCtx) -> Result<()> {
 async fn find_or_generate_operator_key(
     ctx: &mut StdCtx,
     org_alias: &str,
-    org_config: &OrgConfig,
+    local: &LocalOperatorRecord,
 ) -> Result<StoredQosOperatorKey> {
-    let (_, local) = org_config
-        .select_local_operator()
-        .with_context(|| format!("org '{org_alias}'"))?;
     debug!(operator_key_path = %local.key_path.display(), "resolving operator key");
 
     if let Some(operator_key) = StoredQosOperatorKey::load(&local.key_path).await? {
@@ -703,10 +729,42 @@ pub struct LoggedIn {
     user_id: String,
     alias: String,
     api_public_key: String,
-    operator_public_key: QosOperatorPublicKey,
     config_file_path: String,
     api_key_path: String,
-    operator_key_path: String,
+    #[serde(flatten)]
+    operator: LoggedInOperator,
+}
+
+/// The operator backend the login landed on: a local login reports its key
+/// file, a hosted login reports the registered identity. Both carry the qos
+/// composite public key.
+#[derive(Serialize)]
+#[serde(
+    tag = "operatorKind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+enum LoggedInOperator {
+    Local {
+        operator_public_key: QosOperatorPublicKey,
+        operator_key_path: String,
+    },
+    Hosted {
+        operator_name: String,
+        operator_id: Uuid,
+        operator_public_key: String,
+    },
+}
+
+/// Local, like every org `login` itself creates; exists for [`LoggedIn`]'s
+/// `Default`, which the outcome payload-enumeration tests construct.
+impl Default for LoggedInOperator {
+    fn default() -> Self {
+        Self::Local {
+            operator_public_key: QosOperatorPublicKey::default(),
+            operator_key_path: String::new(),
+        }
+    }
 }
 
 #[derive(Default, Serialize)]
@@ -764,24 +822,46 @@ User: {} ({})
 Active Org: {}
 
 Credentials
-  API public key:        {}
-  Operator public key:   {}
-
-Saved to
-  Config file:    {}
-  API key:        {}
-  Operator key:   {}"#,
+  API public key:        {}"#,
             self.organization_name,
             self.organization_id,
             self.username,
             self.user_id,
             self.alias,
             self.api_public_key,
-            self.operator_public_key,
-            self.config_file_path,
-            self.api_key_path,
-            self.operator_key_path
-        )
+        )?;
+
+        match &self.operator {
+            LoggedInOperator::Local {
+                operator_public_key,
+                operator_key_path,
+            } => write!(
+                f,
+                r#"
+  Operator public key:   {operator_public_key}
+
+Saved to
+  Config file:    {}
+  API key:        {}
+  Operator key:   {operator_key_path}"#,
+                self.config_file_path, self.api_key_path,
+            ),
+            LoggedInOperator::Hosted {
+                operator_name,
+                operator_id,
+                operator_public_key,
+            } => write!(
+                f,
+                r#"
+  Operator public key:   {operator_public_key}
+  Hosted operator:       {operator_name} ({operator_id})
+
+Saved to
+  Config file:    {}
+  API key:        {}"#,
+                self.config_file_path, self.api_key_path,
+            ),
+        }
     }
 }
 
@@ -796,6 +876,77 @@ mod tests {
     use std::path::PathBuf;
 
     const OVERRIDE_URL: &str = "http://127.0.0.1:8081";
+
+    fn logged_in_with(operator: LoggedInOperator) -> LoggedIn {
+        LoggedIn {
+            organization_name: "Org".to_string(),
+            organization_id: "org-1".to_string(),
+            username: "user".to_string(),
+            user_id: "user-1".to_string(),
+            alias: "prod".to_string(),
+            api_public_key: "api-key".to_string(),
+            config_file_path: "/config/tvc.config.toml".to_string(),
+            api_key_path: "/keys/api_key.json".to_string(),
+            operator,
+        }
+    }
+
+    /// The local outcome keeps its pre-hosted JSON fields and gains only the
+    /// additive `operatorKind` tag — this is a compatibility contract.
+    #[test]
+    fn logged_in_local_json_reports_the_key_file() {
+        let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+        let logged_in = logged_in_with(LoggedInOperator::Local {
+            operator_public_key: composite.parse().unwrap(),
+            operator_key_path: "/keys/operator.json".to_string(),
+        });
+
+        assert_eq!(
+            serde_json::to_value(&logged_in).unwrap(),
+            serde_json::json!({
+                "organizationName": "Org",
+                "organizationId": "org-1",
+                "username": "user",
+                "userId": "user-1",
+                "alias": "prod",
+                "apiPublicKey": "api-key",
+                "configFilePath": "/config/tvc.config.toml",
+                "apiKeyPath": "/keys/api_key.json",
+                "operatorKind": "local",
+                "operatorPublicKey": composite,
+                "operatorKeyPath": "/keys/operator.json",
+            })
+        );
+    }
+
+    /// The hosted outcome reports the registered identity and no key path.
+    #[test]
+    fn logged_in_hosted_json_reports_the_registered_identity() {
+        let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+        let logged_in = logged_in_with(LoggedInOperator::Hosted {
+            operator_name: "hosted-op".to_string(),
+            operator_id: Uuid::from_u128(0x11),
+            operator_public_key: composite.clone(),
+        });
+
+        assert_eq!(
+            serde_json::to_value(&logged_in).unwrap(),
+            serde_json::json!({
+                "organizationName": "Org",
+                "organizationId": "org-1",
+                "username": "user",
+                "userId": "user-1",
+                "alias": "prod",
+                "apiPublicKey": "api-key",
+                "configFilePath": "/config/tvc.config.toml",
+                "apiKeyPath": "/keys/api_key.json",
+                "operatorKind": "hosted",
+                "operatorName": "hosted-op",
+                "operatorId": Uuid::from_u128(0x11).to_string(),
+                "operatorPublicKey": composite,
+            })
+        );
+    }
 
     #[test]
     fn new_org_api_base_url_defaults_to_prod() {

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -266,13 +266,6 @@ impl OperatorRecord {
             }),
         }
     }
-
-    pub fn operator_kind(&self) -> OperatorKind {
-        match self.kind {
-            OperatorRecordKind::Local(_) => OperatorKind::Local,
-            OperatorRecordKind::Hosted(_) => OperatorKind::Hosted,
-        }
-    }
 }
 
 /// Kind-specific durable operator metadata.
@@ -341,6 +334,16 @@ pub enum SelectLocalOperatorError {
     MultipleLocalOperators,
 }
 
+/// Failure modes of selecting the sole hosted operator of an organization.
+/// Which organization it was is the caller's context to add.
+#[derive(Debug, Error)]
+pub enum SelectHostedOperatorError {
+    #[error("no hosted operator is configured")]
+    NoHostedOperator,
+    #[error("multiple hosted operators are configured")]
+    MultipleHostedOperators,
+}
+
 impl OrgConfig {
     /// Select the sole local operator registry entry, with its kind-specific
     /// record. Purely a registry query: whether local is the organization's
@@ -360,6 +363,34 @@ impl OrgConfig {
             (Some(sole), None) => Ok(sole),
             (None, _) => Err(SelectLocalOperatorError::NoLocalOperator),
             (Some(_), Some(_)) => Err(SelectLocalOperatorError::MultipleLocalOperators),
+        }
+    }
+
+    /// The hosted operator registry entries, each with its kind-specific
+    /// record, in config order.
+    pub(crate) fn hosted_operators(
+        &self,
+    ) -> impl Iterator<Item = (&OperatorRecord, &HostedOperatorRecord)> {
+        self.operators
+            .iter()
+            .filter_map(|operator| match &operator.kind {
+                OperatorRecordKind::Hosted(hosted) => Some((operator, hosted)),
+                OperatorRecordKind::Local(_) => None,
+            })
+    }
+
+    /// Select the sole hosted operator registry entry, with its kind-specific
+    /// record. Purely a registry query: whether hosted is the organization's
+    /// default backend is resolution policy, decided elsewhere.
+    pub(crate) fn select_hosted_operator(
+        &self,
+    ) -> Result<(&OperatorRecord, &HostedOperatorRecord), SelectHostedOperatorError> {
+        let mut hosted = self.hosted_operators();
+
+        match (hosted.next(), hosted.next()) {
+            (Some(sole), None) => Ok(sole),
+            (None, _) => Err(SelectHostedOperatorError::NoHostedOperator),
+            (Some(_), Some(_)) => Err(SelectHostedOperatorError::MultipleHostedOperators),
         }
     }
 }

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -368,13 +368,11 @@ impl OrgConfig {
 
     /// The hosted operator registry entries, each with its kind-specific
     /// record, in config order.
-    pub(crate) fn hosted_operators(
-        &self,
-    ) -> impl Iterator<Item = (&OperatorRecord, &HostedOperatorRecord)> {
+    pub(crate) fn hosted_operators(&self) -> impl Iterator<Item = (&str, &HostedOperatorRecord)> {
         self.operators
             .iter()
             .filter_map(|operator| match &operator.kind {
-                OperatorRecordKind::Hosted(hosted) => Some((operator, hosted)),
+                OperatorRecordKind::Hosted(hosted) => Some((operator.name.as_str(), hosted)),
                 OperatorRecordKind::Local(_) => None,
             })
     }
@@ -384,7 +382,7 @@ impl OrgConfig {
     /// default backend is resolution policy, decided elsewhere.
     pub(crate) fn select_hosted_operator(
         &self,
-    ) -> Result<(&OperatorRecord, &HostedOperatorRecord), SelectHostedOperatorError> {
+    ) -> Result<(&str, &HostedOperatorRecord), SelectHostedOperatorError> {
         let mut hosted = self.hosted_operators();
 
         match (hosted.next(), hosted.next()) {

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -232,11 +232,10 @@ pub(crate) async fn resolve_operator(
                     bail!("--skip-post is only supported for local operators");
                 }
 
-                let (record, hosted) = org
+                let (name, hosted) = org
                     .select_hosted_operator()
                     .with_context(|| format!("org '{alias}'"))?;
-                let hosted =
-                    ResolvedHostedOperator::from_registry(org.id.clone(), &record.name, hosted)?;
+                let hosted = ResolvedHostedOperator::from_registry(org.id.clone(), name, hosted)?;
                 let auth = build_client().await?;
                 ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
 
@@ -337,9 +336,9 @@ impl Config {
 
         let mut candidates: Vec<OperatorCandidate> = org
             .hosted_operators()
-            .map(|(record, hosted)| OperatorCandidate {
+            .map(|(name, hosted)| OperatorCandidate {
                 id: hosted.operator_id.to_string(),
-                name: Some(record.name.clone()),
+                name: name.to_owned().into(),
             })
             .collect();
 

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -163,8 +163,13 @@ pub(crate) enum SignerRequirement {
 ///    operator — even when the org's default operator kind is local.
 /// 3. Otherwise the active org's `default_operator_kind` decides, and never
 ///    crosses over: `local` resolves the sole local record (reconciling a
-///    given ID against its configured one); `hosted` refuses — an ID is
-///    required, and resolution never falls back to the local key.
+///    given ID against its configured one); `hosted` resolves the sole
+///    hosted record when no ID names one, and never falls back to the
+///    local key.
+///
+/// Config is loaded lazily inside: the explicit-seed path must not depend
+/// on a config file being present or well-formed (pinned by
+/// `explicit_seed_does_not_load_malformed_config`).
 pub(crate) async fn resolve_operator(
     explicit: Option<LocalOperatorSeedSource>,
     operator_id: Option<Uuid>,
@@ -220,7 +225,27 @@ pub(crate) async fn resolve_operator(
     if org.default_operator_kind == OperatorKind::Hosted {
         match operator_id {
             Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
-            None => bail!("--operator-id is required to approve with a hosted operator"),
+            None => {
+                // A hosted default cannot satisfy an offline approval;
+                // refuse before selection or credentials.
+                if requirement == SignerRequirement::OfflineApproval {
+                    bail!("--skip-post is only supported for local operators");
+                }
+
+                let (record, hosted) = org
+                    .select_hosted_operator()
+                    .with_context(|| format!("org '{alias}'"))?;
+                let hosted =
+                    ResolvedHostedOperator::from_registry(org.id.clone(), &record.name, hosted)?;
+                let auth = build_client().await?;
+                ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
+
+                return Ok(ResolvedOperator {
+                    name: Some(hosted.name().to_string()),
+                    operator_id: Some(hosted.operator_id()),
+                    signer: Box::new(HostedSigner::new(hosted, auth)),
+                });
+            }
         }
     }
 

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -13,7 +13,7 @@ pub(crate) use hosted::{ResolvedHostedOperator, hosted_activity_error};
 use crate::{
     approvals::ValidatedManifest,
     client::build_client,
-    config::turnkey::{Config, OperatorKind},
+    config::turnkey::{Config, OperatorKind, StoredQosOperatorKey},
     local_operator_key::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
@@ -279,6 +279,80 @@ pub(crate) async fn resolve_operator(
     })
 }
 
+/// One operator identity known for the active org, labeled with its registry
+/// name when it has one. The ID stays a string: callers that need a UUID
+/// parse at their own boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OperatorCandidate {
+    pub id: String,
+    pub name: Option<String>,
+}
+
+impl Display for OperatorCandidate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self.name {
+            Some(name) => write!(f, "{name} ({})", self.id),
+            None => f.write_str(&self.id),
+        }
+    }
+}
+
+/// Operator semantics of the registry [`Config`] holds; the methods live
+/// here, with the rest of operator resolution, rather than in the config
+/// module.
+impl Config {
+    /// Best-effort read of the active org's operator public key under its
+    /// default backend, as qos composite hex, for prompt and template
+    /// defaults. The local backend reads the sole registered key file; the
+    /// hosted backend joins the sole record's stored points. `None` on any
+    /// miss.
+    pub(crate) async fn default_operator_public_key(&self) -> Option<String> {
+        let (_, org) = self.active_org_config()?;
+
+        match org.default_operator_kind {
+            OperatorKind::Local => {
+                let (_, local) = org.select_local_operator().ok()?;
+                let operator_key = StoredQosOperatorKey::load(&local.key_path).await.ok()??;
+                Some(operator_key.public_key.to_string())
+            }
+            OperatorKind::Hosted => {
+                let (_, hosted) = org.select_hosted_operator().ok()?;
+                Some(format!(
+                    "{}{}",
+                    hosted.encrypt_public_key, hosted.sign_public_key
+                ))
+            }
+        }
+    }
+
+    /// Operator identities known for the active org: registered hosted
+    /// operators (config order) then the last `app create`'s manifest-set
+    /// operator IDs, deduplicated by ID. Each source keeps one authoritative
+    /// home — durable hosted identities live in the registry,
+    /// app-create-minted ones only in the saved IDs.
+    pub(crate) fn known_operator_candidates(&self) -> Vec<OperatorCandidate> {
+        let Some((_, org)) = self.active_org_config() else {
+            return Vec::new();
+        };
+
+        let mut candidates: Vec<OperatorCandidate> = org
+            .hosted_operators()
+            .map(|(record, hosted)| OperatorCandidate {
+                id: hosted.operator_id.to_string(),
+                name: Some(record.name.clone()),
+            })
+            .collect();
+
+        for id in self.get_last_operator_ids().unwrap_or_default() {
+            if candidates.iter().all(|candidate| candidate.id != id) {
+                candidates.push(OperatorCandidate { id, name: None });
+            }
+        }
+
+        candidates
+    }
+}
+
 pub(crate) fn timestamp_ms() -> Result<u128> {
     Ok(SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -289,12 +363,120 @@ pub(crate) fn timestamp_ms() -> Result<u128> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::turnkey::{
+        HostedOperatorRecord, LocalOperatorRecord, OperatorRecord, OperatorRecordKind, OrgConfig,
+    };
     use qos_p256::P256Pair;
+    use std::{collections::HashMap, path::PathBuf};
 
     fn public_keys() -> (String, String) {
         let first = P256Pair::generate().unwrap().public_key().to_bytes();
         let second = P256Pair::generate().unwrap().public_key().to_bytes();
         (hex::encode(&first[..65]), hex::encode(&second[65..]))
+    }
+
+    const HOSTED_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+    fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
+        Config {
+            active_org: Some("active".to_string()),
+            orgs: HashMap::from([(
+                "active".to_string(),
+                OrgConfig {
+                    id: "org-id".to_string(),
+                    api_key_path: PathBuf::from("api-key.json"),
+                    api_base_url: "https://api.turnkey.com".to_string(),
+                    default_operator_kind: OperatorKind::Local,
+                    operators,
+                    extra: toml::Table::new(),
+                },
+            )]),
+            ..Config::default()
+        }
+    }
+
+    fn hosted_operator(name: &str) -> OperatorRecord {
+        let (encrypt_public_key, sign_public_key) = public_keys();
+        OperatorRecord {
+            name: name.to_string(),
+            kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                operator_id: HOSTED_ID.parse().unwrap(),
+                wallet_id: Uuid::from_u128(0xB1),
+                path: "m/5527107'/0'/0'".to_string(),
+                encrypt_public_key,
+                sign_public_key,
+                extra: toml::Table::new(),
+            }),
+        }
+    }
+
+    fn local_operator() -> OperatorRecord {
+        OperatorRecord {
+            name: "local".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path: PathBuf::from("operator.json"),
+                operator_id: None,
+                extra: toml::Table::new(),
+            }),
+        }
+    }
+
+    #[test]
+    fn candidates_are_registered_hosted_operators_then_saved_ids() {
+        let mut config = config_with_operators(vec![local_operator(), hosted_operator("hosted")]);
+        config
+            .set_last_operator_ids(&["44444444-4444-4444-8444-444444444444".to_string()])
+            .unwrap();
+
+        assert_eq!(
+            config.known_operator_candidates(),
+            vec![
+                OperatorCandidate {
+                    id: HOSTED_ID.to_string(),
+                    name: Some("hosted".to_string()),
+                },
+                OperatorCandidate {
+                    id: "44444444-4444-4444-8444-444444444444".to_string(),
+                    name: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn candidates_dedupe_saved_ids_against_the_registry() {
+        let mut config = config_with_operators(vec![hosted_operator("hosted")]);
+        config
+            .set_last_operator_ids(&[HOSTED_ID.to_string()])
+            .unwrap();
+
+        assert_eq!(
+            config.known_operator_candidates(),
+            vec![OperatorCandidate {
+                id: HOSTED_ID.to_string(),
+                name: Some("hosted".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn candidates_are_empty_without_an_active_org() {
+        assert_eq!(Config::default().known_operator_candidates(), Vec::new());
+    }
+
+    #[test]
+    fn candidate_display_labels_named_operators() {
+        let named = OperatorCandidate {
+            id: HOSTED_ID.to_string(),
+            name: Some("hosted".to_string()),
+        };
+        let unnamed = OperatorCandidate {
+            id: HOSTED_ID.to_string(),
+            name: None,
+        };
+
+        assert_eq!(named.to_string(), format!("hosted ({HOSTED_ID})"));
+        assert_eq!(unnamed.to_string(), HOSTED_ID);
     }
 
     #[test]

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -170,7 +170,7 @@ pub(crate) struct ResolvedHostedOperator {
 
 impl ResolvedHostedOperator {
     /// Parse and validate a hosted registry record into a resolved operator.
-    fn from_registry(
+    pub(super) fn from_registry(
         organization_id: String,
         name: &str,
         record: &HostedOperatorRecord,
@@ -246,21 +246,16 @@ impl Config {
             return Ok(None);
         };
 
-        let mut matches =
-            org.operators
-                .iter()
-                .filter_map(|operator| match &operator.kind {
-                    OperatorRecordKind::Hosted(hosted) => (hosted.operator_id == *operator_id)
-                        .then_some((operator.name.as_str(), hosted)),
-                    OperatorRecordKind::Local(_) => None,
-                });
+        let mut matches = org
+            .hosted_operators()
+            .filter(|(_, hosted)| hosted.operator_id == *operator_id);
 
         match (matches.next(), matches.next()) {
             (None, _) => Ok(None),
-            (Some((name, record)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
+            (Some((record, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
                 org.id.clone(),
-                name,
-                record,
+                &record.name,
+                hosted,
             )?)),
             (Some(_), Some(_)) => bail!("multiple hosted operators have ID {operator_id}"),
         }
@@ -371,7 +366,9 @@ pub(crate) fn hosted_activity_error(operation: &str, error: TurnkeyClientError) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::turnkey::{LocalOperatorRecord, OperatorKind, OrgConfig};
+    use crate::config::turnkey::{
+        LocalOperatorRecord, OperatorKind, OrgConfig, SelectHostedOperatorError,
+    };
     use crate::operator::OperatorPublicKeyParseError;
     use qos_p256::P256Pair;
     use std::collections::HashMap;
@@ -528,6 +525,50 @@ mod tests {
             error.downcast_ref::<OperatorPublicKeyParseError>(),
             Some(&OperatorPublicKeyParseError::InvalidHex)
         );
+    }
+
+    #[test]
+    fn selects_the_sole_hosted_operator_ignoring_locals() {
+        let local = OperatorRecord {
+            name: "local".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path: PathBuf::from("operator.json"),
+                operator_id: None,
+                extra: toml::Table::new(),
+            }),
+        };
+        let config = config_with_operators(vec![local, hosted_operator("hosted", hosted_record())]);
+        let org = &config.orgs["active"];
+
+        let (operator, hosted) = org.select_hosted_operator().unwrap();
+
+        assert_eq!(operator.name, "hosted");
+        assert_eq!(hosted.operator_id, Uuid::parse_str(OPERATOR_ID).unwrap());
+    }
+
+    #[test]
+    fn selecting_a_hosted_operator_requires_one_to_exist() {
+        let config = config_with_operators(Vec::new());
+        let org = &config.orgs["active"];
+
+        assert!(matches!(
+            org.select_hosted_operator(),
+            Err(SelectHostedOperatorError::NoHostedOperator)
+        ));
+    }
+
+    #[test]
+    fn selecting_a_hosted_operator_refuses_multiple() {
+        let config = config_with_operators(vec![
+            hosted_operator("first", hosted_record()),
+            hosted_operator("second", hosted_record()),
+        ]);
+        let org = &config.orgs["active"];
+
+        assert!(matches!(
+            org.select_hosted_operator(),
+            Err(SelectHostedOperatorError::MultipleHostedOperators)
+        ));
     }
 
     #[test]

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -252,9 +252,9 @@ impl Config {
 
         match (matches.next(), matches.next()) {
             (None, _) => Ok(None),
-            (Some((record, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
+            (Some((name, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
                 org.id.clone(),
-                &record.name,
+                name,
                 hosted,
             )?)),
             (Some(_), Some(_)) => bail!("multiple hosted operators have ID {operator_id}"),
@@ -540,9 +540,9 @@ mod tests {
         let config = config_with_operators(vec![local, hosted_operator("hosted", hosted_record())]);
         let org = &config.orgs["active"];
 
-        let (operator, hosted) = org.select_hosted_operator().unwrap();
+        let (name, hosted) = org.select_hosted_operator().unwrap();
 
-        assert_eq!(operator.name, "hosted");
+        assert_eq!(name, "hosted");
         assert_eq!(hosted.operator_id, Uuid::parse_str(OPERATOR_ID).unwrap());
     }
 

--- a/tvc/tests/app_create.rs
+++ b/tvc/tests/app_create.rs
@@ -1,0 +1,195 @@
+//! Integration tests for `tvc app create`'s operator-reuse decision.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use qos_p256::P256Pair;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::TempDir;
+use tvc::config::app::KNOWN_QUORUM_KEY;
+use tvc::config::turnkey::{
+    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
+};
+
+const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+
+/// Write a config whose active org knows TWO operators — one registered
+/// hosted record and one saved manifest-set ID — so the reuse decision has
+/// multiple candidates. Returns the org's composite public key.
+fn write_two_candidate_config(home: &Path) -> String {
+    let turnkey_dir = home.join(".config/turnkey");
+    std::fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+    let (encrypt_public_key, sign_public_key) = composite.split_at(composite.len() / 2);
+
+    let config = Config {
+        active_org: Some("hosted-org".to_string()),
+        orgs: HashMap::from([(
+            "hosted-org".to_string(),
+            OrgConfig {
+                id: "44444444-4444-4444-8444-444444444444".to_string(),
+                api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
+                api_base_url: "http://127.0.0.1:1".to_string(),
+                default_operator_kind: OperatorKind::Hosted,
+                operators: vec![OperatorRecord {
+                    name: "hosted-op".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                        wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: encrypt_public_key.to_string(),
+                        sign_public_key: sign_public_key.to_string(),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::from([(
+            "hosted-org".to_string(),
+            vec!["33333333-3333-4333-8333-333333333333".to_string()],
+        )]),
+        extra: toml::Table::new(),
+    };
+    std::fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+
+    composite
+}
+
+/// Picking among multiple reuse candidates needs a prompt; with piped
+/// (non-TTY) stdin and no --non-interactive flag, the fence must bail with
+/// the remediation message instead of reaching the selection prompt.
+#[test]
+fn piped_stdin_with_multiple_reuse_candidates_errors() {
+    let temp = TempDir::new().unwrap();
+    let composite = write_two_candidate_config(temp.path());
+
+    // A complete app config: nothing to fill, so the run goes straight to
+    // the reuse decision.
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "newOperators": [{{
+            "name": "operator-1",
+            "publicKey": "{composite}"
+        }}]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env_remove(NON_INTERACTIVE_ENV)
+        .args([
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "multiple operator IDs are known for the active org",
+        ));
+}
+
+/// The escape hatch the fence's error names: an explicit
+/// `existingOperatorIds` picks the operator in the config, so the same
+/// piped-stdin run sails past the reuse decision without a prompt. The
+/// command still fails later — creating the app needs credentials this
+/// fixture doesn't have — but only after the decision.
+#[test]
+fn piped_stdin_multiple_candidates_with_explicit_ids_proceeds() {
+    let temp = TempDir::new().unwrap();
+    write_two_candidate_config(temp.path());
+
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "existingOperatorIds": ["33333333-3333-4333-8333-333333333333"]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env_remove(NON_INTERACTIVE_ENV)
+        .args([
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Creating app 'test-app'"))
+        .stderr(predicate::str::contains("multiple operator IDs are known").not());
+}
+
+/// The other escape hatch: `--no-operator-reuse` opts out of the decision
+/// entirely, so the piped-stdin run mints new operators from the config and
+/// never needs a prompt. Fails later on missing credentials, as above.
+#[test]
+fn piped_stdin_multiple_candidates_with_no_reuse_flag_proceeds() {
+    let temp = TempDir::new().unwrap();
+    let composite = write_two_candidate_config(temp.path());
+
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "newOperators": [{{
+            "name": "operator-1",
+            "publicKey": "{composite}"
+        }}]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env_remove(NON_INTERACTIVE_ENV)
+        .args([
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+            "--no-operator-reuse",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Creating app 'test-app'"))
+        .stderr(predicate::str::contains("multiple operator IDs are known").not());
+}

--- a/tvc/tests/app_create_help.rs
+++ b/tvc/tests/app_create_help.rs
@@ -11,7 +11,5 @@ fn app_create_help_documents_operator_reuse_opt_out() {
         .success()
         .stdout(predicate::str::contains("--no-operator-reuse"))
         .stdout(predicate::str::contains("TVC_NO_OPERATOR_REUSE"))
-        .stdout(predicate::str::contains(
-            "reusing the most recently created",
-        ));
+        .stdout(predicate::str::contains("instead of reusing a known one"));
 }

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -1,4 +1,6 @@
-//! Fixtures shared across the tvc integration-test binaries.
+//! Fixtures shared across the tvc integration-test binaries. Each binary
+//! compiles its own copy and uses a subset, so unused items are expected.
+#![allow(dead_code)]
 
 use std::{
     collections::HashMap,
@@ -7,8 +9,8 @@ use std::{
 };
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use tvc::config::turnkey::{
-    Config, KeyCurve, OperatorKind, OperatorRecord, OrgConfig, QosOperatorPublicKey, StoredApiKey,
-    StoredQosOperatorKey,
+    Config, HostedOperatorRecord, KeyCurve, OperatorKind, OperatorRecord, OperatorRecordKind,
+    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey,
 };
 
 /// Dead port: connection attempts fail immediately, so commands stop at their
@@ -47,6 +49,58 @@ pub fn write_profiles_config(home: &Path, profiles: &[(&str, &str)], active_org:
     let config = Config {
         active_org: active_org.map(String::from),
         orgs,
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+        extra: toml::Table::new(),
+    };
+
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+}
+
+/// Write a v1 `tvc.config.toml` under `home` whose sole, active organization
+/// defaults to the hosted backend and registers exactly one operator, hosted
+/// — the fixture for commands that need local key material a hosted-only org
+/// does not have. The record carries a real generated composite key split
+/// into its two points, the way `operator create` stores it.
+pub fn write_hosted_only_config(home: &Path, alias: &str, org_id: &str) {
+    let turnkey_dir = home.join(".config/turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let composite = hex::encode(
+        qos_p256::P256Pair::generate()
+            .unwrap()
+            .public_key()
+            .to_bytes(),
+    );
+    let (encrypt_public_key, sign_public_key) = composite.split_at(composite.len() / 2);
+
+    let config = Config {
+        active_org: Some(alias.to_string()),
+        orgs: HashMap::from([(
+            alias.to_string(),
+            OrgConfig {
+                id: org_id.to_string(),
+                api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+                default_operator_kind: OperatorKind::Hosted,
+                operators: vec![OperatorRecord {
+                    name: "hosted-op".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                        wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: encrypt_public_key.to_string(),
+                        sign_public_key: sign_public_key.to_string(),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
         last_created_app_id: HashMap::new(),
         last_operator_ids: HashMap::new(),
         extra: toml::Table::new(),

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -117,6 +117,28 @@ fn hosted_default_rejects_skip_post_without_operator_id() {
         ));
 }
 
+/// Without `--operator-id` or saved IDs, a registered hosted operator is the
+/// posting candidate: target-building auto-selects it and resolution then
+/// proceeds to credential loading.
+#[test]
+fn registered_hosted_operator_is_the_post_candidate_without_saved_ids() {
+    let temp = TempDir::new().unwrap();
+    write_hosted_config(&temp);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--manifest-id")
+        .arg("11111111-1111-4111-8111-111111111111")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No API key found for org 'test'"));
+}
+
 #[test]
 fn explicit_seed_rejects_hosted_operator_id() {
     let temp = TempDir::new().unwrap();

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -94,8 +94,11 @@ fn hosted_dry_run_does_not_require_operator_id() {
         .stdout(predicate::str::contains("Dry run complete"));
 }
 
+/// A hosted default alone cannot satisfy `--skip-post`: the refusal fires
+/// during resolution, before operator selection or credential loading (the
+/// fixture deliberately has no API key on disk).
 #[test]
-fn hosted_approval_requires_explicit_operator_id() {
+fn hosted_default_rejects_skip_post_without_operator_id() {
     let temp = TempDir::new().unwrap();
     write_hosted_config(&temp);
 
@@ -110,7 +113,7 @@ fn hosted_approval_requires_explicit_operator_id() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--operator-id is required to approve with a hosted operator",
+            "--skip-post is only supported for local operators",
         ));
 }
 

--- a/tvc/tests/keys_backup_operator_key.rs
+++ b/tvc/tests/keys_backup_operator_key.rs
@@ -7,12 +7,37 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+const ORG_HOSTED_ONLY: &str = "88888888-8888-4888-8888-888888888888";
 
 fn operator_key_path(home: &TempDir, alias: &str) -> PathBuf {
     home.path()
         .join(".config/turnkey/orgs")
         .join(alias)
         .join("operator.json")
+}
+
+/// A hosted-only org has nothing exportable: the failure explains why
+/// instead of leaving a bare missing-operator error.
+#[test]
+fn hosted_only_org_explains_there_is_no_key_file_to_back_up() {
+    let temp = TempDir::new().unwrap();
+    common::write_hosted_only_config(temp.path(), "hosted-org", ORG_HOSTED_ONLY);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("keys")
+        .arg("backup-operator-key")
+        .arg("--output")
+        .arg(temp.path().join("backup.json"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "org 'hosted-org' has no local operator key file to back up",
+        ))
+        .stderr(predicate::str::contains(
+            "held by Turnkey and cannot be exported",
+        ));
 }
 
 #[test]

--- a/tvc/tests/keys_re_encrypt_local_share.rs
+++ b/tvc/tests/keys_re_encrypt_local_share.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use qos_core::protocol::services::boot::{
@@ -115,6 +117,65 @@ fn re_encrypt_local_share_requires_metadata_and_provision_bundle() {
         ))
         .stderr(predicate::str::contains("--quorum-key-metadata <PATH>"))
         .stderr(predicate::str::contains("--provision-bundle <PATH>"));
+}
+
+/// Without explicit seed flags the operator comes from the active org's
+/// registry, and a hosted-only org has no local key to decrypt with: the
+/// failure explains that and points at the hosted counterpart.
+#[test]
+fn hosted_only_org_is_pointed_at_deploy_provision() {
+    let temp = TempDir::new().unwrap();
+    common::write_hosted_only_config(
+        temp.path(),
+        "hosted-org",
+        "88888888-8888-4888-8888-888888888888",
+    );
+
+    // Parseable metadata and bundle: both are read before the operator is
+    // resolved, which is where this run must fail.
+    let metadata_path = temp.path().join("quorum_key_metadata.json");
+    let provision_bundle_path = temp.path().join("provision_bundle.json");
+    let quorum_pair = P256Pair::generate().unwrap();
+    let manifest_envelope = sample_manifest_envelope(quorum_pair.public_key().to_bytes(), vec![]);
+    fs::write(
+        &metadata_path,
+        serde_json::to_vec_pretty(&json!({
+            "quorumKeyPublic": hex::encode(quorum_pair.public_key().to_bytes()),
+            "threshold": 1,
+            "shares": [],
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        &provision_bundle_path,
+        serde_json::to_vec_pretty(&json!({
+            "attestationDocumentCoseSign1Base64": "not parsed before operator resolution",
+            "manifestEnvelope": manifest_envelope,
+            "fetchedAtUnixMs": 1_712_345_678_901_u64,
+            "deploymentId": "deploy-123",
+            "ephemeralPublicKeyHex": hex::encode(quorum_pair.public_key().to_bytes()),
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env_remove("TVC_OPERATOR_SEED")
+        .arg("keys")
+        .arg("re-encrypt-local-share")
+        .arg("--quorum-key-metadata")
+        .arg(&metadata_path)
+        .arg("--provision-bundle")
+        .arg(&provision_bundle_path)
+        .arg("--dangerous-skip-verification")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "needs the local operator key the share was encrypted to",
+        ))
+        .stderr(predicate::str::contains("tvc deploy provision"));
 }
 
 #[test]

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -18,9 +18,11 @@ use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
 use std::thread::{self, JoinHandle};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use tvc::config::app::KNOWN_QUORUM_KEY;
 use tvc::config::turnkey::{
-    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
+    Config, HostedOperatorRecord, KeyCurve, OperatorKind, OperatorRecord, OperatorRecordKind,
+    OrgConfig, StoredApiKey,
 };
 
 /// Default per-step timeout. Generous enough for CI-runner cold cargo builds
@@ -577,4 +579,53 @@ fn app_create_reuses_the_registered_hosted_operator_by_default() {
         "Reusing operator hosted-op (11111111-1111-4111-8111-111111111111)",
     );
     session.exp_eof().unwrap();
+}
+
+/// Logging in to an org whose default backend is hosted needs no local key:
+/// login reports the registered hosted operator and generates nothing.
+#[test]
+fn login_reports_the_hosted_operator_for_a_hosted_default_org() {
+    let temp = tempfile::TempDir::new().unwrap();
+    write_hosted_org_config(temp.path());
+
+    // An existing API key so login skips generation and goes straight to
+    // verification.
+    let api_key_dir = temp.path().join(".config/turnkey/orgs/hosted-org");
+    std::fs::create_dir_all(&api_key_dir).unwrap();
+    let stamper = TurnkeyP256ApiKey::generate();
+    let api_key = StoredApiKey {
+        public_key: hex::encode(stamper.compressed_public_key()),
+        private_key: hex::encode(stamper.private_key()),
+        curve: KeyCurve::P256,
+    };
+    std::fs::write(
+        api_key_dir.join("api_key.json"),
+        serde_json::to_string_pretty(&api_key).unwrap(),
+    )
+    .unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &[
+            "login",
+            "--org",
+            "hosted-org",
+            "--api-base-url",
+            &api_base_url,
+        ],
+    );
+
+    session.exp_string("Using existing API key.").unwrap();
+    exp_wrapped(
+        &mut session,
+        "Using hosted operator 'hosted-op' (11111111-1111-4111-8111-111111111111).",
+    );
+    let output = session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(output.contains("Successfully logged in!"), "{output}");
+    assert!(!output.contains("Generating operator key"), "{output}");
+    assert!(output.contains("Hosted operator:"), "{output}");
 }

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -10,22 +10,50 @@
 
 mod common;
 
+use qos_p256::P256Pair;
 use rexpect::session::PtySession;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
 use std::thread::{self, JoinHandle};
+use tvc::config::app::KNOWN_QUORUM_KEY;
+use tvc::config::turnkey::{
+    Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
+};
 
 /// Default per-step timeout. Generous enough for CI-runner cold cargo builds
 /// of the binary; tight enough to fail fast if an `exp_string` mismatches.
 const TIMEOUT_MS: u64 = 10_000;
+
+const ORG_HOSTED: &str = "88888888-8888-4888-8888-888888888888";
 
 fn spawn(args: &str) -> PtySession {
     let bin = env!("CARGO_BIN_EXE_tvc");
     let cmd = format!("{bin} {args}");
     rexpect::spawn(&cmd, Some(TIMEOUT_MS))
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {cmd}"))
+}
+
+/// Expect `text` while tolerating the PTY's hard wrap: output longer than the
+/// terminal width gets a line break injected at an arbitrary point, so the
+/// text is matched as a regex that accepts a break between any two characters.
+fn exp_wrapped(session: &mut PtySession, text: &str) {
+    let pattern: String = text
+        .chars()
+        .map(|c| {
+            let escaped = if r"\.+*?()|[]{}^$".contains(c) {
+                format!(r"\{c}")
+            } else {
+                c.to_string()
+            };
+            format!("{escaped}[\r\n]*")
+        })
+        .collect();
+    session
+        .exp_regex(&pattern)
+        .unwrap_or_else(|e| panic!("expected (wrap-tolerant) {text:?}: {e}"));
 }
 
 /// Spawn the binary in a PTY with `HOME` pointed at an isolated directory and
@@ -39,7 +67,10 @@ fn spawn_with_home(home: &Path, args: &[&str]) -> PtySession {
         .env("HOME", home)
         .env_remove("TVC_ORG")
         .env_remove("TVC_API_BASE_URL")
-        .env_remove("TVC_NON_INTERACTIVE");
+        .env_remove("TVC_NON_INTERACTIVE")
+        .env_remove("TVC_ORG_ID")
+        .env_remove("TVC_API_KEY_PUBLIC")
+        .env_remove("TVC_API_KEY_PRIVATE");
 
     rexpect::session::spawn_command(cmd, Some(TIMEOUT_MS))
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {bin} {}", args.join(" ")))
@@ -379,4 +410,171 @@ fn login_existing_operator_key_prints_backup_tip() {
     session.exp_string("Successfully logged in!").unwrap();
     session.exp_eof().unwrap();
     server.join().unwrap();
+}
+
+/// Write a v1 config whose active org's registry holds exactly one operator,
+/// hosted, storing a real composite public key the way `operator create`
+/// stores it: encryption point and signing point as separate hex fields.
+/// Returns the composite.
+fn write_hosted_org_config(home: &Path) -> String {
+    let turnkey_dir = home.join(".config/turnkey");
+    std::fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+    let (encrypt_public_key, sign_public_key) = composite.split_at(composite.len() / 2);
+
+    let config = Config {
+        active_org: Some("hosted-org".to_string()),
+        orgs: HashMap::from([(
+            "hosted-org".to_string(),
+            OrgConfig {
+                id: ORG_HOSTED.to_string(),
+                api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
+                api_base_url: common::LOCAL_API_BASE_URL.to_string(),
+                default_operator_kind: OperatorKind::Hosted,
+                operators: vec![OperatorRecord {
+                    name: "hosted-op".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                        wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: encrypt_public_key.to_string(),
+                        sign_public_key: sign_public_key.to_string(),
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+        extra: toml::Table::new(),
+    };
+    std::fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+
+    composite
+}
+
+/// The explicit minting path for an org whose operator is hosted: with
+/// `--no-operator-reuse`, `app create` offers the registered hosted
+/// operator's public key as the fill default, exactly as it offers a local
+/// key file's key. Both are the same qos composite — the local file stores
+/// encrypt ‖ sign concatenated, and the hosted registry record stores the
+/// two points separately — so the org's one operator must be one Enter away
+/// in both worlds. (Without the flag, the default flow reuses the registered
+/// identity by ID instead of minting; see the sibling test below.)
+///
+/// The command exits nonzero after the fill — creating the app needs
+/// credentials this fixture doesn't have — but that is outside this test's
+/// scope.
+#[test]
+fn app_create_offers_the_hosted_operator_key_as_the_fill_default() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let composite = write_hosted_org_config(temp.path());
+
+    // An app config whose only placeholder is the operator public key.
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "newOperators": [{{
+            "name": "operator-1",
+            "publicKey": "<FILL_IN_OPERATOR_PUBLIC_KEY>"
+        }}]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &[
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+            "--no-operator-reuse",
+        ],
+    );
+
+    // The prompt offers the hosted operator's composite key as its default;
+    // Enter accepts it.
+    session
+        .exp_string("Operator 'operator-1' public key")
+        .unwrap();
+    exp_wrapped(&mut session, &composite);
+    session.send_line("").unwrap();
+
+    session.exp_string("Save filled config").unwrap();
+    session.send_line("y").unwrap();
+    exp_wrapped(&mut session, "Wrote ");
+    session.exp_eof().unwrap();
+
+    let saved: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&app_config_path).unwrap()).unwrap();
+    assert_eq!(
+        saved["manifestSetParams"]["newOperators"][0]["publicKey"], composite,
+        "accepting the default must land the hosted operator's key in the saved config"
+    );
+}
+
+/// The default flow for an org with a registered hosted operator reuses that
+/// identity via `existingOperatorIds` instead of minting a duplicate operator
+/// around the same key material.
+///
+/// The command exits nonzero afterwards — creating the app needs credentials
+/// this fixture doesn't have — but the reuse announcement precedes that.
+#[test]
+fn app_create_reuses_the_registered_hosted_operator_by_default() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let composite = write_hosted_org_config(temp.path());
+
+    // A complete app config: nothing to fill, so the run goes straight to
+    // the reuse decision.
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "newOperators": [{{
+            "name": "operator-1",
+            "publicKey": "{composite}"
+        }}]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &[
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+        ],
+    );
+
+    exp_wrapped(
+        &mut session,
+        "Reusing operator hosted-op (11111111-1111-4111-8111-111111111111)",
+    );
+    session.exp_eof().unwrap();
 }

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -417,8 +417,9 @@ fn login_existing_operator_key_prints_backup_tip() {
 /// Write a v1 config whose active org's registry holds exactly one operator,
 /// hosted, storing a real composite public key the way `operator create`
 /// stores it: encryption point and signing point as separate hex fields.
-/// Returns the composite.
-fn write_hosted_org_config(home: &Path) -> String {
+/// `saved_operator_ids` become the org's `last_operator_ids`, making them
+/// additional reuse candidates. Returns the composite.
+fn write_hosted_org_config(home: &Path, saved_operator_ids: &[&str]) -> String {
     let turnkey_dir = home.join(".config/turnkey");
     std::fs::create_dir_all(&turnkey_dir).unwrap();
 
@@ -449,7 +450,10 @@ fn write_hosted_org_config(home: &Path) -> String {
             },
         )]),
         last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
+        last_operator_ids: HashMap::from([(
+            "hosted-org".to_string(),
+            saved_operator_ids.iter().map(|id| id.to_string()).collect(),
+        )]),
         extra: toml::Table::new(),
     };
     std::fs::write(
@@ -476,7 +480,7 @@ fn write_hosted_org_config(home: &Path) -> String {
 #[test]
 fn app_create_offers_the_hosted_operator_key_as_the_fill_default() {
     let temp = tempfile::TempDir::new().unwrap();
-    let composite = write_hosted_org_config(temp.path());
+    let composite = write_hosted_org_config(temp.path(), &[]);
 
     // An app config whose only placeholder is the operator public key.
     let app_config_path = temp.path().join("app.json");
@@ -540,7 +544,7 @@ fn app_create_offers_the_hosted_operator_key_as_the_fill_default() {
 #[test]
 fn app_create_reuses_the_registered_hosted_operator_by_default() {
     let temp = tempfile::TempDir::new().unwrap();
-    let composite = write_hosted_org_config(temp.path());
+    let composite = write_hosted_org_config(temp.path(), &[]);
 
     // A complete app config: nothing to fill, so the run goes straight to
     // the reuse decision.
@@ -581,12 +585,77 @@ fn app_create_reuses_the_registered_hosted_operator_by_default() {
     session.exp_eof().unwrap();
 }
 
+/// With SEVERAL known operators — a registered hosted record plus a saved
+/// manifest-set ID — the default flow prompts to pick one, and the chosen
+/// candidate (here the second, selected with a down-arrow) is what gets
+/// reused.
+///
+/// The command exits nonzero afterwards — creating the app needs credentials
+/// this fixture doesn't have — but the selection and reuse announcement
+/// precede that.
+#[test]
+fn app_create_prompts_to_pick_among_multiple_reuse_candidates() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let composite = write_hosted_org_config(temp.path(), &["33333333-3333-4333-8333-333333333333"]);
+
+    // A complete app config: nothing to fill, so the run goes straight to
+    // the reuse decision.
+    let app_config_path = temp.path().join("app.json");
+    std::fs::write(
+        &app_config_path,
+        format!(
+            r#"{{
+    "name": "test-app",
+    "quorumPublicKey": "{KNOWN_QUORUM_KEY}",
+    "manifestSetParams": {{
+        "name": "manifest-set",
+        "threshold": 1,
+        "newOperators": [{{
+            "name": "operator-1",
+            "publicKey": "{composite}"
+        }}]
+    }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &[
+            "app",
+            "create",
+            "--config-file",
+            app_config_path.to_str().unwrap(),
+        ],
+    );
+
+    // Both candidates are offered: the registered record with its name, and
+    // the saved ID bare.
+    session.exp_string("Select operator to reuse").unwrap();
+    exp_wrapped(
+        &mut session,
+        "hosted-op (11111111-1111-4111-8111-111111111111)",
+    );
+    exp_wrapped(&mut session, "33333333-3333-4333-8333-333333333333");
+
+    // Down-arrow to the saved ID, Enter to confirm.
+    session.send("\x1b[B").unwrap();
+    session.send_line("").unwrap();
+
+    exp_wrapped(
+        &mut session,
+        "Reusing operator 33333333-3333-4333-8333-333333333333",
+    );
+    session.exp_eof().unwrap();
+}
+
 /// Logging in to an org whose default backend is hosted needs no local key:
 /// login reports the registered hosted operator and generates nothing.
 #[test]
 fn login_reports_the_hosted_operator_for_a_hosted_default_org() {
     let temp = tempfile::TempDir::new().unwrap();
-    write_hosted_org_config(temp.path());
+    write_hosted_org_config(temp.path(), &[]);
 
     // An existing API key so login skips generation and goes straight to
     // verification.


### PR DESCRIPTION
Third in the stack, extracted from #224 — based on #237; retarget when it merges. This is the fix for login being impossible when an org has no local operator.

## Sole-hosted resolution

`select_hosted_operator` (typed `SelectHostedOperatorError`, sibling of the local selector) resolves the sole hosted registry record. `resolve_operator`'s hosted-default arm no longer demands `--operator-id`: with none given it refuses `--skip-post` before selection or credentials, then resolves the sole hosted record — no crossover to the local key, precedence otherwise unchanged. Dead `OperatorRecord::operator_kind()` deleted. Per review comments on #224: hosted registry iteration is now `OrgConfig::hosted_operators()`, and both hosted lookups go through it.

## Registered hosted operators in defaults

`Config::default_operator_public_key()` (a method per review feedback) honors the org's default backend — local reads the sole key file, hosted joins the sole record's stored points — replacing the three copies of the local-only helper in `app init`, `app create`, and `keys init-local-quorum-key`. `Config::known_operator_candidates()` unions registered hosted operators (config order) with the last `app create`'s saved IDs, deduplicated; `app create` reuses over that union by default (`--no-operator-reuse` still mints), and `deploy approve` sources its posting candidate from it. Flagged behavior change: a local-default org with a registered hosted record and no saved IDs now auto-posts via the hosted identity instead of bailing.

## Hosted-default login

`execute_login` matches on `default_operator_kind` with no crossover: local finds or generates the registered key file (backup nudge unchanged); hosted reports the registered identity and generates nothing. The JSON outcome flattens a `LoggedInOperator` enum — local keeps its exact pre-hosted fields plus an additive `operatorKind` tag; hosted emits `operatorName`/`operatorId`/composite `operatorPublicKey` and no `operatorKeyPath`. Covered by complete-JSON serde tests and a mock-whoami pty login test.

## Local-only commands explain themselves

For hosted-only orgs, `keys backup-operator-key` explains the private key is held by Turnkey and cannot be exported, and `keys re-encrypt-local-share` points at `tvc deploy provision`; typed errors are preserved through the chains. Shared `write_hosted_only_config` fixture in `tests/common.rs`.

One review comment deliberately deferred: "no `Config::load` in the operator module" — `resolve_operator` keeps its lazy load because `explicit_seed_does_not_load_malformed_config` pins that explicit-seed approvals must not depend on a well-formed config file; documented in its rustdoc.