### PR TITLE
test(tvc): harden config and key-directory migration coverage

### DIFF
--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -58,7 +58,7 @@ pub struct Config {
     /// Org registry keyed by organization ID, in config-file order.
     #[serde(default)]
     pub orgs: IndexMap<Uuid, OrgConfig>,
-    /// Edge-side names for organizations.
+    /// User-facing names for organizations.
     #[serde(default)]
     pub aliases: Aliases,
     /// Last created app ID per organization (for convenience).
@@ -72,7 +72,7 @@ pub struct Config {
     pub extra: toml::Table,
 }
 
-/// Edge-side names for UUID-identified resources.
+/// User-facing names for UUID-identified resources.
 ///
 /// The one serialized alias surface: a name maps to exactly one ID by map
 /// construction, and every mutation goes through these methods. Nothing in
@@ -466,6 +466,7 @@ mod disk {
     }
 
     pub(super) mod v0 {
+        use indexmap::IndexMap;
         use serde::Deserialize;
         use std::collections::HashMap;
         use uuid::Uuid;
@@ -476,8 +477,10 @@ mod disk {
         pub(super) struct Config {
             #[serde(default)]
             pub(super) active_org: Option<String>,
+            /// File order is preserved: the duplicate-organization merge keeps
+            /// the first profile in file order, for v0 exactly as for v1.
             #[serde(default)]
-            pub(super) orgs: HashMap<String, toml::Table>,
+            pub(super) orgs: IndexMap<String, toml::Table>,
             #[serde(default)]
             pub(super) last_created_app_id: HashMap<String, Uuid>,
             #[serde(default)]
@@ -1179,6 +1182,257 @@ default_alias = true
 
         assert_eq!(loaded, config);
         assert!(!backup_file_path(&path).exists());
+    }
+
+    #[tokio::test]
+    async fn migrates_v1_to_v2_eagerly_with_backup_lifecycle() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            format!(
+                r#"
+version = 1
+active_org = "prod"
+future_root = "keep-root"
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+future_org = 42
+
+[last_created_app_id]
+prod = "{APP_ID}"
+
+[last_operator_ids]
+prod = ["{OPERATOR_ID}"]
+"#
+            ),
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        // Registry and side maps re-key from alias to organization ID, and
+        // unknown fields survive at both levels.
+        assert_eq!(config.aliases.resolve("prod").unwrap().id(), ORG_1);
+        assert_eq!(config.active_org, Some(ORG_1));
+        assert_eq!(config.last_created_app_id[&ORG_1], APP_ID);
+        assert_eq!(config.last_operator_ids[&ORG_1], vec![OPERATOR_ID]);
+        assert_eq!(
+            config.orgs[&ORG_1].extra["future_org"],
+            toml::Value::Integer(42)
+        );
+        assert_eq!(
+            config.extra["future_root"],
+            toml::Value::String("keep-root".into())
+        );
+
+        // Eagerly rewritten: the file on disk is v2 and the backup is gone.
+        let saved = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(saved.contains("version = 2"), "{saved}");
+        assert!(!backup_file_path(&path).exists());
+
+        let reloaded = Config::load_from_path(&path).await.unwrap();
+        assert_eq!(reloaded, config);
+    }
+
+    /// The fence blocks even when the config file itself already carries the
+    /// migrated schema: a crash between writing the new file and removing
+    /// the backup must surface, not be silently absorbed.
+    #[tokio::test]
+    async fn an_existing_backup_blocks_even_an_already_migrated_config() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+
+        let mut config = Config::default();
+        config
+            .add_org(ORG_1, API_BASE_URL_PROD.to_string())
+            .unwrap();
+        config.save_to_path(&path).await.unwrap();
+        tokio::fs::write(backup_file_path(&path), v0_config())
+            .await
+            .unwrap();
+
+        let error = Config::load_from_path(&path)
+            .await
+            .expect_err("backup must block");
+
+        assert!(
+            error.to_string().contains("interrupted config migration"),
+            "{error}"
+        );
+    }
+
+    /// Deleting the backup — the manual fix the refusal instructs — unblocks
+    /// the next load with the already-migrated contents intact.
+    #[tokio::test]
+    async fn removing_the_backup_recovers_the_post_write_crash_window() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(&path, v0_config()).await.unwrap();
+        let migrated = Config::load_from_path(&path).await.unwrap();
+
+        // Recreate the crash window: the migrated file was written but the
+        // process died before the backup was removed.
+        tokio::fs::write(backup_file_path(&path), v0_config())
+            .await
+            .unwrap();
+        Config::load_from_path(&path)
+            .await
+            .expect_err("fence engaged");
+
+        tokio::fs::remove_file(backup_file_path(&path))
+            .await
+            .unwrap();
+
+        assert_eq!(Config::load_from_path(&path).await.unwrap(), migrated);
+    }
+
+    /// Restoring the backup over the config path — the manual fix for a
+    /// crash between parking the original and writing the new file — re-runs
+    /// the migration cleanly.
+    #[tokio::test]
+    async fn restoring_the_backup_recovers_the_pre_write_crash_window() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        // The crash window: original parked at the backup path, no config.
+        tokio::fs::write(backup_file_path(&path), v0_config())
+            .await
+            .unwrap();
+        Config::load_from_path(&path)
+            .await
+            .expect_err("fence engaged");
+
+        tokio::fs::rename(backup_file_path(&path), &path)
+            .await
+            .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.active_org, Some(ORG_1));
+        assert!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .unwrap()
+                .contains("version = 2")
+        );
+        assert!(!backup_file_path(&path).exists());
+    }
+
+    /// v0 kept its organizations in file order too: a duplicated
+    /// organization ID merges to the first profile in file order, exactly as
+    /// it does for v1, not to a hash-ordered arbitrary one.
+    #[tokio::test]
+    async fn v0_duplicate_org_ids_merge_to_the_first_profile_in_file_order() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            r#"
+[orgs.first]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/first/api.json"
+operator_key_path = "/keys/first/operator.json"
+
+[orgs.second]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/second/api.json"
+operator_key_path = "/keys/second/operator.json"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.orgs.len(), 1);
+        assert_eq!(
+            config.orgs[&ORG_1].api_key_path,
+            PathBuf::from("/keys/first/api.json")
+        );
+        // Both names survive as aliases for the kept profile.
+        assert_eq!(config.aliases.resolve("first").unwrap().id(), ORG_1);
+        assert_eq!(config.aliases.resolve("second").unwrap().id(), ORG_1);
+    }
+
+    #[test]
+    fn v0_missing_operator_key_path_names_the_organization() {
+        let error = disk::from_toml(
+            r#"
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+"#,
+        )
+        .map(|_| ())
+        .expect_err("v0 without operator_key_path must fail");
+
+        assert!(
+            format!("{error:#}")
+                .contains("v0 config for organization 'prod' is missing operator_key_path"),
+            "{error:#}"
+        );
+    }
+
+    /// Side-map entries whose alias has no surviving profile are dropped —
+    /// there is no organization ID to re-key them under.
+    #[tokio::test]
+    async fn v1_side_maps_drop_entries_for_unknown_aliases() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            format!(
+                r#"
+version = 1
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+
+[last_created_app_id]
+ghost = "{APP_ID}"
+
+[last_operator_ids]
+prod = ["{OPERATOR_ID}"]
+"#
+            ),
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert!(config.last_created_app_id.is_empty());
+        assert_eq!(config.last_operator_ids[&ORG_1], vec![OPERATOR_ID]);
+    }
+
+    /// An active_org naming an alias with no profile cannot survive the
+    /// re-keying; the migrated config simply has no active organization.
+    #[tokio::test]
+    async fn v1_dangling_active_org_migrates_to_none() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            r#"
+version = 1
+active_org = "ghost"
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.active_org, None);
+        assert_eq!(config.aliases.resolve("prod").unwrap().id(), ORG_1);
     }
 
     #[test]

--- a/tvc/tests/config_migration.rs
+++ b/tvc/tests/config_migration.rs
@@ -1,0 +1,255 @@
+//! End-to-end config-migration behavior through the real binary: any
+//! config-loading command migrates eagerly, migration notes reach stderr,
+//! the interrupted-migration fence blocks with instructions, and the
+//! instructed manual fixes actually recover.
+//!
+//! The vehicle command is `keys backup-operator-key --output <path>`: it
+//! loads the config right after its non-interactive input check and touches
+//! no network, so every run deterministically exercises the load path.
+
+mod common;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+const ORG_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+fn config_path(home: &Path) -> PathBuf {
+    home.join(".config/turnkey/tvc.config.toml")
+}
+
+fn backup_path(home: &Path) -> PathBuf {
+    home.join(".config/turnkey/tvc.config.toml.backup")
+}
+
+fn write_config(home: &Path, contents: &str) {
+    let dir = home.join(".config/turnkey");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("tvc.config.toml"), contents).unwrap();
+}
+
+fn v0_config() -> String {
+    format!(
+        r#"
+active_org = "default"
+
+[orgs.default]
+id = "{ORG_ID}"
+api_key_path = "/keys/api.json"
+operator_key_path = "/keys/operator.json"
+"#
+    )
+}
+
+fn run_config_loading_command(home: &Path) -> assert_cmd::assert::Assert {
+    cargo_bin_cmd!("tvc")
+        .env("HOME", home)
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("keys")
+        .arg("backup-operator-key")
+        .arg("--output")
+        .arg(home.join("backup-out.json"))
+        .assert()
+}
+
+/// A v0 config is rewritten to the current schema by the first command that
+/// loads it — even one that goes on to fail — and the fence backup is gone
+/// afterwards.
+#[test]
+fn any_config_loading_command_migrates_v0_eagerly() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+
+    // The command itself fails later (the registered key file does not
+    // exist); the migration has already been persisted by then.
+    run_config_loading_command(temp.path()).failure();
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(saved.contains(ORG_ID), "{saved}");
+    assert!(!backup_path(temp.path()).exists());
+}
+
+/// A jump straight from v0 to the current schema is one load, not a chain of
+/// upgrades the user must run in order: the rewritten file keeps the org,
+/// its alias, and the active-org marker.
+#[test]
+fn v0_to_v2_is_a_single_load_with_nothing_left_behind() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+
+    run_config_loading_command(temp.path()).failure();
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(table["version"].as_integer(), Some(2));
+    assert_eq!(table["active_org"].as_str(), Some(ORG_ID));
+    assert_eq!(table["aliases"]["default"].as_str(), Some(ORG_ID));
+    assert!(table["orgs"][ORG_ID].is_table(), "{saved}");
+}
+
+/// Lossy migration decisions are reported on stderr, once, at migration
+/// time.
+#[test]
+fn v1_duplicate_merge_notes_reach_stderr() {
+    let temp = TempDir::new().unwrap();
+    write_config(
+        temp.path(),
+        &format!(
+            r#"
+version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "{ORG_ID}"
+api_key_path = "/keys/a/api.json"
+
+[orgs.alias-b]
+id = "{ORG_ID}"
+api_key_path = "/keys/b/api.json"
+default_alias = true
+"#
+        ),
+    );
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains(
+            "config migration: merged duplicate profile 'alias-a'",
+        ));
+
+    // The note is one-time: the migrated file loads silently afterwards.
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("config migration").not());
+}
+
+/// An interrupted migration blocks every command with the recovery
+/// instructions, and does not touch either file while blocked.
+#[test]
+fn an_interrupted_migration_blocks_every_command_with_instructions() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+    fs::write(backup_path(temp.path()), "pre-migration bytes").unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"))
+        .stderr(predicate::str::contains("delete"));
+
+    assert_eq!(
+        fs::read_to_string(config_path(temp.path())).unwrap(),
+        v0_config(),
+        "a blocked load must not rewrite the config"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_path(temp.path())).unwrap(),
+        "pre-migration bytes"
+    );
+}
+
+/// The crash window between parking the original and writing the new file
+/// leaves only the backup; starting fresh would shadow the user's data, so
+/// the same fence applies.
+#[test]
+fn a_backup_alone_blocks_instead_of_starting_fresh() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".config/turnkey")).unwrap();
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+}
+
+/// Manual fix for the post-write window: the config is already migrated, so
+/// deleting the backup is the instructed resolution — and it works.
+#[test]
+fn deleting_the_backup_recovers_the_post_write_crash_window() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+    run_config_loading_command(temp.path()).failure();
+
+    // Recreate the window: migrated config on disk, stale backup beside it.
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+
+    fs::remove_file(backup_path(temp.path())).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration").not());
+}
+
+/// Manual fix for the pre-write window: the config file is missing, so
+/// restoring the backup over the config path re-runs the migration cleanly.
+#[test]
+fn restoring_the_backup_recovers_the_pre_write_crash_window() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".config/turnkey")).unwrap();
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+
+    fs::rename(backup_path(temp.path()), config_path(temp.path())).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration").not());
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(!backup_path(temp.path()).exists());
+}
+
+/// A config written by a newer tvc is refused by name and left untouched.
+#[test]
+fn a_newer_config_version_is_refused_and_left_untouched() {
+    let temp = TempDir::new().unwrap();
+    let contents = format!("version = 3\n\n[orgs.{ORG_ID}]\napi_key_path = \"/keys/api.json\"\n");
+    write_config(temp.path(), &contents);
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains(
+            "config written by a newer tvc (version 3)",
+        ));
+
+    assert_eq!(
+        fs::read_to_string(config_path(temp.path())).unwrap(),
+        contents
+    );
+}
+
+/// The config-schema migration is eager, but the key-directory migration is
+/// interactive-only: a non-interactive command migrates the file schema and
+/// keeps reading key files from the legacy alias-keyed directory it still
+/// points at.
+#[test]
+fn non_interactive_commands_use_legacy_directories_without_moving_them() {
+    let temp = TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_ID)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_ID);
+
+    run_config_loading_command(temp.path()).success();
+
+    // Schema migrated, directories untouched, config still points at the
+    // legacy layout.
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(legacy_dir.join("operator.json").exists());
+    assert!(!id_dir.exists());
+    assert!(
+        saved.contains(legacy_dir.join("api_key.json").to_str().unwrap()),
+        "{saved}"
+    );
+}

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -792,3 +792,230 @@ fn login_reports_the_hosted_operator_for_a_hosted_default_org() {
     assert!(!output.contains("Generating operator key"), "{output}");
     assert!(output.contains("Hosted operator:"), "{output}");
 }
+
+/// A crash between the directory rename and the config save leaves the files
+/// moved but the config still pointing at the legacy paths. The next
+/// interactive login heals: it treats the move as done and rewrites the
+/// config.
+#[test]
+fn login_heals_a_crash_between_directory_move_and_config_save() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    // Recreate the crash window: the rename happened, the save did not.
+    std::fs::rename(&legacy_dir, &id_dir).unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_dir.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        id_dir.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// A crash mid-loop strands at most one organization (the migration saves
+/// after each): the next interactive login finishes the job in one pass,
+/// healing the moved-but-unsaved org and moving the untouched one.
+#[test]
+fn login_finishes_a_partially_migrated_config_in_one_pass() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", ORG_E2E), ("alias-b", ORG_OTHER)],
+        Some("alias-a"),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+    let legacy_a = temp.path().join(".config/turnkey/orgs/alias-a");
+    let legacy_b = temp.path().join(".config/turnkey/orgs/alias-b");
+    let id_a = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+    let id_b = temp.path().join(".config/turnkey/orgs").join(ORG_OTHER);
+
+    // Org A crashed between rename and save; org B was never reached.
+    std::fs::rename(&legacy_a, &id_a).unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_a.display(),
+            id_a.display()
+        ),
+    );
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_b.display(),
+            id_b.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(!legacy_a.exists());
+    assert!(!legacy_b.exists());
+    assert!(id_a.join("operator.json").exists());
+    assert!(id_b.join("operator.json").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        id_a.join("api_key.json").to_str().unwrap()
+    );
+    assert_eq!(
+        table["orgs"][ORG_OTHER]["api_key_path"].as_str().unwrap(),
+        id_b.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// An occupied target directory fails the move: the migration warns, keeps
+/// the organization on its legacy paths, and login still succeeds — nothing
+/// is deleted or overwritten.
+#[test]
+fn login_skips_migration_when_the_target_directory_is_occupied() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    // Someone (or something) already owns the target directory.
+    std::fs::create_dir_all(&id_dir).unwrap();
+    std::fs::write(id_dir.join("unrelated.txt"), "not ours").unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(&mut session, "WARNING: could not move key directory");
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    // Both directories intact; the config still points at the legacy paths.
+    assert!(legacy_dir.join("operator.json").exists());
+    assert_eq!(
+        std::fs::read_to_string(id_dir.join("unrelated.txt")).unwrap(),
+        "not ours"
+    );
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        legacy_dir.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// Merging v1 duplicate profiles keeps one registration per organization;
+/// the losing alias's directory is deliberately orphaned on disk (reported
+/// in the migration note), and only the kept profile's directory migrates.
+#[test]
+fn duplicate_alias_merge_leaves_the_losing_directory_orphaned() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config/turnkey");
+    std::fs::create_dir_all(&turnkey_dir).unwrap();
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+    let legacy_a = temp.path().join(".config/turnkey/orgs/alias-a");
+    let legacy_b = temp.path().join(".config/turnkey/orgs/alias-b");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+    std::fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!(
+            r#"version = 1
+active_org = "alias-b"
+
+[orgs.alias-a]
+id = "{ORG_E2E}"
+api_key_path = "{a}/api_key.json"
+api_base_url = "{url}"
+
+[[orgs.alias-a.operators]]
+name = "default"
+kind = "local"
+key_path = "{a}/operator.json"
+
+[orgs.alias-b]
+id = "{ORG_E2E}"
+api_key_path = "{b}/api_key.json"
+api_base_url = "{url}"
+default_alias = true
+
+[[orgs.alias-b.operators]]
+name = "default"
+kind = "local"
+key_path = "{b}/operator.json"
+"#,
+            a = legacy_a.display(),
+            b = legacy_b.display(),
+            url = common::LOCAL_API_BASE_URL,
+        ),
+    )
+    .unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-b", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        "config migration: merged duplicate profile 'alias-a'",
+    );
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_b.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    // The loser's files stay on disk, untouched and unregistered.
+    assert!(legacy_a.join("operator.json").exists());
+    assert!(!legacy_b.exists());
+    assert!(id_dir.join("operator.json").exists());
+}


### PR DESCRIPTION
Fourth in the breakup chain — targets #224's branch directly, since the v2 migration machinery lives there.

## Config-schema migration

New unit coverage: v1→v2 through the real load path with the backup-fence lifecycle (side maps re-keyed, unknown fields preserved at both levels), the fence blocking even when the config on disk is already migrated, both instructed manual recoveries proven to work (delete the backup post-write; restore it pre-write), v0 duplicate-org merges, missing `operator_key_path` naming its org, dangling side-map aliases and `active_org` dropping cleanly.

New `tests/config_migration.rs` drives the real binary: any config-loading command migrates v0 eagerly in a single load, merge notes reach stderr exactly once, an interrupted migration blocks every command with instructions and touches neither file while blocked, both manual fixes unblock, a newer config version is refused untouched, and non-interactive runs keep using legacy directories without moving them.

One behavior fix surfaced by writing these: `v0::Config.orgs` was a `HashMap`, so duplicate-organization merges from v0 configs were nondeterministic — now an `IndexMap`, so v0 follows the same first-in-file-order rule as v1, pinned by test. Also renames "edge-side" to "user-facing" in the alias docs per review comments.

## Key-directory migration (TVC-55)

Four new pty tests enumerate the crash windows as on-disk fixtures: a crash between rename and save heals on the next interactive login; a crash mid-loop strands at most one org and the next login finishes the job in one pass; an occupied target directory warns, keeps legacy paths, and deletes nothing; and a v1 duplicate-alias merge orphans the losing directory deliberately, with the note on stderr.

SIGTERM-at-checkpoint tests were considered and skipped: the migration loop has no deterministic interrupt point from the PTY, so the windows are seeded as fixtures instead — every enumerated state either heals automatically or refuses with instructions that these tests prove work. No unrecoverable window was found; the remaining ambiguity (non-interactive commands see missing key files between a crashed rename and the healing login) is the case the copy-verify-delete rework eliminates.