### PR TITLE
deps: bump x509-cert to 0.2.5 to match qos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,6 @@ checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "der_derive 0.6.1",
- "flagset",
  "pem-rfc7468 0.6.0",
  "zeroize",
 ]
@@ -2809,7 +2808,7 @@ dependencies = [
  "serde_bytes",
  "sha2",
  "webpki",
- "x509-cert 0.2.5",
+ "x509-cert",
 ]
 
 [[package]]
@@ -4204,7 +4203,7 @@ dependencies = [
  "turnkey_api_key_stamper",
  "turnkey_client",
  "webpki",
- "x509-cert 0.1.0",
+ "x509-cert",
  "x509-parser",
 ]
 
@@ -4843,18 +4842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-cert"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd27a832a85efcf56cad058e4e3256d1781b927e113a9e37d96916d639e4af7"
-dependencies = [
- "const-oid",
- "der 0.6.1",
- "flagset",
- "spki 0.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ coset = { version = "0.3.7", default-features = false }
 
 # Certificate handling
 webpki = { version = "0.22.4", default-features = false }
-x509-cert = { version = "=0.1.0", features = ["pem"], default-features = false }
+x509-cert = { version = "=0.2.5", features = ["pem"], default-features = false }
 x509-parser = { version = "0.14.0", default-features = false }
 
 # Serialization formats

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -179,8 +179,8 @@ fn verify_cose_sign1_sig(
         .tbs_certificate
         .subject_public_key_info
         .subject_public_key;
-    let key =
-        PublicKey::from_sec1_bytes(pub_key).map_err(|_| AttestError::FailedDecodeKeyFromCert)?;
+    let key = PublicKey::from_sec1_bytes(pub_key.raw_bytes())
+        .map_err(|_| AttestError::FailedDecodeKeyFromCert)?;
     let key_wrapped = P384PubKey(key);
 
     // Verify the signature against the extracted public key


### PR DESCRIPTION
Bumps `x509-cert` from `=0.1.0` to `=0.2.5` so the workspace matches qos, and adapts `proofs` to the 0.2 API (`subject_public_key` is now a `BitString`, read via `.raw_bytes()`).

Part of TVC-306.