### PR TITLE
refactor(tvc): load config once at dispatch and pass it into commands

### DIFF
--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -1,12 +1,15 @@
 //! CLI parsing and dispatch.
 
 use crate::commands::{self, Run};
+use crate::config::turnkey::{CONFIG_DIR, CONFIG_FILE, Config};
 use crate::errors::strip_ansi;
 use crate::outcome::Outcome;
 use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell, StdCtx};
+use anyhow::Context;
 use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser, error::ErrorKind};
 use std::ffi::OsString;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::ExitCode;
 use tracing::debug;
 
@@ -200,62 +203,101 @@ fn args_request_json_output(args: impl IntoIterator<Item = OsString>) -> bool {
 
 impl Commands {
     async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<Outcome> {
+        let home = std::env::var("HOME").context("HOME environment variable not set")?;
+        let path = PathBuf::from(home).join(CONFIG_DIR).join(CONFIG_FILE);
+        debug!(config_path = %path.display(), "loading tvc config");
+
+        let config = if !path.exists() {
+            debug!(config_path = %path.display(), "tvc config not found; using defaults");
+            let config = Config::default();
+            config.save().await?;
+            config
+        } else {
+            let content = tokio::fs::read_to_string(&path)
+                .await
+                .with_context(|| format!("failed to read config file: {}", path.display()))?;
+
+            let config = Config::from_toml(&content)
+                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+
+            debug!(
+                config_path = %path.display(),
+                active_org = ?config.active_org,
+                org_count = config.orgs.len(),
+                "loaded tvc config"
+            );
+
+            config
+        };
+
         match self {
             Commands::Deploy { command } => match command {
-                DeployCommands::Approve(args) => args.run(ctx).await.map(Into::into),
+                DeployCommands::Approve(args) => args.run(ctx, config).await.map(Into::into),
                 DeployCommands::GetStatus(args) => {
-                    commands::deploy::get_status::run(ctx, args).await
+                    commands::deploy::get_status::run(ctx, args, config).await
                 }
                 DeployCommands::ProvisioningDetails(args) => {
-                    commands::deploy::provisioning_details::run(ctx, args).await
+                    commands::deploy::provisioning_details::run(ctx, args, config).await
                 }
                 DeployCommands::Provision(args) => {
-                    commands::deploy::provision::run(ctx, args).await
+                    commands::deploy::provision::run(ctx, args, config).await
                 }
                 DeployCommands::PostShare(args) => {
-                    commands::deploy::post_share::run(ctx, args).await
+                    commands::deploy::post_share::run(ctx, args, config).await
                 }
-                DeployCommands::Status(args) => commands::deploy::status::run(ctx, args).await,
-                DeployCommands::Create(args) => commands::deploy::create::run(ctx, args).await,
-                DeployCommands::Init(args) => commands::deploy::init::run(ctx, args).await,
+                DeployCommands::Status(args) => {
+                    commands::deploy::status::run(ctx, args, config).await
+                }
+                DeployCommands::Create(args) => {
+                    commands::deploy::create::run(ctx, args, config).await
+                }
+                DeployCommands::Init(args) => commands::deploy::init::run(ctx, args, config).await,
                 DeployCommands::DebugLogs(args) => {
-                    commands::deploy::debug_logs::run(ctx, args).await
+                    commands::deploy::debug_logs::run(ctx, args, config).await
                 }
-                DeployCommands::Delete(args) => commands::deploy::delete::run(ctx, args).await,
-                DeployCommands::Restore(args) => commands::deploy::restore::run(ctx, args).await,
+                DeployCommands::Delete(args) => {
+                    commands::deploy::delete::run(ctx, args, config).await
+                }
+                DeployCommands::Restore(args) => {
+                    commands::deploy::restore::run(ctx, args, config).await
+                }
             },
             Commands::App { command } => match command {
-                AppCommands::Status(args) => commands::app::status::run(ctx, args).await,
-                AppCommands::List(args) => commands::app::list::run(ctx, args).await,
-                AppCommands::Create(args) => commands::app::create::run(ctx, args).await,
-                AppCommands::Init(args) => commands::app::init::run(ctx, args).await,
+                AppCommands::Status(args) => commands::app::status::run(ctx, args, config).await,
+                AppCommands::List(args) => commands::app::list::run(ctx, args, config).await,
+                AppCommands::Create(args) => commands::app::create::run(ctx, args, config).await,
+                AppCommands::Init(args) => commands::app::init::run(ctx, args, config).await,
                 AppCommands::SetLiveDeploy(args) => {
-                    commands::app::set_live_deploy::run(ctx, args).await
+                    commands::app::set_live_deploy::run(ctx, args, config).await
                 }
-                AppCommands::Delete(args) => commands::app::delete::run(ctx, args).await,
+                AppCommands::Delete(args) => commands::app::delete::run(ctx, args, config).await,
             },
             Commands::Keys { command } => match command {
-                KeysCommands::BackupOperatorKey(args) => args.run(ctx).await.map(Into::into),
+                KeysCommands::BackupOperatorKey(args) => {
+                    args.run(ctx, config).await.map(Into::into)
+                }
                 KeysCommands::CreateQuorumKey(args) => {
-                    commands::keys::create_quorum_key::run(ctx, args).await
+                    commands::keys::create_quorum_key::run(ctx, args, config).await
                 }
                 KeysCommands::GenerateLocalQuorumKey(args) => {
                     commands::keys::generate_local_quorum_key::run(ctx, args).await
                 }
                 KeysCommands::InitLocalQuorumKey(args) => {
-                    commands::keys::init_local_quorum_key::run(ctx, args).await
+                    commands::keys::init_local_quorum_key::run(ctx, args, config).await
                 }
                 KeysCommands::ReEncryptLocalShare(args) => {
-                    commands::keys::re_encrypt_local_share::run(ctx, args).await
+                    commands::keys::re_encrypt_local_share::run(ctx, args, config).await
                 }
             },
-            Commands::Login(args) => commands::login::run(ctx, args).await,
+            Commands::Login(args) => commands::login::run(ctx, args, config).await,
             Commands::Operator { command } => match command {
-                OperatorCommands::Create(args) => commands::operator::create::run(ctx, args).await,
+                OperatorCommands::Create(args) => {
+                    commands::operator::create::run(ctx, args, config).await
+                }
             },
             Commands::Profile { command } => match command {
                 ProfileCommands::Delete(delete_args) => {
-                    commands::login::run_delete(ctx, delete_args).await
+                    commands::login::run_delete(ctx, delete_args, config).await
                 }
             },
             Commands::Version => commands::version::run(),

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -39,12 +39,13 @@ pub struct AuthenticatedClient {
 /// `TVC_API_KEY_PRIVATE` are all set, builds the client from env vars.
 /// `TVC_API_BASE_URL` is optional and defaults to `https://api.turnkey.com`.
 ///
-/// Otherwise, falls back to loading from `~/.config/turnkey/` (after `tvc login`).
+/// Otherwise, falls back to the active org's stored credentials in `config`
+/// (set up by `tvc login`).
 ///
 /// If only some of the three required env vars are set, errors with the list of
 /// missing names — no merged resolve between env and disk vars.
 #[instrument(skip_all)]
-pub async fn build_client() -> Result<AuthenticatedClient> {
+pub async fn build_client(config: &Config) -> Result<AuthenticatedClient> {
     debug!("building authenticated Turnkey client");
 
     let (org_id, api_base_url, api_key_public, api_key_private) =
@@ -55,7 +56,7 @@ pub async fn build_client() -> Result<AuthenticatedClient> {
             }
             None => {
                 debug!(auth_source = "config", "using local config credentials");
-                load_credentials_from_config().await?
+                load_credentials_from_config(config).await?
             }
         };
 
@@ -99,9 +100,7 @@ pub async fn fetch_tvc_deployment(
 }
 
 #[instrument(skip_all)]
-async fn load_credentials_from_config() -> Result<(String, String, String, String)> {
-    let config = Config::load().await?;
-
+async fn load_credentials_from_config(config: &Config) -> Result<(String, String, String, String)> {
     let (alias, org_config) = config
         .active_org_config()
         .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?;

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -57,26 +57,20 @@ struct Overrides {
 }
 
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let config = if ctx.is_non_interactive() {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: turnkey::Config) -> Result<Outcome> {
+    let app_config = if ctx.is_non_interactive() {
         build_app_config_non_interactive(&args).await?
     } else {
-        build_app_config_interactive(ctx, &args).await?
+        build_app_config_interactive(ctx, &args, &config).await?
     };
 
-    let mut app_config = apply_overrides(config, &args.overrides);
+    let mut app_config = apply_overrides(app_config, &args.overrides);
 
     // Reuse a known operator by default so repeated `app create` runs don't
     // mint a fresh operator ID for the same key. The decision itself is pure
-    // (`decide_operator_reuse`); this endpoint does the I/O — collecting
-    // candidates best-effort, since reuse is a convenience: a failed config
-    // load falls back to no reuse and the real error surfaces when
-    // `run_with_config` reloads the config — and adapts multi-candidate
-    // handling to the mode.
-    let candidates = match turnkey::Config::load().await {
-        Ok(config) => config.known_operator_candidates(),
-        Err(_) => Vec::new(),
-    };
+    // (`decide_operator_reuse`); this endpoint supplies the candidates and
+    // adapts multi-candidate handling to the mode.
+    let candidates = config.known_operator_candidates();
 
     match decide_operator_reuse(
         args.no_operator_reuse,
@@ -103,7 +97,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         }
     }
 
-    run_with_config(ctx, args, app_config).await
+    run_with_app_config(ctx, args, config, app_config).await
 }
 
 /// What to do with the manifest set's operators at create time.
@@ -168,35 +162,36 @@ fn apply_operator_reuse<Out: io::Write, Err: io::Write>(
     Ok(())
 }
 
-async fn build_app_config_interactive(ctx: &mut StdCtx, args: &Args) -> Result<AppConfig> {
-    let mut config = match read_app_config_file_bytes(&args.config_file).await {
+async fn build_app_config_interactive(
+    ctx: &mut StdCtx,
+    args: &Args,
+    config: &turnkey::Config,
+) -> Result<AppConfig> {
+    let mut app_config = match read_app_config_file_bytes(&args.config_file).await {
         Ok(bytes) => parse_app_config(&bytes, &args.config_file)?,
         Err(_) => AppConfig::template(None),
     };
 
     let mut changed = false;
     loop {
-        match config.validate() {
+        match app_config.validate() {
             Ok(()) => break,
             Err(errors) if errors.has_non_placeholder_error() => {
                 return Err(invalid_app_config_error(&args.config_file, errors));
             }
             _ => {
                 changed = true;
-                let saved_operator_public_key = match turnkey::Config::load().await {
-                    Ok(config) => config.default_operator_public_key().await,
-                    Err(_) => None,
-                };
-                config.fill_interactively(saved_operator_public_key.as_deref())?;
+                let saved_operator_public_key = config.default_operator_public_key().await;
+                app_config.fill_interactively(saved_operator_public_key.as_deref())?;
             }
         }
     }
 
     if changed {
-        offer_to_save_app_config(ctx, &args.config_file, &config)?;
+        offer_to_save_app_config(ctx, &args.config_file, &app_config)?;
     }
 
-    Ok(config)
+    Ok(app_config)
 }
 
 async fn build_app_config_non_interactive(args: &Args) -> Result<AppConfig> {
@@ -236,10 +231,15 @@ fn offer_to_save_app_config(ctx: &mut StdCtx, path: &Path, config: &AppConfig) -
     Ok(())
 }
 
-async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) -> Result<Outcome> {
+async fn run_with_app_config(
+    ctx: &mut StdCtx,
+    args: Args,
+    mut config: turnkey::Config,
+    app_config: AppConfig,
+) -> Result<Outcome> {
     shell_println!(ctx, "Creating app '{}'...", app_config.name)?;
 
-    let auth = build_client().await?;
+    let auth = build_client(&config).await?;
 
     let intent = build_create_tvc_app_intent(&app_config);
 
@@ -257,7 +257,6 @@ async fn run_with_config(ctx: &mut StdCtx, args: Args, app_config: AppConfig) ->
     let app_id = result.result.app_id;
     let operator_ids = result.result.manifest_set_operator_ids;
 
-    let mut config = turnkey::Config::load().await?;
     config.set_last_app_id(&app_id)?;
     config.set_last_operator_ids(&operator_ids)?;
     config.save().await?;

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -1,6 +1,7 @@
 //! App delete command - marks an app and all deployments for deletion.
 
 use crate::client::build_client;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use anyhow::{Context, Result};
@@ -23,8 +24,8 @@ pub struct Args {
 
 /// Run the app delete command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let auth = build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
+    let auth = build_client(&config).await?;
 
     let intent = DeleteTvcAppAndDeploymentsIntent {
         app_id: args.app_id.to_string(),

--- a/tvc/src/commands/app/init.rs
+++ b/tvc/src/commands/app/init.rs
@@ -32,7 +32,7 @@ pub struct Args {
 }
 
 /// Run the app init command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -40,28 +40,25 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
             ensure_stdin_is_tty()?;
         }
     }
-    execute(args).await
+    execute(args, &config).await
 }
 
-async fn execute(args: Args) -> Result<Outcome> {
+async fn execute(args: Args, config: &Config) -> Result<Outcome> {
     // Check if file already exists
     if args.output.exists() {
         bail!("File already exists: {}", args.output.display());
     }
 
     // Try to load the operator public key from config, best-effort.
-    let operator_public_key = match Config::load().await {
-        Ok(config) => config.default_operator_public_key().await,
-        Err(_) => None,
-    };
+    let operator_public_key = config.default_operator_public_key().await;
 
     // Generate template (optionally walking prompts to fill it in)
-    let mut config = AppConfig::template(operator_public_key.as_deref());
+    let mut app_config = AppConfig::template(operator_public_key.as_deref());
     if args.interactive {
-        config.fill_interactively(operator_public_key.as_deref())?;
+        app_config.fill_interactively(operator_public_key.as_deref())?;
     }
 
-    let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
+    let json = serde_json::to_string_pretty(&app_config).context("failed to serialize config")?;
 
     // Write to file
     std::fs::write(&args.output, json)

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -8,6 +8,7 @@ use turnkey_client::generated::GetTvcAppsRequest;
 use turnkey_client::generated::external::data::v1::TvcApp;
 
 use crate::commands::display::{format_egress_enabled, yes_no};
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use tracing::instrument;
 
@@ -26,8 +27,8 @@ pub struct Args {
 
 /// Run the app list command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
 
     let response = auth
         .client

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -1,6 +1,7 @@
 //! App set-live-deploy command.
 
 use crate::client::build_client;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use anyhow::{Context, Result};
@@ -23,8 +24,8 @@ pub struct Args {
 
 /// Run the app set-live-deploy command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let auth = build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
+    let auth = build_client(&config).await?;
 
     let deployment_id = args.deploy_id.to_string();
 

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -13,6 +13,7 @@ use crate::commands::app_status::{
     ReplicaCounts, TimestampPayload, format_replica_counts, sanitize_app_status,
 };
 use crate::commands::display::format_egress_enabled;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use tracing::instrument;
 
@@ -29,8 +30,8 @@ pub struct Args {
 
 /// Run the app status command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
 
     let app_id = args.app_id.to_string();
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -113,7 +113,7 @@ impl Run for Args {
     type Outcome = ApproveOutcome;
 
     #[instrument(skip_all)]
-    async fn run(self, ctx: &mut StdCtx) -> anyhow::Result<Self::Outcome> {
+    async fn run(self, ctx: &mut StdCtx, config: Config) -> anyhow::Result<Self::Outcome> {
         let args = ArgsWithResolvedOperatorSeedSource::try_from(self)?;
 
         // Manifest review prompts are required unless explicitly skipped;
@@ -122,7 +122,7 @@ impl Run for Args {
             bail_required_in_non_interactive("--dangerous-skip-interactive")?;
         }
 
-        let (manifest, fetched) = load_manifest(ctx, &args).await?;
+        let (manifest, fetched) = load_manifest(ctx, &args, &config).await?;
         let manifest = ValidatedManifest::try_from(&manifest)?;
 
         if !args.dangerous_skip_interactive {
@@ -133,6 +133,7 @@ impl Run for Args {
             BuildPostTargetArgs::from(&args),
             fetched.as_ref().map(|(id, _)| *id),
             ctx.is_non_interactive(),
+            &config,
         )
         .await?;
 
@@ -147,7 +148,7 @@ impl Run for Args {
             posted_approvals: fetched.map(|(_, approvals)| approvals).unwrap_or_default(),
         };
 
-        run_with_resolved_inputs(ctx, inputs).await
+        run_with_resolved_inputs(ctx, inputs, &config).await
     }
 }
 
@@ -427,6 +428,7 @@ async fn build_post_target(
     args: BuildPostTargetArgs,
     fetched_manifest_id: Option<Uuid>,
     non_interactive: bool,
+    config: &Config,
 ) -> anyhow::Result<(Option<PostTarget>, Option<Uuid>)> {
     if args.dry_run || args.skip_post {
         return Ok((None, args.operator_id));
@@ -439,8 +441,6 @@ async fn build_post_target(
     let operator_id = if let Some(operator_id) = args.operator_id {
         operator_id
     } else {
-        let config = Config::load().await?;
-
         let candidates = config
             .known_operator_candidates()
             .into_iter()
@@ -481,6 +481,7 @@ async fn build_post_target(
 async fn run_with_resolved_inputs(
     ctx: &mut StdCtx,
     inputs: ResolvedApproveInputs<'_>,
+    config: &Config,
 ) -> anyhow::Result<ApproveOutcome> {
     if inputs.dry_run {
         return Ok(ApproveOutcome::DryRun(ApprovalDryRun));
@@ -508,8 +509,14 @@ async fn run_with_resolved_inputs(
     } else {
         SignerRequirement::Any
     };
-    let operator =
-        resolve_operator(inputs.operator_seed_source, inputs.operator_id, requirement).await?;
+
+    let operator = resolve_operator(
+        config,
+        inputs.operator_seed_source,
+        inputs.operator_id,
+        requirement,
+    )
+    .await?;
 
     let approval = operator.approve_manifest(&inputs.manifest).await?;
 
@@ -545,7 +552,8 @@ async fn run_with_resolved_inputs(
                 operator_id: &operator_id,
                 deploy_id: target.deploy_id.as_ref(),
             };
-            let posted = post_approval_to_api(ctx, plan, &approval, &inputs.manifest).await?;
+            let posted =
+                post_approval_to_api(ctx, plan, &approval, &inputs.manifest, config).await?;
 
             Ok(ApproveOutcome::Posted(ApprovalPosted {
                 approval_or_path: ApprovalOutput::new(approval, inputs.approval_out),
@@ -564,12 +572,13 @@ async fn run_with_resolved_inputs(
 async fn load_manifest(
     ctx: &mut StdCtx,
     args: &ArgsWithResolvedOperatorSeedSource,
+    config: &Config,
 ) -> anyhow::Result<(VersionedManifest, Option<(Uuid, Vec<OperatorApproval>)>)> {
     match (&args.manifest, &args.deploy_id) {
         (Some(path), _) => Ok((read_manifest_from_path(path).await?, None)),
         (_, Some(deploy_id)) => {
             let (manifest, manifest_id, approvals) =
-                fetch_manifest_from_deploy(ctx, &deploy_id.to_string()).await?;
+                fetch_manifest_from_deploy(ctx, &deploy_id.to_string(), config).await?;
             Ok((manifest, Some((manifest_id, approvals))))
         }
         (None, None) => bail!("a manifest source is required"),
@@ -582,11 +591,12 @@ async fn post_approval_to_api(
     plan: PostApprovalPlan<'_>,
     approval: &Approval,
     manifest: &ValidatedManifest<'_>,
+    config: &Config,
 ) -> anyhow::Result<PostedApproval> {
     shell_println!(ctx)?;
     shell_println!(ctx, "Posting approval to Turnkey...")?;
 
-    let auth = crate::client::build_client().await?;
+    let auth = crate::client::build_client(config).await?;
 
     let tvc_approval = TvcManifestApproval {
         operator_id: plan.operator_id.to_string(),
@@ -773,14 +783,15 @@ async fn read_manifest_from_path(path: &Path) -> anyhow::Result<VersionedManifes
 
 /// Fetch manifest from Turnkey using GetTvcDeployment API.
 /// Returns the manifest, its Turnkey manifest_id, and the deployment itself.
-#[instrument(skip(ctx))]
+#[instrument(skip(ctx, config))]
 async fn fetch_manifest_from_deploy(
     ctx: &mut StdCtx,
     deploy_id: &str,
+    config: &Config,
 ) -> anyhow::Result<(VersionedManifest, Uuid, Vec<OperatorApproval>)> {
     shell_println!(ctx, "Fetching deployment {deploy_id}...")?;
 
-    let auth = build_client().await?;
+    let auth = build_client(config).await?;
 
     let request = GetTvcDeploymentRequest {
         organization_id: auth.org_id.clone(),

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -151,57 +151,61 @@ struct ResolvedDeployInputs {
 }
 
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     let inputs = if ctx.is_non_interactive() {
         build_inputs_non_interactive(args).await?
     } else {
-        build_inputs_interactive(ctx, args).await?
+        build_inputs_interactive(ctx, args, &config).await?
     };
 
-    run_with_resolved_inputs(ctx, inputs).await
+    run_with_resolved_inputs(ctx, inputs, &config).await
 }
 
-async fn build_inputs_interactive(ctx: &mut StdCtx, args: Args) -> Result<ResolvedDeployInputs> {
+async fn build_inputs_interactive(
+    ctx: &mut StdCtx,
+    args: Args,
+    config: &Config,
+) -> Result<ResolvedDeployInputs> {
     let Args {
         config_file: config_path,
         pivot_pull_secret,
         overrides,
     } = args;
-    let (mut config, file_loaded) = read_config_file_bytes(config_path.as_deref())
+    let (mut deploy_config, file_loaded) = read_config_file_bytes(config_path.as_deref())
         .await?
         .map(|(path, contents)| {
             serde_json::from_str(&contents)
                 .with_context(|| format!("failed to parse config file: {}", path.display()))
         })
         .transpose()?
-        .map(|config| (config, true))
+        .map(|deploy_config| (deploy_config, true))
         .unwrap_or_else(|| (flag_only_template(), false));
 
-    apply_overrides(&mut config, &overrides);
+    apply_overrides(&mut deploy_config, &overrides);
 
     let mut config_updated = false;
     loop {
-        match config.validate() {
+        match deploy_config.validate() {
             Ok(()) => break,
             Err(errors) if errors.has_non_placeholder_error() => {
                 return Err(invalid_deploy_config_error(errors));
             }
             _ => {
                 config_updated = true;
-                let saved_app_id = Config::load().await.ok().and_then(|c| c.get_last_app_id());
-                config.fill_interactively(ctx, saved_app_id.as_deref())?;
+                let saved_app_id = config.get_last_app_id();
+                deploy_config.fill_interactively(ctx, saved_app_id.as_deref())?;
             }
         }
     }
 
     if config_updated && let Some(path) = &config_path {
-        offer_to_save_config(ctx, path, &config, file_loaded)?;
+        offer_to_save_config(ctx, path, &deploy_config, file_loaded)?;
     }
     let pivot_pull_secret = read_pivot_pull_secret(pivot_pull_secret.as_deref()).await?;
 
     Ok(ResolvedDeployInputs {
         config_path,
-        config,
+        config: deploy_config,
         pivot_pull_secret,
     })
 }
@@ -380,6 +384,7 @@ fn pin_image_url(image_url: &str, resolved_digest: &str) -> String {
 async fn run_with_resolved_inputs(
     ctx: &mut StdCtx,
     inputs: ResolvedDeployInputs,
+    config: &Config,
 ) -> Result<Outcome> {
     let deploy_config = inputs.config;
 
@@ -391,7 +396,7 @@ async fn run_with_resolved_inputs(
     shell_println!(ctx, "{}", format_port_summary(&deploy_config))?;
     shell_println!(ctx)?;
 
-    let auth = build_client().await?;
+    let auth = build_client(config).await?;
 
     // validate that the app exists
     fetch_tvc_app(&auth, &deploy_config.app_id).await?;

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -1,6 +1,7 @@
 //! Deploy debug-logs command.
 
 use crate::commands::app_status::TimestampPayload;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::{Ctx, StdCtx};
 use crate::shell_eprintln;
@@ -126,8 +127,8 @@ pub struct Args {
 
 /// Run the `deploy debug-logs` command.
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
 
     let request = DebugLogQueryRequest {
         organization_id: auth.org_id,

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -1,6 +1,7 @@
 //! Deploy delete command - marks a deployment for deletion.
 
 use crate::client::build_client;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use anyhow::{Context, Result};
@@ -23,8 +24,8 @@ pub struct Args {
 
 /// Run the deploy delete command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let auth = build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
+    let auth = build_client(&config).await?;
 
     let intent = DeleteTvcDeploymentIntent {
         deployment_id: args.deploy_id.to_string(),

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -15,6 +15,7 @@ use crate::{
     client::{fetch_tvc_app, fetch_tvc_deployment},
     commands::app_status::{ReplicaCounts, TimestampPayload, format_replica_counts},
     commands::display::format_egress_enabled,
+    config::turnkey::Config,
     outcome::Outcome,
     output::StdCtx,
 };
@@ -30,14 +31,14 @@ pub struct Args {
 
 /// Run the deploy get-status command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
     let deployment_id = args.deploy_id.to_string();
 
     // TODO (TVC-154):
     // this is a little backwards, all the variables that are needed to build the client
     // are resolved INSIDE the `build-client`. Instead, all the necessary data for the client
     // should be resolved, then passed into an infallible constructor
-    let auth = crate::client::build_client().await?;
+    let auth = crate::client::build_client(&config).await?;
     let org_id = auth.org_id.clone();
 
     let deployment = fetch_tvc_deployment(&auth, org_id.clone(), deployment_id.clone()).await?;

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -49,7 +49,7 @@ pub struct Args {
 
 /// Run the deploy init command.
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: turnkey::Config) -> Result<Outcome> {
     if args.interactive {
         if ctx.is_non_interactive() {
             bail_interactive_conflicts_with_non_interactive()?;
@@ -57,10 +57,10 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
             ensure_stdin_is_tty()?;
         }
     }
-    execute(ctx, args).await
+    execute(ctx, args, &config).await
 }
 
-async fn execute(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+async fn execute(ctx: &mut StdCtx, args: Args, config: &turnkey::Config) -> Result<Outcome> {
     let Args {
         output,
         from_deployment,
@@ -80,25 +80,22 @@ async fn execute(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
 
     let is_from_deployment = from_deployment.is_some();
 
+    // The last created app ID prefills the blank template and the interactive
+    // prompt defaults.
+    let saved_app_id = config.get_last_app_id();
+
     // Seed the config either from an existing deployment or a blank template.
-    let mut config = match from_deployment {
+    let mut deploy_config = match from_deployment {
         Some(deploy_id) => {
             // TODO (TVC-154):
             // TL;DR split fetching the data/resources separately
             // from building the client
-            let auth = build_client().await?;
+            let auth = build_client(config).await?;
             let org_id = auth.org_id.clone();
             let deployment = fetch_tvc_deployment(&auth, org_id, deploy_id).await?;
             DeployConfig::try_from(deployment)?
         }
-        None => {
-            // Try to get the last created app ID to prefill the template.
-            let last_app_id = turnkey::Config::load()
-                .await
-                .ok()
-                .and_then(|config| config.get_last_app_id());
-            DeployConfig::template(last_app_id.as_deref())
-        }
+        None => DeployConfig::template(saved_app_id.as_deref()),
     };
 
     // Optionally walk prompts to fill any remaining placeholders (e.g. the
@@ -106,16 +103,13 @@ async fn execute(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     // In `--from-deployment` mode the app ID is already set, so the saved-app-id
     // default is only consulted for a blank template.
     if is_interactive {
-        let saved_app_id = turnkey::Config::load()
-            .await
-            .ok()
-            .and_then(|config| config.get_last_app_id());
-        config.fill_interactively(ctx, saved_app_id.as_deref())?;
+        deploy_config.fill_interactively(ctx, saved_app_id.as_deref())?;
     }
 
-    let needs_pull_secret = config.pull_secret_is_placeholder();
+    let needs_pull_secret = deploy_config.pull_secret_is_placeholder();
 
-    let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
+    let json =
+        serde_json::to_string_pretty(&deploy_config).context("failed to serialize config")?;
 
     // Write to file
     std::fs::write(&output, json)

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -1,6 +1,7 @@
 //! Deploy post-share command.
 
 use crate::commands::keys::re_encrypt_local_share::ReEncryptedShareOutput;
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use crate::util::read_json_file;
@@ -29,7 +30,7 @@ pub struct Args {
 
 /// Run the deploy post-share command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
     let re_encrypted_share: ReEncryptedShareOutput =
         read_json_file(&args.re_encrypted_share, "re-encrypted share output").await?;
 
@@ -38,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         &args.share_operator_id.to_string(),
     );
 
-    let auth = crate::client::build_client().await?;
+    let auth = crate::client::build_client(&config).await?;
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system time before unix epoch")?

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -62,7 +62,7 @@ impl Display for ProvisioningShareCreated {
 
 /// Run the hosted deploy provision command.
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     let Args {
         deploy_id,
         operator_id,
@@ -76,9 +76,8 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
         )?;
     }
 
-    let config = Config::load().await?;
     let operator = config.resolve_hosted_operator(&operator_id)?;
-    let auth = build_client().await?;
+    let auth = build_client(&config).await?;
     ensure_authenticated_org(&auth.org_id, operator.organization_id())?;
 
     let details = fetch_provisioning_details(&auth, &deploy_id).await?;

--- a/tvc/src/commands/deploy/provisioning_details.rs
+++ b/tvc/src/commands/deploy/provisioning_details.rs
@@ -1,5 +1,6 @@
 //! Deploy provisioning-details command.
 
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use crate::provisioning::{
@@ -61,8 +62,8 @@ const SUMMARY_PCR_MAX_INDEX: usize = 17;
 
 /// Run the deploy provisioning-details command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
     let details = fetch_provisioning_details(&auth, &args.deploy_id).await?;
 
     let summary = build_summary_with_optional_verify(

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use turnkey_client::generated::{ActivityStatus, RestoreTvcDeploymentIntent};
 use uuid::Uuid;
 
+use crate::config::turnkey::Config;
 use crate::outcome::Outcome;
 use tracing::instrument;
 
@@ -24,8 +25,8 @@ pub struct Args {
 
 /// Run the deploy restore command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
 
     let intent = RestoreTvcDeploymentIntent {
         deployment_id: args.deploy_id.to_string(),

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -14,6 +14,7 @@ use crate::approvals::{ApprovalValidationWithMeta, OperatorApproval, ValidatedMa
 use crate::client::fetch_tvc_app;
 use crate::commands::app_status::TimestampPayload;
 use crate::commands::display::{OrUnknown, format_egress_enabled, yes_no};
+use crate::config::turnkey::Config;
 use crate::errors::MissingResource;
 use crate::outcome::Outcome;
 use tracing::instrument;
@@ -31,8 +32,8 @@ pub struct Args {
 
 /// Run the deploy status command.
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
-    let auth = crate::client::build_client().await?;
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
+    let auth = crate::client::build_client(&config).await?;
     let deploy_id = args.deploy_id.to_string();
 
     let request = GetTvcDeploymentRequest {

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -38,7 +38,7 @@ pub struct Args {
 impl Run for Args {
     type Outcome = OperatorKeyBackedUp;
 
-    async fn run(self, ctx: &mut StdCtx) -> Result<OperatorKeyBackedUp> {
+    async fn run(self, ctx: &mut StdCtx, config: Config) -> Result<OperatorKeyBackedUp> {
         // Reject before loading config or resolving the organization when
         // there is no way to prompt for the destination: --non-interactive,
         // JSON mode, or a non-TTY stdin.
@@ -47,8 +47,6 @@ impl Run for Args {
         if !can_prompt && self.output.is_none() {
             return Err(error_required_in_non_interactive("--output"));
         }
-
-        let config = Config::load().await?;
 
         let (alias, org_config) = match &self.org {
             Some(query) => find_org(&config, query).ok_or_else(|| {

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -103,7 +103,7 @@ impl OperatorSource {
 
 /// Run the hosted quorum-key creation command.
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     let Args {
         threshold,
         operator_encrypt_keys,
@@ -120,12 +120,12 @@ pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
     validate_threshold(threshold, operator_source.len())?;
 
     let (operator_encrypt_keys, configured_org_id) =
-        resolve_operator_encrypt_keys(operator_source).await?;
+        resolve_operator_encrypt_keys(&config, operator_source)?;
     let operator_encrypt_keys = normalize_operator_encrypt_keys(operator_encrypt_keys)?;
 
     let intent = build_create_tvc_quorum_key_intent(threshold, operator_encrypt_keys);
     let expected_share_count = intent.operator_encrypt_keys.len();
-    let auth = build_client().await?;
+    let auth = build_client(&config).await?;
     if let Some(configured_org_id) = configured_org_id {
         ensure_authenticated_org(&auth.org_id, &configured_org_id)?;
     }
@@ -148,15 +148,15 @@ fn parse_operator_id(value: &str) -> std::result::Result<Uuid, String> {
     Uuid::parse_str(value.trim()).map_err(|_| "must be a UUID".to_string())
 }
 
-async fn resolve_operator_encrypt_keys(
+fn resolve_operator_encrypt_keys(
+    config: &Config,
     operator_source: OperatorSource,
 ) -> Result<(Vec<OperatorPublicKey>, Option<String>)> {
     match operator_source {
         OperatorSource::EncryptKeys(keys) => Ok((keys, None)),
         OperatorSource::OperatorIds(operator_ids) => {
             validate_operator_ids(&operator_ids)?;
-            let config = Config::load().await?;
-            resolve_operator_ids(&config, &operator_ids)
+            resolve_operator_ids(config, &operator_ids)
         }
     }
 }

--- a/tvc/src/commands/keys/init_local_quorum_key.rs
+++ b/tvc/src/commands/keys/init_local_quorum_key.rs
@@ -26,15 +26,12 @@ pub struct Args {
 }
 
 /// Run the quorum key init command.
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     if args.output.exists() {
         anyhow::bail!("File already exists: {}", args.output.display());
     }
 
-    let operator_public_key = match Config::load().await {
-        Ok(config) => config.default_operator_public_key().await,
-        Err(_) => None,
-    };
+    let operator_public_key = config.default_operator_public_key().await;
 
     let config = QuorumKeyConfig::template(operator_public_key.as_deref());
     let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -1,6 +1,6 @@
 //! Re-encrypt local share command.
 
-use crate::config::turnkey::SelectLocalOperatorError;
+use crate::config::turnkey::{Config, SelectLocalOperatorError};
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
@@ -99,7 +99,7 @@ impl Display for ReEncryptedShareGenerated {
 }
 
 /// Run the re-encrypt-local-share command.
-pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result<Outcome> {
     let operator_seed_source =
         LocalOperatorSeedSource::from_args(args.operator_seed, args.operator_seed_path)?;
 
@@ -114,7 +114,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> anyhow::Result<Outcome> {
         read_json_file(&args.quorum_key_metadata, "quorum key metadata file").await?;
     let provision_bundle: ProvisionBundle =
         read_json_file(&args.provision_bundle, "provision bundle").await?;
-    let operator_pair = resolve_local_operator(operator_seed_source)
+    let operator_pair = resolve_local_operator(&config, operator_seed_source)
         .await
         .map_err(|error| {
             // Decryption needs local key material a hosted-only org does not

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -69,15 +69,13 @@ struct LoginPlan {
 }
 
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
     debug!(
         non_interactive = ctx.is_non_interactive(),
         org_arg_present = args.org.is_some(),
         api_base_url_override_present = args.api_base_url.is_some(),
         "running login command"
     );
-
-    let config = Config::load().await?;
 
     let plan = if ctx.is_non_interactive() {
         build_login_plan_non_interactive(args)?
@@ -90,7 +88,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
 
 /// Permanently delete a saved login profile: its config entry and its API and
 /// operator key files on disk.
-pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<Outcome> {
+pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) -> Result<Outcome> {
     let is_non_interactive = ctx.is_non_interactive();
     debug!(
         non_interactive = is_non_interactive,
@@ -110,7 +108,6 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs) -> Result<Outcome> {
         }
     }
 
-    let mut config = Config::load().await?;
     let alias = resolve_profile_alias(&config, args.org)?;
     let org_id = config
         .orgs

--- a/tvc/src/commands/mod.rs
+++ b/tvc/src/commands/mod.rs
@@ -5,7 +5,7 @@
 //! an implementation of [`Run`] (the target shape; `deploy approve` is the
 //! pilot).
 
-use crate::{outcome, output::StdCtx};
+use crate::{config::turnkey::Config, outcome, output::StdCtx};
 
 pub mod app;
 pub mod app_status;
@@ -25,5 +25,9 @@ pub mod version;
 pub trait Run {
     type Outcome: Into<outcome::Outcome>;
 
-    fn run(self, ctx: &mut StdCtx) -> impl Future<Output = anyhow::Result<Self::Outcome>> + Send;
+    fn run(
+        self,
+        ctx: &mut StdCtx,
+        config: Config,
+    ) -> impl Future<Output = anyhow::Result<Self::Outcome>> + Send;
 }

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -99,14 +99,13 @@ Saved: true"#,
 }
 
 #[instrument(skip_all)]
-pub async fn run(_ctx: &mut StdCtx, args: Args) -> Result<Outcome> {
-    let mut config = Config::load().await?;
+pub async fn run(_ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Outcome> {
     let (alias, configured_org_id) = config
         .active_org_config()
         .map(|(alias, org)| (alias.clone(), org.id.as_str()))
         .context("No active organization. Run `tvc login` first.")?;
 
-    let auth = build_client().await?;
+    let auth = build_client(&config).await?;
     ensure_authenticated_org(&auth.org_id, configured_org_id)?;
 
     let HostedOperatorSpec { name, wallet, path } = args.into();

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -23,8 +23,8 @@ use thiserror::Error;
 use tracing::debug;
 use uuid::Uuid;
 
-const CONFIG_DIR: &str = ".config/turnkey";
-const CONFIG_FILE: &str = "tvc.config.toml";
+pub const CONFIG_DIR: &str = ".config/turnkey";
+pub const CONFIG_FILE: &str = "tvc.config.toml";
 const ORGS_DIR: &str = "orgs";
 const API_KEY_FILE: &str = "api_key.json";
 const OPERATOR_KEY_FILE: &str = "operator.json";
@@ -429,25 +429,8 @@ pub fn default_operator_key_path(alias: &str) -> Result<PathBuf> {
 }
 
 impl Config {
-    /// Load config from disk, or return default if it doesn't exist
-    pub async fn load() -> Result<Self> {
-        let path = config_file_path()?;
-        debug!(config_path = %path.display(), "loading tvc config");
-        if !path.exists() {
-            debug!(config_path = %path.display(), "tvc config not found; using defaults");
-            return Ok(Config::default());
-        }
-
-        let config = Self::load_from_path(&path).await?;
-
-        debug!(
-            config_path = %path.display(),
-            active_org = ?config.active_org,
-            org_count = config.orgs.len(),
-            "loaded tvc config"
-        );
-
-        Ok(config)
+    pub fn from_toml(content: &str) -> Result<Self> {
+        disk::from_toml(content)
     }
 
     /// Save config to disk
@@ -461,14 +444,6 @@ impl Config {
         );
 
         self.save_to_path(&path).await
-    }
-
-    async fn load_from_path(path: &Path) -> Result<Self> {
-        let content = tokio::fs::read_to_string(path)
-            .await
-            .with_context(|| format!("failed to read config file: {}", path.display()))?;
-        disk::from_toml(&content)
-            .with_context(|| format!("failed to parse config file: {}", path.display()))
     }
 
     async fn save_to_path(&self, path: &Path) -> Result<()> {
@@ -631,7 +606,8 @@ default = ["operator-123"]
         let path = temp.path().join("tvc.config.toml");
         tokio::fs::write(&path, V0_CONFIG).await.unwrap();
 
-        let config = Config::load_from_path(&path).await.unwrap();
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let config = Config::from_toml(&content).unwrap();
         let original = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(original, V0_CONFIG);
 

--- a/tvc/src/local_operator_key.rs
+++ b/tvc/src/local_operator_key.rs
@@ -45,12 +45,12 @@ pub enum LocalCredentialSource {
 /// Resolve one local key pair. Explicit credentials bypass config entirely;
 /// otherwise the sole active local registry entry supplies the JSON key path.
 pub async fn resolve_local_operator(
+    config: &Config,
     explicit: Option<LocalOperatorSeedSource>,
 ) -> anyhow::Result<LocalPair> {
     let source = match explicit {
         Some(source) => LocalCredentialSource::Explicit(source),
         None => {
-            let config = Config::load().await?;
             let (alias, org_config) = config.active_org_config().ok_or_else(|| {
                 anyhow!(
                     "No active organization. Run `tvc login` first or provide \
@@ -183,8 +183,11 @@ mod tests {
 
     #[tokio::test]
     async fn explicit_value_resolves_without_config() {
-        resolve_local_operator(Some(LocalOperatorSeedSource::Value(seed())))
-            .await
-            .unwrap();
+        resolve_local_operator(
+            &Config::default(),
+            Some(LocalOperatorSeedSource::Value(seed())),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -171,27 +171,27 @@ pub(crate) enum SignerRequirement {
 /// on a config file being present or well-formed (pinned by
 /// `explicit_seed_does_not_load_malformed_config`).
 pub(crate) async fn resolve_operator(
+    config: &Config,
     explicit: Option<LocalOperatorSeedSource>,
     operator_id: Option<Uuid>,
     requirement: SignerRequirement,
 ) -> Result<ResolvedOperator> {
     if let Some(explicit) = explicit {
         if let Some(id) = operator_id {
-            let config = Config::load().await?;
             ensure!(
                 config.find_hosted_operator(&id)?.is_none(),
                 "explicit local operator seed cannot be used with a hosted operator ID"
             );
         }
 
+        let signer = resolve_local_operator(config, Some(explicit)).await?;
+
         return Ok(ResolvedOperator {
             name: None,
             operator_id,
-            signer: Box::new(resolve_local_operator(Some(explicit)).await?),
+            signer: Box::new(signer),
         });
     }
-
-    let config = Config::load().await?;
 
     let hosted = operator_id
         .map(|id| config.find_hosted_operator(&id))
@@ -205,7 +205,7 @@ pub(crate) async fn resolve_operator(
             bail!("--skip-post is only supported for local operators");
         }
 
-        let auth = build_client().await?;
+        let auth = build_client(config).await?;
         ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
 
         return Ok(ResolvedOperator {
@@ -236,7 +236,7 @@ pub(crate) async fn resolve_operator(
                     .select_hosted_operator()
                     .with_context(|| format!("org '{alias}'"))?;
                 let hosted = ResolvedHostedOperator::from_registry(org.id.clone(), name, hosted)?;
-                let auth = build_client().await?;
+                let auth = build_client(config).await?;
                 ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
 
                 return Ok(ResolvedOperator {

--- a/tvc/tests/app_set_live_deploy.rs
+++ b/tvc/tests/app_set_live_deploy.rs
@@ -38,9 +38,14 @@ fn missing_deploy_id_fails() {
 
 #[test]
 fn set_live_deploy_reaches_auth_setup() {
+    // Config is built before dispatch, so the binary needs a HOME even on the
+    // env-auth path; a fresh temp dir keeps the test hermetic.
+    let home = tempfile::TempDir::new().unwrap();
+
     set_live_deploy_cmd()
         .arg("--deploy-id")
         .arg("5376f492-d014-4e01-a6bb-20fc97448e25")
+        .env("HOME", home.path())
         .env("TVC_ORG_ID", "org_env")
         .assert()
         .failure()

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -33,9 +33,13 @@ fn generated_api_key() -> (String, String) {
 
 #[test]
 fn env_auth_accepts_all_three_required_vars() {
+    // Config is built before dispatch, so the binary needs a HOME even on the
+    // env-auth path; a fresh temp dir keeps each test hermetic.
+    let home = TempDir::new().unwrap();
     let (public_key, private_key) = generated_api_key();
 
     app_status_cmd()
+        .env("HOME", home.path())
         .env(ENV_ORG_ID, "org-env")
         .env(ENV_API_KEY_PUBLIC, public_key)
         .env(ENV_API_KEY_PRIVATE, private_key)
@@ -48,9 +52,11 @@ fn env_auth_accepts_all_three_required_vars() {
 
 #[test]
 fn env_auth_rejects_two_required_vars() {
+    let home = TempDir::new().unwrap();
     let (public_key, _) = generated_api_key();
 
     app_status_cmd()
+        .env("HOME", home.path())
         .env(ENV_ORG_ID, "org-env")
         .env(ENV_API_KEY_PUBLIC, public_key)
         .assert()
@@ -61,7 +67,10 @@ fn env_auth_rejects_two_required_vars() {
 
 #[test]
 fn env_auth_rejects_one_required_var() {
+    let home = TempDir::new().unwrap();
+
     app_status_cmd()
+        .env("HOME", home.path())
         .env(ENV_ORG_ID, "org-env")
         .assert()
         .failure()

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -186,7 +186,10 @@ fn hosted_operator_rejects_skip_post_before_api_activity() {
 }
 
 #[test]
-fn explicit_seed_does_not_load_malformed_config() {
+fn malformed_config_fails_before_dispatch_even_with_explicit_seed() {
+    // Config is built once before dispatch, so a corrupt config file surfaces
+    // immediately for every command — even an offline approve whose explicit
+    // seed never reads it.
     let temp = TempDir::new().unwrap();
     let config_dir = temp.path().join(".config/turnkey");
     fs::create_dir_all(&config_dir).unwrap();
@@ -203,7 +206,8 @@ fn explicit_seed_does_not_load_malformed_config() {
         .arg("--skip-post")
         .arg("--dangerous-skip-interactive")
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("failed to parse config file"));
 }
 
 #[test]

--- a/tvc/tests/error_output.rs
+++ b/tvc/tests/error_output.rs
@@ -15,6 +15,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::process::Output;
 use std::thread::{self, JoinHandle};
+use tempfile::TempDir;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 
 const DEPLOYMENT_ID: &str = "00000000-0000-0000-0000-000000000000";
@@ -26,10 +27,13 @@ fn tvc_command() -> assert_cmd::Command {
     command
 }
 
-fn authenticated_command(api_base_url: &str) -> assert_cmd::Command {
+// Config is built before dispatch, so the binary needs a HOME even on the
+// env-auth path; the caller owns the temp dir so it outlives the command run.
+fn authenticated_command(home: &TempDir, api_base_url: &str) -> assert_cmd::Command {
     let stamper = TurnkeyP256ApiKey::generate();
     let mut command = tvc_command();
     command
+        .env("HOME", home.path())
         .env("TVC_ORG_ID", "org-test")
         .env(
             "TVC_API_KEY_PUBLIC",
@@ -110,8 +114,12 @@ fn spawn_json_server(
     (format!("http://{address}"), handle)
 }
 
-fn deploy_status_command(api_base_url: &str, message_format: Option<&str>) -> assert_cmd::Command {
-    let mut command = authenticated_command(api_base_url);
+fn deploy_status_command(
+    home: &TempDir,
+    api_base_url: &str,
+    message_format: Option<&str>,
+) -> assert_cmd::Command {
+    let mut command = authenticated_command(home, api_base_url);
     command
         .arg("deploy")
         .arg("status")
@@ -199,6 +207,8 @@ fn help_remains_plain_text() {
 
 #[test]
 fn http_status_errors_emit_stable_codes_status_and_full_chain() {
+    let home = TempDir::new().unwrap();
+
     for (status, expected_code) in [
         (401, "unauthorized"),
         (403, "unauthorized"),
@@ -208,7 +218,7 @@ fn http_status_errors_emit_stable_codes_status_and_full_chain() {
         let server_message = format!("server failure {status}");
         let body = format!(r#"{{"code":{status},"message":"{server_message}"}}"#);
         let (api_base_url, server) = spawn_json_server(status, body, GET_DEPLOYMENT_PATH);
-        let output = command_output(deploy_status_command(&api_base_url, Some("json")), 1);
+        let output = command_output(deploy_status_command(&home, &api_base_url, Some("json")), 1);
         server.join().unwrap();
 
         let message = single_json_message(&output);
@@ -227,12 +237,13 @@ fn http_status_errors_emit_stable_codes_status_and_full_chain() {
 
 #[test]
 fn successful_response_with_missing_resource_has_no_http_status() {
+    let home = TempDir::new().unwrap();
     let (api_base_url, server) = spawn_json_server(
         200,
         r#"{"tvcDeployment":null}"#.to_string(),
         GET_DEPLOYMENT_PATH,
     );
-    let output = command_output(deploy_status_command(&api_base_url, Some("json")), 1);
+    let output = command_output(deploy_status_command(&home, &api_base_url, Some("json")), 1);
     server.join().unwrap();
 
     let message = single_json_message(&output);
@@ -247,11 +258,12 @@ fn successful_response_with_missing_resource_has_no_http_status() {
 
 #[test]
 fn connection_failure_emits_network_error_without_http_status() {
+    let home = TempDir::new().unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let api_base_url = format!("http://{}", listener.local_addr().unwrap());
     drop(listener);
 
-    let mut command = authenticated_command(&api_base_url);
+    let mut command = authenticated_command(&home, &api_base_url);
     command
         .arg("app")
         .arg("list")
@@ -271,15 +283,19 @@ fn connection_failure_emits_network_error_without_http_status() {
 
 #[test]
 fn human_and_json_runtime_errors_render_identical_message_text() {
+    let home = TempDir::new().unwrap();
     let body = r#"{"code":404,"message":"deployment absent"}"#.to_string();
     let (json_api_base_url, json_server) =
         spawn_json_server(404, body.clone(), GET_DEPLOYMENT_PATH);
-    let json_output = command_output(deploy_status_command(&json_api_base_url, Some("json")), 1);
+    let json_output = command_output(
+        deploy_status_command(&home, &json_api_base_url, Some("json")),
+        1,
+    );
     json_server.join().unwrap();
     let json_message = single_json_message(&json_output);
 
     let (human_api_base_url, human_server) = spawn_json_server(404, body, GET_DEPLOYMENT_PATH);
-    let human_output = command_output(deploy_status_command(&human_api_base_url, None), 1);
+    let human_output = command_output(deploy_status_command(&home, &human_api_base_url, None), 1);
     human_server.join().unwrap();
 
     assert!(human_output.stdout.is_empty());
@@ -297,12 +313,13 @@ const CLIENT_VERSION_TOO_OLD_BODY: &str = r#"{"code":3,"message":"tvc 0.12.0 is 
 
 #[test]
 fn client_version_rejection_emits_dedicated_code() {
+    let home = TempDir::new().unwrap();
     let (api_base_url, server) = spawn_json_server(
         400,
         CLIENT_VERSION_TOO_OLD_BODY.to_string(),
         GET_DEPLOYMENT_PATH,
     );
-    let output = command_output(deploy_status_command(&api_base_url, Some("json")), 1);
+    let output = command_output(deploy_status_command(&home, &api_base_url, Some("json")), 1);
     server.join().unwrap();
 
     let message = single_json_message(&output);
@@ -313,12 +330,13 @@ fn client_version_rejection_emits_dedicated_code() {
 
 #[test]
 fn client_version_rejection_renders_human_hint() {
+    let home = TempDir::new().unwrap();
     let (api_base_url, server) = spawn_json_server(
         400,
         CLIENT_VERSION_TOO_OLD_BODY.to_string(),
         GET_DEPLOYMENT_PATH,
     );
-    let output = command_output(deploy_status_command(&api_base_url, None), 1);
+    let output = command_output(deploy_status_command(&home, &api_base_url, None), 1);
     server.join().unwrap();
 
     assert!(output.stdout.is_empty());

--- a/tvc/tests/keys_create_quorum_key.rs
+++ b/tvc/tests/keys_create_quorum_key.rs
@@ -1,6 +1,7 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use qos_p256::P256Pair;
+use tempfile::TempDir;
 
 const FIRST_OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
 const SECOND_OPERATOR_ID: &str = "22222222-2222-4222-8222-222222222222";
@@ -45,11 +46,15 @@ fn create_quorum_key_requires_threshold_and_one_operator_source() {
 
 #[test]
 fn create_quorum_key_reads_explicit_inputs_from_env() {
+    // Config is built before dispatch, so reaching in-command validation
+    // needs a HOME; a fresh temp dir keeps the test hermetic.
+    let home = TempDir::new().unwrap();
     let first = operator_encrypt_key();
     let second = operator_encrypt_key();
 
     cargo_bin_cmd!("tvc")
         .env_clear()
+        .env("HOME", home.path())
         .env("TVC_QUORUM_KEY_THRESHOLD", "3")
         .env("TVC_OPERATOR_ENCRYPT_KEYS", format!("{first},{second}"))
         .arg("keys")
@@ -66,8 +71,11 @@ fn create_quorum_key_reads_explicit_inputs_from_env() {
 
 #[test]
 fn create_quorum_key_reads_operator_ids_from_env() {
+    let home = TempDir::new().unwrap();
+
     cargo_bin_cmd!("tvc")
         .env_clear()
+        .env("HOME", home.path())
         .env("TVC_QUORUM_KEY_THRESHOLD", "3")
         .env(
             "TVC_OPERATOR_IDS",

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -371,7 +371,9 @@ fn approve_non_interactive_requires_operator_id_when_saved_ids_are_ambiguous() {
 }
 
 #[test]
-fn deploy_init_template_does_not_require_readable_existing_config() {
+fn deploy_init_fails_before_dispatch_on_malformed_config() {
+    // Config is built once before dispatch, so a corrupt config file surfaces
+    // immediately for every command — even offline template generation.
     let temp = TempDir::new().unwrap();
     let turnkey_dir = temp.path().join(".config").join("turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
@@ -385,13 +387,10 @@ fn deploy_init_template_does_not_require_readable_existing_config() {
         .arg("--output")
         .arg(&output)
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Port guidance:"))
-        .stdout(predicate::str::contains(
-            "Use the same port for both unless your binary exposes health checks",
-        ));
+        .failure()
+        .stderr(predicate::str::contains("failed to parse config file"));
 
-    assert!(output.exists(), "deploy init should write the template");
+    assert!(!output.exists(), "no template should be written");
 }
 
 #[test]


### PR DESCRIPTION
Removes every `Config::load()` call site. The CLI builds the config once in `Commands::run` (loading `tvc.config.toml`, or writing the default on first run) and passes it down: command endpoints take an owned `Config` (matching the `Run` trait), shared helpers (`build_client`, `resolve_operator`, `resolve_local_operator`, ...) take `&Config`.

Behavior changes that fall out of the top-level load, encoded in the updated integration tests:
- every command now requires `HOME` and a well-formed config before dispatch, including env-auth (CI) runs and offline paths (`deploy approve --operator-seed --skip-post`, `deploy init`)
- a malformed config file fails fast with a parse error instead of being ignored on paths that never read it
- first run writes the default config file