### PR TITLE
feat: add Secrets API convenience methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,17 +4115,21 @@ version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "hex",
  "http 0.2.12",
  "mime",
+ "p256 0.13.2",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with 3.14.0",
+ "sha2",
  "thiserror 2.0.12",
  "tokio",
  "turnkey_api_key_stamper",
+ "turnkey_enclave_encrypt",
  "wiremock",
 ]
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added high-level secret import, metadata listing, unilateral export, and multi-party export proposal APIs.
+
 ## [0.14.0](https://github.com/tkhq/rust-sdk/compare/turnkey_client-v0.13.1...turnkey_client-v0.14.0) - 2026-08-05
 
 ### Other

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,15 +14,18 @@ categories = ["api-bindings"]
 [dependencies]
 mime.workspace = true
 chrono.workspace = true
+hex.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 turnkey_api_key_stamper.workspace = true
+turnkey_enclave_encrypt.workspace = true
 
 [features]
 reqwest_native_tls = ["reqwest/native-tls-vendored", "reqwest/native-tls-alpn"]
@@ -34,3 +37,4 @@ reqwest_hickory_dns = ["reqwest/hickory-dns"]
 wiremock.workspace = true
 http.workspace = true
 base64.workspace = true
+p256.workspace = true

--- a/client/src/generated/client.rs
+++ b/client/src/generated/client.rs
@@ -1801,7 +1801,7 @@ impl<S: Stamp> TurnkeyClient<S> {
             app_proofs: activity.app_proofs,
         })
     }
-    /// List wallets accounts
+    /// List wallet accounts
     ///
     /// List all accounts within a wallet.
     pub async fn get_wallet_accounts(
@@ -3861,6 +3861,45 @@ impl<S: Stamp> TurnkeyClient<S> {
         )
         .await
     }
+    /// Get swap quote
+    ///
+    /// Get a swap quote. Asset chains are derived from CAIP-19 asset IDs; cross-chain quotes are supported.
+    pub async fn create_swap_quote(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::CreateSwapQuoteIntent,
+    ) -> Result<ActivityResult<immutable_activity::CreateSwapQuoteResult>, TurnkeyClientError> {
+        let request = external_activity::CreateSwapQuoteRequest {
+            r#type: "ACTIVITY_TYPE_CREATE_SWAP_QUOTE".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+            generate_app_proofs: self.generate_app_proofs(),
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/create_swap_quote".to_string())
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::CreateSwapQuoteResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
     /// Get swap status
     ///
     /// Poll the status of a swap by its swap_request_id. Covers same-chain and cross-chain swaps.
@@ -3870,6 +3909,45 @@ impl<S: Stamp> TurnkeyClient<S> {
     ) -> Result<coordinator::GetSwapStatusResponse, TurnkeyClientError> {
         self.process_request(&request, "/public/v1/query/get_swap_status".to_string())
             .await
+    }
+    /// Execute swap
+    ///
+    /// Execute the exact provider quote identified by quote_id through the activity pipeline and Turnkey broadcasting. Requests must use ACTIVITY_TYPE_EXECUTE_SWAP_V2.
+    pub async fn execute_swap(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::ExecuteSwapIntentV2,
+    ) -> Result<ActivityResult<immutable_activity::ExecuteSwapResult>, TurnkeyClientError> {
+        let request = external_activity::ExecuteSwapRequest {
+            r#type: "ACTIVITY_TYPE_EXECUTE_SWAP_V2".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+            generate_app_proofs: self.generate_app_proofs(),
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/execute_swap".to_string())
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::ExecuteSwapResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
     }
     /// Claim swap fees
     ///
@@ -4299,6 +4377,19 @@ impl<S: Stamp> TurnkeyClient<S> {
         self.process_request(&request, "/public/v1/query/validate_tvc_image".to_string())
             .await
     }
+    /// Get TVC QOS versions
+    ///
+    /// List QOS versions supported for new TVC deployments and the latest recommended QOS version.
+    pub async fn get_tvc_qos_versions(
+        &self,
+        request: coordinator::GetTvcQosVersionsRequest,
+    ) -> Result<coordinator::GetTvcQosVersionsResponse, TurnkeyClientError> {
+        self.process_request(
+            &request,
+            "/public/v1/query/get_tvc_qos_versions".to_string(),
+        )
+        .await
+    }
     /// List TVC Deployments
     ///
     /// List all deployments for a given TVC App
@@ -4677,6 +4768,54 @@ impl<S: Stamp> TurnkeyClient<S> {
             status: activity.status,
             app_proofs: activity.app_proofs,
         })
+    }
+    /// Export secrets
+    ///
+    /// Export secrets encrypted to client-provided target public keys.
+    pub async fn export_secrets(
+        &self,
+        organization_id: String,
+        timestamp_ms: u128,
+        params: immutable_activity::ExportSecretsIntent,
+    ) -> Result<ActivityResult<immutable_activity::ExportSecretsResult>, TurnkeyClientError> {
+        let request = external_activity::ExportSecretsRequest {
+            r#type: "ACTIVITY_TYPE_EXPORT_SECRETS".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity: external_activity::Activity = self
+            .process_activity(&request, "/public/v1/submit/export_secrets".to_string())
+            .await?;
+        let inner = activity
+            .result
+            .ok_or_else(|| TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or_else(|| TurnkeyClientError::MissingInnerResult)?;
+        let result = match inner {
+            immutable_activity::result::Inner::ExportSecretsResult(res) => res,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        Ok(ActivityResult {
+            result,
+            activity_id: activity.id,
+            status: activity.status,
+            app_proofs: activity.app_proofs,
+        })
+    }
+    /// List secrets
+    ///
+    /// List secret metadata for an organization.
+    pub async fn list_secrets(
+        &self,
+        request: coordinator::ListSecretsRequest,
+    ) -> Result<coordinator::ListSecretsResponse, TurnkeyClientError> {
+        self.process_request(&request, "/public/v1/query/list_secrets".to_string())
+            .await
     }
     /// Get IP Allowlist
     ///

--- a/client/src/generated/external.activity.v1.rs
+++ b/client/src/generated/external.activity.v1.rs
@@ -1756,6 +1756,19 @@ pub struct ImportSecretsRequest {
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
+pub struct ExportSecretsRequest {
+    pub r#type: ::prost::alloc::string::String,
+    pub timestamp_ms: ::prost::alloc::string::String,
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub parameters: ::core::option::Option<
+        super::super::super::immutable::activity::v1::ExportSecretsIntent,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
 pub struct SparkPrepareTransferRequest {
     pub r#type: ::prost::alloc::string::String,
     pub timestamp_ms: ::prost::alloc::string::String,

--- a/client/src/generated/external.data.v1.rs
+++ b/client/src/generated/external.data.v1.rs
@@ -566,6 +566,25 @@ pub struct EarnVault {
     pub display: ::core::option::Option<EarnValueDisplay>,
     pub name: ::prost::alloc::string::String,
     pub curator: ::prost::alloc::string::String,
+    pub liquidity: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub liquidity_display: ::core::option::Option<EarnValueDisplay>,
+}
+#[derive(Debug)]
+/// EarnVaultExposure is one underlying market a vault allocates into, and the
+/// share of the vault's assets held there.
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct EarnVaultExposure {
+    pub market_id: ::prost::alloc::string::String,
+    pub collateral_symbol: ::prost::alloc::string::String,
+    pub collateral_caip19: ::prost::alloc::string::String,
+    pub lltv_pct: ::prost::alloc::string::String,
+    pub supplied: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub display: ::core::option::Option<EarnValueDisplay>,
+    pub share_pct: ::prost::alloc::string::String,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -592,6 +611,11 @@ pub struct EarnEnabledVault {
     pub claimable_client_fee_display: ::core::option::Option<EarnValueDisplay>,
     #[serde(default)]
     pub client_fee_wallet: ::core::option::Option<::prost::alloc::string::String>,
+    pub liquidity: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub liquidity_display: ::core::option::Option<EarnValueDisplay>,
+    #[serde(default)]
+    pub exposures: ::prost::alloc::vec::Vec<EarnVaultExposure>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -606,6 +630,8 @@ pub struct AssetMetadata {
     pub name: ::prost::alloc::string::String,
     #[serde(default)]
     pub stable: bool,
+    #[serde(default)]
+    pub earn_providers: Vec<super::super::super::immutable::data::v1::EarnProvider>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -821,6 +847,50 @@ pub struct LogLine {
     #[serde(default)]
     pub ts: ::core::option::Option<Timestamp>,
 }
+/// ProvisioningState describes the observed quorum-key provisioning progress of
+/// a TVC deployment.
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ProvisioningState {
+    /// The provisioning state was not reported. This value supports responses
+    /// produced before provisioning state reporting was introduced.
+    #[serde(rename = "PROVISIONING_STATE_UNSPECIFIED")]
+    Unspecified = 0,
+    /// The deployment is starting up and provisioning details are not yet
+    /// available.
+    #[serde(rename = "PROVISIONING_STATE_PENDING")]
+    Pending = 1,
+    /// A deployment replica is ready to accept quorum key provisioning.
+    #[serde(rename = "PROVISIONING_STATE_AWAITING_PROVISION")]
+    AwaitingProvision = 2,
+    /// At least one deployment replica has a provisioned quorum key.
+    #[serde(rename = "PROVISIONING_STATE_PROVISIONED")]
+    Provisioned = 3,
+}
+impl ProvisioningState {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "PROVISIONING_STATE_UNSPECIFIED",
+            Self::Pending => "PROVISIONING_STATE_PENDING",
+            Self::AwaitingProvision => "PROVISIONING_STATE_AWAITING_PROVISION",
+            Self::Provisioned => "PROVISIONING_STATE_PROVISIONED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PROVISIONING_STATE_UNSPECIFIED" => Some(Self::Unspecified),
+            "PROVISIONING_STATE_PENDING" => Some(Self::Pending),
+            "PROVISIONING_STATE_AWAITING_PROVISION" => Some(Self::AwaitingProvision),
+            "PROVISIONING_STATE_PROVISIONED" => Some(Self::Provisioned),
+            _ => None,
+        }
+    }
+}
 #[derive(Debug)]
 /// An account derived from a Wallet
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -843,11 +913,13 @@ pub struct WalletAccount {
     pub public_key: ::core::option::Option<::prost::alloc::string::String>,
     #[serde(default)]
     pub wallet_details: ::core::option::Option<Wallet>,
+    #[serde(default)]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// TODO(tim): temporarily removing this since it's always "false"
     /// bool exported = 12 [
     ///   (google.api.field_behavior) = REQUIRED,
     ///   (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "True when a given Account is exported, false otherwise."}
     /// ];
     #[serde(default)]
-    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    pub caip2_prefix: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -177,6 +177,7 @@ pub mod intent {
         ExecuteSwapIntentV2(super::ExecuteSwapIntentV2),
         CreateSwapQuoteIntent(super::CreateSwapQuoteIntent),
         ImportSecretsIntent(super::ImportSecretsIntent),
+        ExportSecretsIntent(super::ExportSecretsIntent),
     }
 }
 #[derive(Debug)]
@@ -1802,7 +1803,7 @@ pub struct OtpLoginIntentV2 {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpAuthIntent {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     #[serde(default)]
@@ -1828,7 +1829,7 @@ pub struct InitOtpAuthIntent {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpIntent {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     /// @inject_tag: validate:"omitempty,min=6,max=9"
@@ -1862,7 +1863,7 @@ pub struct InitOtpIntent {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpIntentV2 {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     /// @inject_tag: validate:"omitempty,min=6,max=9"
@@ -1898,7 +1899,7 @@ pub struct InitOtpIntentV2 {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpIntentV3 {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     /// @inject_tag: validate:"tk_label_length,tk_label"
@@ -1934,7 +1935,7 @@ pub struct InitOtpIntentV3 {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpAuthIntentV2 {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     /// @inject_tag: validate:"omitempty,min=6,max=9"
@@ -1965,7 +1966,7 @@ pub struct InitOtpAuthIntentV2 {
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct InitOtpAuthIntentV3 {
-    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+    /// @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
     pub otp_type: ::prost::alloc::string::String,
     pub contact: ::prost::alloc::string::String,
     /// @inject_tag: validate:"omitempty,min=6,max=9"
@@ -2797,6 +2798,7 @@ pub mod result {
         EthUndelegate7702Result(super::EthUndelegate7702Result),
         CreateSwapQuoteResult(super::CreateSwapQuoteResult),
         ImportSecretsResult(super::ImportSecretsResult),
+        ExportSecretsResult(super::ExportSecretsResult),
     }
 }
 #[derive(Debug)]
@@ -4547,6 +4549,33 @@ pub struct ImportSecretsResult {
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
+pub struct ExportSecretsIntent {
+    #[serde(default)]
+    pub secrets: ::prost::alloc::vec::Vec<ExportSecretParams>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct ExportSecretParams {
+    /// @inject_tag: validate:"required,uuid"
+    pub secret_id: ::prost::alloc::string::String,
+    /// @inject_tag: validate:"hexadecimal"
+    pub target_public_key: ::prost::alloc::string::String,
+    pub encryption_suite: super::super::models::v1::TransportEncryptionSuite,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct ExportSecretsResult {
+    #[serde(default)]
+    pub secret_payloads: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
 pub struct ClientSignature {
     pub public_key: ::prost::alloc::string::String,
     pub scheme: super::super::common::v1::ClientSignatureScheme,
@@ -5096,6 +5125,8 @@ pub enum ActivityType {
     CreateSwapQuote = 161,
     #[serde(rename = "ACTIVITY_TYPE_IMPORT_SECRETS")]
     ImportSecrets = 162,
+    #[serde(rename = "ACTIVITY_TYPE_EXPORT_SECRETS")]
+    ExportSecrets = 163,
 }
 impl ActivityType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -5290,6 +5321,7 @@ impl ActivityType {
             Self::ExecuteSwapV2 => "ACTIVITY_TYPE_EXECUTE_SWAP_V2",
             Self::CreateSwapQuote => "ACTIVITY_TYPE_CREATE_SWAP_QUOTE",
             Self::ImportSecrets => "ACTIVITY_TYPE_IMPORT_SECRETS",
+            Self::ExportSecrets => "ACTIVITY_TYPE_EXPORT_SECRETS",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -5517,6 +5549,7 @@ impl ActivityType {
             "ACTIVITY_TYPE_EXECUTE_SWAP_V2" => Some(Self::ExecuteSwapV2),
             "ACTIVITY_TYPE_CREATE_SWAP_QUOTE" => Some(Self::CreateSwapQuote),
             "ACTIVITY_TYPE_IMPORT_SECRETS" => Some(Self::ImportSecrets),
+            "ACTIVITY_TYPE_EXPORT_SECRETS" => Some(Self::ExportSecrets),
             _ => None,
         }
     }

--- a/client/src/generated/services.coordinator.public.v1.rs
+++ b/client/src/generated/services.coordinator.public.v1.rs
@@ -1204,13 +1204,16 @@ pub struct GetTvcDeploymentProvisioningDetailsRequest {
     pub deployment_id: ::prost::alloc::string::String,
 }
 #[derive(Debug)]
+#[serde_with::serde_as]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct GetTvcDeploymentProvisioningDetailsResponse {
     #[serde(default)]
+    #[serde_as(as = "Option<serde_with::base64::Base64>")]
     pub attestation_document: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[serde(default)]
+    #[serde_as(as = "Option<serde_with::base64::Base64>")]
     pub manifest_envelope: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[serde(default)]
     pub provisioning_state: Option<

--- a/client/src/generated/services.coordinator.public.v1.rs
+++ b/client/src/generated/services.coordinator.public.v1.rs
@@ -749,6 +749,8 @@ pub struct SwapError {
     pub message: ::prost::alloc::string::String,
     #[serde(default)]
     pub origin_tx_error: ::core::option::Option<TxError>,
+    #[serde(default)]
+    pub provider_reason: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -839,6 +841,8 @@ pub struct ListEarnEnabledVaultsRequest {
     pub provider: super::super::super::super::immutable::data::v1::EarnProvider,
     #[serde(default)]
     pub caip19: ::core::option::Option<::prost::alloc::string::String>,
+    #[serde(default)]
+    pub include_exposure: bool,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -1200,17 +1204,18 @@ pub struct GetTvcDeploymentProvisioningDetailsRequest {
     pub deployment_id: ::prost::alloc::string::String,
 }
 #[derive(Debug)]
-#[serde_with::serde_as]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
 pub struct GetTvcDeploymentProvisioningDetailsResponse {
     #[serde(default)]
-    #[serde_as(as = "serde_with::base64::Base64")]
-    pub attestation_document: ::prost::alloc::vec::Vec<u8>,
+    pub attestation_document: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[serde(default)]
-    #[serde_as(as = "serde_with::base64::Base64")]
-    pub manifest_envelope: ::prost::alloc::vec::Vec<u8>,
+    pub manifest_envelope: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[serde(default)]
+    pub provisioning_state: Option<
+        super::super::super::super::external::data::v1::ProvisioningState,
+    >,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -1523,6 +1528,44 @@ pub struct EmailEventDetails {
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq)]
+pub struct ListSecretsRequest {
+    pub organization_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub pagination_options: ::core::option::Option<
+        super::super::super::super::external::options::v1::Pagination,
+    >,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct ListSecretsResponse {
+    #[serde(default)]
+    pub secrets: ::prost::alloc::vec::Vec<SecretMetadata>,
+}
+#[derive(Debug)]
+#[serde_with::serde_as]
+/// Metadata view of a secret. Excludes the encrypted payload and
+/// cryptographic material.
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct SecretMetadata {
+    pub secret_id: ::prost::alloc::string::String,
+    #[serde(default)]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[serde(default)]
+    pub static_properties: ::prost::alloc::vec::Vec<
+        super::super::super::super::immutable::models::v1::KeyValue,
+    >,
+    #[serde(default)]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub created_at_unix_ms: u64,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
 pub struct ListEthTransactionHistoryRequest {
     pub organization_id: ::prost::alloc::string::String,
     pub address: ::prost::alloc::string::String,
@@ -1679,4 +1722,20 @@ pub struct TransactionHistoryTurnkey {
     pub sponsored: bool,
     pub activity_fingerprint: ::prost::alloc::string::String,
     pub submitted_at: ::prost::alloc::string::String,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct GetTvcQosVersionsRequest {
+    pub organization_id: ::prost::alloc::string::String,
+}
+#[derive(Debug)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+pub struct GetTvcQosVersionsResponse {
+    #[serde(default)]
+    pub available_versions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub latest_version: ::prost::alloc::string::String,
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -64,6 +64,7 @@ pub struct ActivityResult<T> {
 pub use turnkey_api_key_stamper::{TurnkeyP256ApiKey, TurnkeySecp256k1ApiKey};
 
 pub mod generated;
+pub mod secrets;
 
 pub mod retry;
 pub mod well_known;
@@ -130,6 +131,24 @@ pub enum TurnkeyClientError {
 
     #[error("Stamper error")]
     StamperError(#[from] StamperError),
+
+    #[error("Enclave encryption failed: {0}")]
+    EnclaveEncrypt(#[from] turnkey_enclave_encrypt::errors::EnclaveEncryptError),
+
+    #[error("Malformed export secrets proposal: {0}")]
+    MalformedSecretsProposal(String),
+
+    #[error("Missing secret export result: {0}")]
+    MissingSecretResult(String),
+
+    #[error("Secret export payload count mismatch: expected {expected}, received {actual}")]
+    SecretPayloadCountMismatch { expected: usize, actual: usize },
+
+    #[error("Secret export fingerprint mismatch: expected {expected}, received {actual}")]
+    SecretFingerprintMismatch { expected: String, actual: String },
+
+    #[error("Exported secret is not valid UTF-8: {0}")]
+    InvalidSecretUtf8(String),
 }
 
 /// Builder for [`TurnkeyClient<S>`].
@@ -369,14 +388,23 @@ impl<S: Stamp> TurnkeyClient<S> {
         Request: Serialize,
         Response: DeserializeOwned,
     {
+        let post_body = serde_json::to_vec(&request)?;
+        self.process_serialized_request(&post_body, path).await
+    }
+
+    /// Stamps and posts an already-serialized JSON request without changing its bytes.
+    pub(crate) async fn process_serialized_request<Response: DeserializeOwned>(
+        &self,
+        post_body: &[u8],
+        path: String,
+    ) -> Result<Response, TurnkeyClientError> {
         let url = format!("{}{}", self.base_url, path);
-        let post_body = serde_json::to_string(&request)?;
-        let StampHeader { name, value } = self.api_key.stamp(post_body.as_bytes())?;
+        let StampHeader { name, value } = self.api_key.stamp(post_body)?;
         let res = self
             .http
             .post(url)
             .header(name, value)
-            .body(post_body)
+            .body(post_body.to_vec())
             .send()
             .await?;
 

--- a/client/src/secrets.rs
+++ b/client/src/secrets.rs
@@ -1,0 +1,1010 @@
+//! High-level helpers for importing, listing, and exporting secrets.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use turnkey_api_key_stamper::Stamp;
+use turnkey_enclave_encrypt::{ExportClient, ImportClient, QuorumPublicKey};
+
+use crate::generated::external::activity::v1::{
+    Activity, ExportSecretsRequest, InitImportSecretsRequest,
+};
+use crate::generated::external::options::v1::Pagination;
+use crate::generated::immutable::activity::v1::{
+    ActivityStatus, ActivityType, ExportSecretParams, ExportSecretsIntent, ExportSecretsResult,
+    ImportSecretParams, ImportSecretsIntent, InitImportSecretsIntent, InitImportSecretsResult,
+    result,
+};
+use crate::generated::immutable::models::v1::{KeyValue, TransportEncryptionSuite};
+use crate::generated::services::coordinator::public::v1::{
+    ActivityResponse, GetActivitiesRequest, GetActivityRequest, ListSecretsRequest, SecretMetadata,
+};
+use crate::{TurnkeyClient, TurnkeyClientError};
+
+const EXPORT_SECRETS_PATH: &str = "/public/v1/submit/export_secrets";
+const INIT_IMPORT_SECRETS_PATH: &str = "/public/v1/submit/init_import_secrets";
+
+/// Input for importing one UTF-8 secret.
+#[derive(Debug, Clone)]
+pub struct ImportSecretInput {
+    /// Organization receiving the secret.
+    pub organization_id: String,
+    /// Caller-provided activity timestamp in Unix milliseconds.
+    pub timestamp_ms: u128,
+    /// Plaintext UTF-8 secret material.
+    pub plaintext: String,
+    /// Optional display name.
+    pub name: Option<String>,
+    /// Deterministically ordered policy-visible properties.
+    pub static_properties: BTreeMap<String, String>,
+}
+
+/// Input for exporting one secret.
+#[derive(Debug, Clone)]
+pub struct ExportSecretInput {
+    /// Organization that owns the secret.
+    pub organization_id: String,
+    /// Caller-provided activity timestamp in Unix milliseconds.
+    pub timestamp_ms: u128,
+    /// Secret identifier.
+    pub secret_id: String,
+}
+
+/// Input for preparing a canonical export proposal.
+#[derive(Debug, Clone)]
+pub struct CreateExportSecretsProposalInput {
+    /// Organization that owns the secrets.
+    pub organization_id: String,
+    /// Caller-provided activity timestamp in Unix milliseconds.
+    pub timestamp_ms: u128,
+    /// Non-empty secret identifiers to export.
+    pub secret_ids: Vec<String>,
+}
+
+/// Validated, shareable canonical export request.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportSecretsProposal {
+    canonical_body: String,
+    fingerprint: String,
+}
+
+impl ExportSecretsProposal {
+    /// Reconstruct and validate a proposal received from another participant.
+    pub fn from_canonical_body(body: impl Into<String>) -> Result<Self, TurnkeyClientError> {
+        let canonical_body = body.into();
+        let request = validate_proposal_body(canonical_body.as_bytes())?;
+        validate_request(&request)?;
+        let fingerprint = fingerprint(canonical_body.as_bytes());
+        Ok(Self {
+            canonical_body,
+            fingerprint,
+        })
+    }
+
+    /// Exact JSON bytes that participants must stamp and submit.
+    #[must_use]
+    pub fn canonical_body(&self) -> &str {
+        &self.canonical_body
+    }
+
+    /// SHA-256 fingerprint of the exact canonical body.
+    #[must_use]
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    fn validated_request(&self) -> Result<ExportSecretsRequest, TurnkeyClientError> {
+        let request = validate_proposal_body(self.canonical_body.as_bytes())?;
+        validate_request(&request)?;
+        let actual = fingerprint(self.canonical_body.as_bytes());
+        if actual != self.fingerprint {
+            return Err(TurnkeyClientError::SecretFingerprintMismatch {
+                expected: self.fingerprint.clone(),
+                actual,
+            });
+        }
+        Ok(request)
+    }
+}
+
+/// A proposal paired with its one-shot, zeroizing recipient key.
+pub struct PreparedExportSecrets {
+    proposal: ExportSecretsProposal,
+    recipient: ExportClient,
+}
+
+impl PreparedExportSecrets {
+    /// Shareable canonical proposal.
+    #[must_use]
+    pub fn proposal(&self) -> &ExportSecretsProposal {
+        &self.proposal
+    }
+}
+
+/// Result of submitting an export proposal.
+#[derive(Debug, Clone)]
+pub struct ExportSecretsSubmission {
+    /// Activity identifier returned by this exact submission.
+    pub activity_id: String,
+    /// Server-reported request fingerprint.
+    pub fingerprint: String,
+    /// Current activity status.
+    pub status: ActivityStatus,
+    /// Payloads returned when the activity completed immediately.
+    pub secret_payloads: Vec<String>,
+}
+
+impl<S: Stamp> TurnkeyClient<S> {
+    /// Imports one UTF-8 secret and returns its identifier.
+    pub async fn import_secret(
+        &self,
+        input: ImportSecretInput,
+        signer_quorum_public_key: &QuorumPublicKey,
+    ) -> Result<String, TurnkeyClientError> {
+        if input.organization_id.is_empty() {
+            return Err(TurnkeyClientError::MalformedSecretsProposal(
+                "organization ID must not be empty".to_string(),
+            ));
+        }
+        let init_request = InitImportSecretsRequest {
+            r#type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS".to_string(),
+            timestamp_ms: input.timestamp_ms.to_string(),
+            organization_id: input.organization_id.clone(),
+            parameters: Some(InitImportSecretsIntent {
+                encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                num_secrets: 1,
+            }),
+        };
+        let activity = self
+            .process_activity(&init_request, INIT_IMPORT_SECRETS_PATH.to_string())
+            .await?;
+        let targets = init_import_result(activity)?.enclave_target_messages;
+        let target = exactly_one(targets, "init import target")?;
+        let encrypted = ImportClient::new(signer_quorum_public_key).encrypt_secret_with_bundle(
+            &input.plaintext,
+            target,
+            &input.organization_id,
+        )?;
+        let static_properties = input
+            .static_properties
+            .into_iter()
+            .map(|(key, value)| KeyValue { key, value })
+            .collect();
+        let imported = self
+            .import_secrets(
+                input.organization_id,
+                input.timestamp_ms,
+                ImportSecretsIntent {
+                    secrets: vec![ImportSecretParams {
+                        name: input.name,
+                        secret_payload: encrypted.secret_payload,
+                        target_public_key: encrypted.target_public_key,
+                        encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                        static_properties,
+                    }],
+                },
+            )
+            .await?;
+        exactly_one(imported.result.secret_ids, "imported secret ID")
+    }
+
+    /// Lists secret metadata for the supplied query.
+    pub async fn get_secrets(
+        &self,
+        request: ListSecretsRequest,
+    ) -> Result<Vec<SecretMetadata>, TurnkeyClientError> {
+        Ok(self.list_secrets(request).await?.secrets)
+    }
+
+    /// Creates a canonical proposal and retains its one-shot recipient key.
+    pub fn create_export_secrets_proposal(
+        &self,
+        input: CreateExportSecretsProposalInput,
+        signer_quorum_public_key: &QuorumPublicKey,
+    ) -> Result<PreparedExportSecrets, TurnkeyClientError> {
+        if input.organization_id.is_empty() || input.secret_ids.iter().any(String::is_empty) {
+            return Err(TurnkeyClientError::MalformedSecretsProposal(
+                "organization and secret IDs must not be empty".to_string(),
+            ));
+        }
+        if input.secret_ids.is_empty() {
+            return Err(TurnkeyClientError::MalformedSecretsProposal(
+                "at least one secret is required".to_string(),
+            ));
+        }
+        let recipient = ExportClient::new(signer_quorum_public_key);
+        let target_public_key = recipient.target_public_key()?;
+        let request = ExportSecretsRequest {
+            r#type: "ACTIVITY_TYPE_EXPORT_SECRETS".to_string(),
+            timestamp_ms: input.timestamp_ms.to_string(),
+            organization_id: input.organization_id,
+            parameters: Some(ExportSecretsIntent {
+                secrets: input
+                    .secret_ids
+                    .into_iter()
+                    .map(|secret_id| ExportSecretParams {
+                        secret_id,
+                        target_public_key: target_public_key.clone(),
+                        encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                    })
+                    .collect(),
+            }),
+        };
+        let canonical_body = serde_json::to_string(&request)?;
+        let proposal = ExportSecretsProposal::from_canonical_body(canonical_body)?;
+        Ok(PreparedExportSecrets {
+            proposal,
+            recipient,
+        })
+    }
+
+    /// Submits the exact canonical proposal bytes once, without polling.
+    pub async fn submit_export_secrets(
+        &self,
+        proposal: &ExportSecretsProposal,
+    ) -> Result<ExportSecretsSubmission, TurnkeyClientError> {
+        let request = proposal.validated_request()?;
+        let response: ActivityResponse = self
+            .process_serialized_request(
+                proposal.canonical_body.as_bytes(),
+                EXPORT_SECRETS_PATH.to_string(),
+            )
+            .await?;
+        let activity = response
+            .activity
+            .ok_or(TurnkeyClientError::MissingActivity)?;
+        validate_export_activity(&activity, &request.organization_id, proposal.fingerprint())?;
+        submission_from_activity(activity)
+    }
+
+    /// Waits for a known submission by its activity ID and decrypts all payloads.
+    pub async fn await_exported_secrets(
+        &self,
+        mut prepared: PreparedExportSecrets,
+        submission: ExportSecretsSubmission,
+    ) -> Result<Vec<String>, TurnkeyClientError> {
+        let request = prepared.proposal.validated_request()?;
+        if submission.fingerprint != prepared.proposal.fingerprint {
+            return Err(TurnkeyClientError::SecretFingerprintMismatch {
+                expected: prepared.proposal.fingerprint.clone(),
+                actual: submission.fingerprint,
+            });
+        }
+        let expected = request
+            .parameters
+            .as_ref()
+            .map_or(0, |parameters| parameters.secrets.len());
+        let payloads = match submission.status {
+            ActivityStatus::Completed => submission.secret_payloads,
+            ActivityStatus::ConsensusNeeded | ActivityStatus::AuthenticatorsNeeded => {
+                return Err(TurnkeyClientError::ActivityRequiresApproval(
+                    submission.activity_id,
+                ));
+            }
+            ActivityStatus::Failed => return Err(TurnkeyClientError::ActivityFailed(None)),
+            ActivityStatus::Pending | ActivityStatus::Created => {
+                self.poll_export_activity(
+                    &request.organization_id,
+                    &submission.activity_id,
+                    &prepared.proposal.fingerprint,
+                )
+                .await?
+            }
+            status => {
+                return Err(TurnkeyClientError::UnexpectedActivityStatus(
+                    status.as_str_name().to_string(),
+                ));
+            }
+        };
+        validate_payload_count(expected, payloads.len())?;
+        prepared
+            .recipient
+            .decrypt_secret_payloads(&payloads, &request.organization_id)
+            .map_err(|error| match error {
+                turnkey_enclave_encrypt::errors::EnclaveEncryptError::InvalidUtf8Bytes(message) => {
+                    TurnkeyClientError::InvalidSecretUtf8(message)
+                }
+                other => TurnkeyClientError::EnclaveEncrypt(other),
+            })
+    }
+
+    /// Finds a previously submitted proposal by fingerprint, then awaits it by activity ID.
+    ///
+    /// This is an explicit fallback for participants that did not perform the submission.
+    pub async fn await_exported_secrets_by_fingerprint(
+        &self,
+        prepared: PreparedExportSecrets,
+    ) -> Result<Vec<String>, TurnkeyClientError> {
+        let request = prepared.proposal.validated_request()?;
+        let mut before = String::new();
+        loop {
+            let response = self
+                .get_activities(GetActivitiesRequest {
+                    organization_id: request.organization_id.clone(),
+                    filter_by_status: Vec::new(),
+                    pagination_options: Some(Pagination {
+                        limit: "100".to_string(),
+                        before: before.clone(),
+                        after: String::new(),
+                    }),
+                    filter_by_type: vec![ActivityType::ExportSecrets],
+                })
+                .await?;
+            if let Some(activity) = response
+                .activities
+                .iter()
+                .find(|activity| activity.fingerprint == prepared.proposal.fingerprint)
+            {
+                let submission = submission_from_activity(activity.clone())?;
+                return self.await_exported_secrets(prepared, submission).await;
+            }
+            if response.activities.len() < 100 {
+                break;
+            }
+            let next = response
+                .activities
+                .last()
+                .map(|activity| activity.id.clone())
+                .ok_or_else(|| {
+                    TurnkeyClientError::MissingSecretResult(
+                        "activity pagination cursor".to_string(),
+                    )
+                })?;
+            if next == before {
+                break;
+            }
+            before = next;
+        }
+        Err(TurnkeyClientError::MissingSecretResult(format!(
+            "no export activity found for {}",
+            prepared.proposal.fingerprint
+        )))
+    }
+
+    /// Exports and decrypts one secret using the submission's returned activity ID.
+    pub async fn export_secret(
+        &self,
+        input: ExportSecretInput,
+        signer_quorum_public_key: &QuorumPublicKey,
+    ) -> Result<String, TurnkeyClientError> {
+        let prepared = self.create_export_secrets_proposal(
+            CreateExportSecretsProposalInput {
+                organization_id: input.organization_id,
+                timestamp_ms: input.timestamp_ms,
+                secret_ids: vec![input.secret_id],
+            },
+            signer_quorum_public_key,
+        )?;
+        let submission = self.submit_export_secrets(prepared.proposal()).await?;
+        let secrets = self.await_exported_secrets(prepared, submission).await?;
+        exactly_one(secrets, "exported secret")
+    }
+
+    async fn poll_export_activity(
+        &self,
+        organization_id: &str,
+        activity_id: &str,
+        expected_fingerprint: &str,
+    ) -> Result<Vec<String>, TurnkeyClientError> {
+        for retry_count in 0..=self.retry_config.max_retries {
+            let response = self
+                .get_activity(GetActivityRequest {
+                    organization_id: organization_id.to_string(),
+                    activity_id: activity_id.to_string(),
+                })
+                .await?;
+            let activity = response
+                .activity
+                .ok_or(TurnkeyClientError::MissingActivity)?;
+            validate_export_activity(&activity, organization_id, expected_fingerprint)?;
+            match activity.status {
+                ActivityStatus::Completed => return export_result(activity),
+                ActivityStatus::ConsensusNeeded | ActivityStatus::AuthenticatorsNeeded => {
+                    return Err(TurnkeyClientError::ActivityRequiresApproval(activity.id));
+                }
+                ActivityStatus::Failed => {
+                    return Err(TurnkeyClientError::ActivityFailed(activity.failure));
+                }
+                ActivityStatus::Pending | ActivityStatus::Created => {
+                    if retry_count == self.retry_config.max_retries {
+                        return Err(TurnkeyClientError::ExceededRetries(retry_count));
+                    }
+                    tokio::time::sleep(self.retry_config.compute_delay(retry_count + 1)).await;
+                }
+                status => {
+                    return Err(TurnkeyClientError::UnexpectedActivityStatus(
+                        status.as_str_name().to_string(),
+                    ));
+                }
+            }
+        }
+        Err(TurnkeyClientError::ExceededRetries(
+            self.retry_config.max_retries,
+        ))
+    }
+}
+
+fn validate_proposal_body(body: &[u8]) -> Result<ExportSecretsRequest, TurnkeyClientError> {
+    let request: ExportSecretsRequest = serde_json::from_slice(body).map_err(|error| {
+        TurnkeyClientError::MalformedSecretsProposal(format!("invalid JSON: {error}"))
+    })?;
+    let canonical = serde_json::to_vec(&request)?;
+    if canonical != body {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "request body is not in canonical serialized form".to_string(),
+        ));
+    }
+    Ok(request)
+}
+
+fn validate_request(request: &ExportSecretsRequest) -> Result<(), TurnkeyClientError> {
+    if request.r#type != "ACTIVITY_TYPE_EXPORT_SECRETS" {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "unexpected request type".to_string(),
+        ));
+    }
+    if request.organization_id.is_empty() {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "organization ID must not be empty".to_string(),
+        ));
+    }
+    let secrets = request
+        .parameters
+        .as_ref()
+        .ok_or_else(|| {
+            TurnkeyClientError::MalformedSecretsProposal("missing parameters".to_string())
+        })?
+        .secrets
+        .as_slice();
+    if secrets.is_empty() || secrets.iter().any(|secret| secret.secret_id.is_empty()) {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "secret IDs must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn fingerprint(body: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(body)))
+}
+
+fn init_import_result(activity: Activity) -> Result<InitImportSecretsResult, TurnkeyClientError> {
+    match activity
+        .result
+        .ok_or_else(|| {
+            TurnkeyClientError::MissingSecretResult("init import activity result".to_string())
+        })?
+        .inner
+        .ok_or_else(|| {
+            TurnkeyClientError::MissingSecretResult("init import inner activity result".to_string())
+        })? {
+        result::Inner::InitImportSecretsResult(value) => Ok(value),
+        other => Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+            serde_json::to_string(&other)?,
+        )),
+    }
+}
+
+fn export_result(activity: Activity) -> Result<Vec<String>, TurnkeyClientError> {
+    match activity
+        .result
+        .ok_or_else(|| {
+            TurnkeyClientError::MissingSecretResult("export activity result".to_string())
+        })?
+        .inner
+        .ok_or_else(|| {
+            TurnkeyClientError::MissingSecretResult("export inner activity result".to_string())
+        })? {
+        result::Inner::ExportSecretsResult(ExportSecretsResult { secret_payloads }) => {
+            Ok(secret_payloads)
+        }
+        other => Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+            serde_json::to_string(&other)?,
+        )),
+    }
+}
+
+fn submission_from_activity(
+    activity: Activity,
+) -> Result<ExportSecretsSubmission, TurnkeyClientError> {
+    let secret_payloads = if activity.status == ActivityStatus::Completed {
+        export_result(activity.clone())?
+    } else {
+        Vec::new()
+    };
+    Ok(ExportSecretsSubmission {
+        activity_id: activity.id,
+        fingerprint: activity.fingerprint,
+        status: activity.status,
+        secret_payloads,
+    })
+}
+
+fn validate_export_activity(
+    activity: &Activity,
+    expected_organization_id: &str,
+    expected_fingerprint: &str,
+) -> Result<(), TurnkeyClientError> {
+    if activity.r#type != ActivityType::ExportSecrets {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "response has unexpected activity type".to_string(),
+        ));
+    }
+    if activity.organization_id != expected_organization_id {
+        return Err(TurnkeyClientError::MalformedSecretsProposal(
+            "response organization does not match proposal".to_string(),
+        ));
+    }
+    if activity.fingerprint != expected_fingerprint {
+        return Err(TurnkeyClientError::SecretFingerprintMismatch {
+            expected: expected_fingerprint.to_string(),
+            actual: activity.fingerprint.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn exactly_one<T>(mut values: Vec<T>, label: &str) -> Result<T, TurnkeyClientError> {
+    if values.len() != 1 {
+        return Err(TurnkeyClientError::MissingSecretResult(format!(
+            "expected one {label}, received {}",
+            values.len()
+        )));
+    }
+    Ok(values.remove(0))
+}
+
+fn validate_payload_count(expected: usize, actual: usize) -> Result<(), TurnkeyClientError> {
+    if expected != actual {
+        return Err(TurnkeyClientError::SecretPayloadCountMismatch { expected, actual });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::time::Duration;
+
+    use p256::ecdsa::SigningKey;
+    use sha2::{Digest, Sha256};
+    use turnkey_enclave_encrypt::{P256Public, server::EnclaveEncryptServer};
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::{RetryConfig, TurnkeyP256ApiKey};
+
+    fn test_quorum_public_key() -> QuorumPublicKey {
+        QuorumPublicKey::from_string(concat!(
+            "04",
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+            "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa",
+            "04",
+            "8ee67fa8ae8e5fac0e343c84fa0921ecb3a31a67aee2e6a0880a09072eaaf2ae",
+            "ffa43f73fa021fa4d0b550072ba1f9011ff7cf917e4bf2708670e5ac57a81c78"
+        ))
+        .unwrap()
+    }
+
+    fn test_quorum_private_key() -> SigningKey {
+        SigningKey::from_slice(
+            &hex::decode("28ebf311b27f34cdf078489584d336423e09c522342f5b067dea36823c2cc5ed")
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    async fn setup() -> (TurnkeyClient<TurnkeyP256ApiKey>, MockServer) {
+        let server = MockServer::start().await;
+        let client = TurnkeyClient::builder()
+            .api_key(TurnkeyP256ApiKey::generate())
+            .base_url(server.uri())
+            .retry_config(RetryConfig {
+                initial_delay: Duration::from_millis(1),
+                multiplier: 1.0,
+                max_delay: Duration::from_millis(1),
+                max_retries: 1,
+            })
+            .build()
+            .unwrap();
+        (client, server)
+    }
+
+    fn prepared(client: &TurnkeyClient<TurnkeyP256ApiKey>) -> PreparedExportSecrets {
+        client
+            .create_export_secrets_proposal(
+                CreateExportSecretsProposalInput {
+                    organization_id: "org-id".to_string(),
+                    timestamp_ms: 123,
+                    secret_ids: vec!["secret-id".to_string()],
+                },
+                &test_quorum_public_key(),
+            )
+            .unwrap()
+    }
+
+    fn activity_json(
+        status: &str,
+        fingerprint: &str,
+        result: serde_json::Value,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "activity": activity_value("activity-id", status, fingerprint, result)
+        })
+    }
+
+    fn activity_value(
+        id: &str,
+        status: &str,
+        fingerprint: &str,
+        result: serde_json::Value,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "organizationId": "org-id",
+            "status": status,
+            "type": "ACTIVITY_TYPE_EXPORT_SECRETS",
+            "result": result,
+            "votes": [],
+            "appProofs": [],
+            "fingerprint": fingerprint,
+            "canApprove": false,
+            "canReject": false
+        })
+    }
+
+    #[test]
+    fn proposal_is_canonical_and_fingerprinted() {
+        let client = TurnkeyClient::builder()
+            .api_key(TurnkeyP256ApiKey::generate())
+            .build()
+            .unwrap();
+        let prepared = prepared(&client);
+        let body = prepared.proposal().canonical_body();
+        assert_eq!(
+            prepared.proposal().fingerprint(),
+            format!("sha256:{}", hex::encode(Sha256::digest(body.as_bytes())))
+        );
+        let reparsed = ExportSecretsProposal::from_canonical_body(body).unwrap();
+        assert_eq!(reparsed.canonical_body(), body);
+        assert_eq!(reparsed.fingerprint(), prepared.proposal().fingerprint());
+    }
+
+    #[test]
+    fn malformed_proposals_are_rejected() {
+        assert!(matches!(
+            ExportSecretsProposal::from_canonical_body("{}"),
+            Err(TurnkeyClientError::SerdeJsonFailure(_))
+                | Err(TurnkeyClientError::MalformedSecretsProposal(_))
+        ));
+        let wrong_type = r#"{"type":"ACTIVITY_TYPE_EXPORT_WALLET","timestampMs":"1","organizationId":"org","parameters":{"secrets":[{"secretId":"id","targetPublicKey":"04","encryptionSuite":"TRANSPORT_ENCRYPTION_SUITE_ENCLAVE_ENCRYPT_V1"}]}}"#;
+        assert!(matches!(
+            ExportSecretsProposal::from_canonical_body(wrong_type),
+            Err(TurnkeyClientError::MalformedSecretsProposal(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn submit_preserves_exact_body_and_returns_consensus_activity_id() {
+        let (client, server) = setup().await;
+        let prepared = prepared(&client);
+        let fingerprint = prepared.proposal().fingerprint().to_string();
+        Mock::given(method("POST"))
+            .and(path(EXPORT_SECRETS_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(activity_json(
+                "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                &fingerprint,
+                serde_json::Value::Null,
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let submission = client
+            .submit_export_secrets(prepared.proposal())
+            .await
+            .unwrap();
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests[0].body,
+            prepared.proposal().canonical_body().as_bytes()
+        );
+        assert!(matches!(
+            client.await_exported_secrets(prepared, submission).await,
+            Err(TurnkeyClientError::ActivityRequiresApproval(id)) if id == "activity-id"
+        ));
+    }
+
+    #[tokio::test]
+    async fn multiple_participants_submit_identical_proposal_bytes() {
+        let (client, server) = setup().await;
+        let prepared = prepared(&client);
+        let fingerprint = prepared.proposal().fingerprint().to_string();
+        Mock::given(method("POST"))
+            .and(path(EXPORT_SECRETS_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(activity_json(
+                "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                &fingerprint,
+                serde_json::Value::Null,
+            )))
+            .expect(2)
+            .mount(&server)
+            .await;
+        client
+            .submit_export_secrets(prepared.proposal())
+            .await
+            .unwrap();
+        client
+            .submit_export_secrets(prepared.proposal())
+            .await
+            .unwrap();
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests[0].body, requests[1].body);
+        assert_eq!(
+            requests[0].body,
+            prepared.proposal().canonical_body().as_bytes()
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_submission_polls_returned_activity_id_and_rejects_partial_payloads() {
+        let (client, server) = setup().await;
+        let prepared = prepared(&client);
+        let fingerprint = prepared.proposal().fingerprint().to_string();
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/get_activity"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(activity_json(
+                "ACTIVITY_STATUS_COMPLETED",
+                &fingerprint,
+                serde_json::json!({"exportSecretsResult":{"secretPayloads":[]}}),
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let error = client
+            .await_exported_secrets(
+                prepared,
+                ExportSecretsSubmission {
+                    activity_id: "activity-id".to_string(),
+                    fingerprint,
+                    status: ActivityStatus::Pending,
+                    secret_payloads: Vec::new(),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            TurnkeyClientError::SecretPayloadCountMismatch {
+                expected: 1,
+                actual: 0
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn export_secret_decrypts_immediate_completion() {
+        let (client, server) = setup().await;
+        Mock::given(method("POST"))
+            .and(path(EXPORT_SECRETS_PATH))
+            .respond_with(|request: &wiremock::Request| {
+                let export_request: ExportSecretsRequest =
+                    serde_json::from_slice(&request.body).unwrap();
+                let target: P256Public =
+                    hex::decode(&export_request.parameters.unwrap().secrets[0].target_public_key)
+                        .unwrap()
+                        .try_into()
+                        .unwrap();
+                let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+                    test_quorum_private_key(),
+                    "org-id".to_string(),
+                    None,
+                );
+                let payload =
+                    serde_json::to_string(&enclave.encrypt(&target, b"immediate secret").unwrap())
+                        .unwrap();
+                let fingerprint = format!(
+                    "sha256:{}",
+                    hex::encode(Sha256::digest(request.body.as_slice()))
+                );
+                ResponseTemplate::new(200).set_body_json(activity_json(
+                    "ACTIVITY_STATUS_COMPLETED",
+                    &fingerprint,
+                    serde_json::json!({
+                        "exportSecretsResult": {"secretPayloads": [payload]}
+                    }),
+                ))
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+        let secret = client
+            .export_secret(
+                ExportSecretInput {
+                    organization_id: "org-id".to_string(),
+                    timestamp_ms: 123,
+                    secret_id: "secret-id".to_string(),
+                },
+                &test_quorum_public_key(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(secret, "immediate secret");
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_response_fingerprint_mismatch() {
+        let (client, server) = setup().await;
+        let prepared = prepared(&client);
+        Mock::given(method("POST"))
+            .and(path(EXPORT_SECRETS_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(activity_json(
+                "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "sha256:wrong",
+                serde_json::Value::Null,
+            )))
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            client.submit_export_secrets(prepared.proposal()).await,
+            Err(TurnkeyClientError::SecretFingerprintMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn fingerprint_fallback_paginates_for_non_submitter() {
+        let (client, server) = setup().await;
+        let prepared = prepared(&client);
+        let fingerprint = prepared.proposal().fingerprint().to_string();
+        let first_page = (0..100)
+            .map(|index| {
+                activity_value(
+                    &format!("id-{index}"),
+                    "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "sha256:other",
+                    serde_json::Value::Null,
+                )
+            })
+            .collect::<Vec<_>>();
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_activities"))
+            .and(body_partial_json(serde_json::json!({
+                "paginationOptions": {"before": ""}
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"activities": first_page})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_activities"))
+            .and(body_partial_json(serde_json::json!({
+                "paginationOptions": {"before": "id-99"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activities": [activity_value(
+                    "matching-activity",
+                    "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    &fingerprint,
+                    serde_json::Value::Null
+                )]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            client
+                .await_exported_secrets_by_fingerprint(prepared)
+                .await,
+            Err(TurnkeyClientError::ActivityRequiresApproval(id)) if id == "matching-activity"
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_secrets_returns_generated_metadata() {
+        let (client, server) = setup().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/list_secrets"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "secrets": [{
+                    "secretId": "secret-id",
+                    "name": "database",
+                    "staticProperties": [],
+                    "createdAtUnixMs": "123"
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let secrets = client
+            .get_secrets(ListSecretsRequest {
+                organization_id: "org-id".to_string(),
+                pagination_options: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].secret_id, "secret-id");
+    }
+
+    #[tokio::test]
+    async fn import_secret_runs_init_encrypt_and_import_sequence() {
+        let (client, server) = setup().await;
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let target = serde_json::to_string(&enclave.publish_secret_target().unwrap()).unwrap();
+        Mock::given(method("POST"))
+            .and(path(INIT_IMPORT_SECRETS_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(activity_json_for_type(
+                    "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
+                    serde_json::json!({
+                        "initImportSecretsResult": {"enclaveTargetMessages": [target]}
+                    }),
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/import_secrets"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(activity_json_for_type(
+                    "ACTIVITY_TYPE_IMPORT_SECRETS",
+                    serde_json::json!({"importSecretsResult": {"secretIds": ["secret-id"]}}),
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let secret_id = client
+            .import_secret(
+                ImportSecretInput {
+                    organization_id: "org-id".to_string(),
+                    timestamp_ms: 123,
+                    plaintext: "secret value".to_string(),
+                    name: Some("database".to_string()),
+                    static_properties: BTreeMap::from([
+                        ("environment".to_string(), "production".to_string()),
+                        ("service".to_string(), "api".to_string()),
+                    ]),
+                },
+                &test_quorum_public_key(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(secret_id, "secret-id");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let import_body: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+        let properties = &import_body["parameters"]["secrets"][0]["staticProperties"];
+        assert_eq!(properties[0]["key"], "environment");
+        assert_eq!(properties[1]["key"], "service");
+    }
+
+    fn activity_json_for_type(activity_type: &str, result: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "activity": {
+                "id": "activity-id",
+                "organizationId": "org-id",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": activity_type,
+                "result": result,
+                "votes": [],
+                "appProofs": [],
+                "fingerprint": "sha256:test",
+                "canApprove": false,
+                "canReject": false
+            }
+        })
+    }
+}

--- a/codegen/src/transform.rs
+++ b/codegen/src/transform.rs
@@ -273,7 +273,7 @@ fn strip_prost_derive_from_attr(attr: &syn::Attribute) -> Option<proc_macro2::To
     })
 }
 
-/// Adds base64 serialization for Vec<u8> fields listed in BASE64_FIELDS.
+/// Adds base64 serialization for Vec<u8> (and Option<Vec<u8>>) fields listed in BASE64_FIELDS.
 /// Returns true if the field was mutated.
 pub fn add_serde_as_for_base64(field: &mut Field, struct_name: &str) -> bool {
     let field_name = match &field.ident {
@@ -289,15 +289,20 @@ pub fn add_serde_as_for_base64(field: &mut Field, struct_name: &str) -> bool {
         return false;
     }
 
-    // Verify the field type is Vec<u8>
-    if !is_vec_u8(&field.ty) {
-        return false;
+    // Verify the field type is Vec<u8> or Option<Vec<u8>>
+    if is_vec_u8(&field.ty) {
+        field
+            .attrs
+            .push(syn::parse_quote!(#[serde_as(as = "serde_with::base64::Base64")]));
+        return true;
     }
-
-    field
-        .attrs
-        .push(syn::parse_quote!(#[serde_as(as = "serde_with::base64::Base64")]));
-    true
+    if is_option_vec_u8(&field.ty) {
+        field
+            .attrs
+            .push(syn::parse_quote!(#[serde_as(as = "Option<serde_with::base64::Base64>")]));
+        return true;
+    }
+    false
 }
 
 fn is_vec_u8(ty: &Type) -> bool {
@@ -316,6 +321,27 @@ fn is_vec_u8(ty: &Type) -> bool {
                     }))) = ab.args.first()
                     {
                         return inner.segments.len() == 1 && inner.segments[0].ident == "u8";
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn is_option_vec_u8(ty: &Type) -> bool {
+    match ty {
+        Type::Path(TypePath { qself: None, path }) => {
+            let seg = match path.segments.last() {
+                Some(s) => s,
+                None => return false,
+            };
+
+            if seg.ident == "Option" {
+                if let PathArguments::AngleBracketed(ab) = &seg.arguments {
+                    if let Some(GenericArgument::Type(inner)) = ab.args.first() {
+                        return is_vec_u8(inner);
                     }
                 }
             }

--- a/enclave_encrypt/CHANGELOG.md
+++ b/enclave_encrypt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added organization-scoped secret import encryption and one-shot batch secret export decryption.
+
 ## [0.11.0](https://github.com/tkhq/rust-sdk/compare/turnkey_enclave_encrypt-v0.10.0...turnkey_enclave_encrypt-v0.11.0) - 2026-07-15
 
 ### Other

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -1,9 +1,9 @@
 //! Enclave Encrypt Client
 use crate::{
-    ClientSendMsg, DATA_VERSION, Kem, P256Public, ServerSendData, ServerSendMsg, ServerSendMsgV0,
-    ServerSendMsgV1, ServerTargetData, ServerTargetMsg, ServerTargetMsgV0, ServerTargetMsgV1,
-    TURNKEY_HPKE_INFO, decompress_p256_public, decrypt, encrypt, errors::EnclaveEncryptError,
-    quorum_public_key::QuorumPublicKey,
+    ClientSendMsg, DATA_VERSION, Kem, P256Public, ServerSecretTargetData, ServerSendData,
+    ServerSendMsg, ServerSendMsgV0, ServerSendMsgV1, ServerTargetData, ServerTargetMsg,
+    ServerTargetMsgV0, ServerTargetMsgV1, TURNKEY_HPKE_INFO, decompress_p256_public, decrypt,
+    encrypt, errors::EnclaveEncryptError, quorum_public_key::QuorumPublicKey,
 };
 use hpke::{Deserializable, Kem as KemTrait, Serializable};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
@@ -16,6 +16,15 @@ use std::str::from_utf8;
 
 /// Expected length (in bytes) for imported private keys
 const EXPECTED_PRIVATE_KEY_BYTE_LENGTH: usize = 32;
+
+/// The encrypted payload and verified enclave target key for one imported secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedSecret {
+    /// JSON-encoded enclave-encrypt payload sent to the import activity.
+    pub secret_payload: String,
+    /// Verified target public key from the signed ingress bundle.
+    pub target_public_key: String,
+}
 
 /// Abstraction over `EnclaveEncryptClient` for authentication flows.
 pub struct AuthenticationClient {
@@ -121,6 +130,30 @@ impl ExportClient {
         Self { encrypt_client }
     }
 
+    /// Creates an export client from the raw private scalar of an existing target key.
+    ///
+    /// This is compatible with external P-256 key generators that persist the scalar directly.
+    /// Prefer [`Self::new`] when the recipient state does not need to cross a process boundary.
+    pub fn dangerous_from_private_key_bytes<B: AsRef<[u8]>>(
+        private: B,
+        quorum_public_key: &QuorumPublicKey,
+    ) -> Result<Self, EnclaveEncryptError> {
+        let target_private = <Kem as KemTrait>::PrivateKey::from_bytes(private.as_ref())
+            .map_err(EnclaveEncryptError::InvalidTargetPrivateKey)?;
+        let secret_key = p256::SecretKey::from_slice(private.as_ref())
+            .map_err(|_| EnclaveEncryptError::InvalidP256PrivateKey)?;
+        let target_public_bytes = secret_key.public_key().to_encoded_point(false);
+        let target_public =
+            <Kem as KemTrait>::PublicKey::from_bytes(target_public_bytes.as_bytes())
+                .map_err(EnclaveEncryptError::InvalidClientTarget)?;
+        let encrypt_client = EnclaveEncryptClient::from_enclave_auth_key_and_target_key(
+            quorum_public_key.verifying_key()?,
+            target_public,
+            target_private,
+        );
+        Ok(Self { encrypt_client })
+    }
+
     /// Returns the target public key bytes, encoded as SEC1 bytes (04 || X || Y)
     ///
     /// This value is returned as a string, ready to be inserted in `EXPORT_WALLET` or `EXPORT_PRIVATE_KEY` activity params.
@@ -163,6 +196,29 @@ impl ExportClient {
         let phrase = from_utf8(&decrypted_bytes)
             .map_err(|e| EnclaveEncryptError::InvalidUtf8Bytes(e.to_string()))?;
         Ok(phrase.to_string())
+    }
+
+    /// Decrypts a batch of secret payloads with this client's one-shot recipient key.
+    ///
+    /// The recipient key remains available only for this call and is consumed even when
+    /// validation or decryption fails part way through the batch.
+    pub fn decrypt_secret_payloads<S: AsRef<str>, T: AsRef<str>>(
+        &mut self,
+        payloads: &[S],
+        organization_id: T,
+    ) -> Result<Vec<String>, EnclaveEncryptError> {
+        let decrypted = self.encrypt_client.decrypt_batch(
+            payloads.iter().map(|payload| payload.as_ref().as_bytes()),
+            organization_id.as_ref(),
+        )?;
+
+        decrypted
+            .into_iter()
+            .map(|bytes| {
+                String::from_utf8(bytes)
+                    .map_err(|error| EnclaveEncryptError::InvalidUtf8Bytes(error.to_string()))
+            })
+            .collect()
     }
 }
 
@@ -277,6 +333,29 @@ impl ImportClient {
 
         serde_json::to_string(&encrypted)
             .map_err(|e| EnclaveEncryptError::CannotSerializeBundle(e.to_string()))
+    }
+
+    /// Encrypts UTF-8 secret material to a signed organization-scoped ingress target.
+    ///
+    /// Unlike wallet import bundles, secret ingress targets are not scoped to a user.
+    pub fn encrypt_secret_with_bundle<S: AsRef<str>, T: AsRef<str>, U: AsRef<str>>(
+        &mut self,
+        secret: S,
+        import_bundle: T,
+        organization_id: U,
+    ) -> Result<EncryptedSecret, EnclaveEncryptError> {
+        let (encrypted, target_public_key) = self.encrypt_client.encrypt_secret(
+            secret.as_ref().as_bytes(),
+            import_bundle.as_ref().as_bytes(),
+            organization_id.as_ref(),
+        )?;
+        let secret_payload = serde_json::to_string(&encrypted)
+            .map_err(|e| EnclaveEncryptError::CannotSerializeBundle(e.to_string()))?;
+
+        Ok(EncryptedSecret {
+            secret_payload,
+            target_public_key,
+        })
     }
 }
 
@@ -395,7 +474,7 @@ impl EnclaveEncryptClient {
                     return Err(EnclaveEncryptError::InvalidOrganization);
                 }
 
-                if !parsed_data.user_id.eq(user_id) {
+                if parsed_data.user_id != user_id {
                     return Err(EnclaveEncryptError::InvalidUser);
                 }
 
@@ -414,12 +493,102 @@ impl EnclaveEncryptClient {
         })
     }
 
+    fn encrypt_secret(
+        &self,
+        plaintext: &[u8],
+        msg_bytes: &[u8],
+        organization_id: &str,
+    ) -> Result<(ClientSendMsg, String), EnclaveEncryptError> {
+        let msg: ServerTargetMsg = serde_json::from_slice(msg_bytes)
+            .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+        if msg.version.as_deref() != Some(DATA_VERSION) {
+            return Err(EnclaveEncryptError::InvalidDataVersion);
+        }
+
+        let msg_v1: ServerTargetMsgV1 = serde_json::from_slice(msg_bytes)
+            .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+        let signature = DerSignature::try_from(&msg_v1.data_signature[..])
+            .map_err(|_| EnclaveEncryptError::InvalidServerTargetSignature)?;
+        let public = PublicKey::from_sec1_bytes(&*msg_v1.enclave_quorum_public)
+            .map_err(|_| EnclaveEncryptError::InvalidEnclaveQuorumPublicKey)?;
+        let enclave_quorum_public = VerifyingKey::from(public);
+        if enclave_quorum_public != self.enclave_auth_key {
+            return Err(EnclaveEncryptError::InvalidEnclaveQuorumPublicKey);
+        }
+        enclave_quorum_public
+            .verify(&msg_v1.data, &signature)
+            .map_err(|_| EnclaveEncryptError::ServerTargetSignatureVerificationFail)?;
+        let parsed_data = serde_json::from_slice::<ServerSecretTargetData>(&msg_v1.data)
+            .map_err(|_| EnclaveEncryptError::FailedToDeserializeData)?;
+        if parsed_data.organization_id != organization_id {
+            return Err(EnclaveEncryptError::InvalidOrganization);
+        }
+        let receiver_public = <Kem as KemTrait>::PublicKey::from_bytes(&*parsed_data.target_public)
+            .map_err(EnclaveEncryptError::InvalidServerTarget)?;
+        let (ciphertext, encapped_public) =
+            encrypt(&receiver_public, plaintext, TURNKEY_HPKE_INFO)?;
+        let target_public_key = hex::encode(*parsed_data.target_public);
+
+        Ok((
+            ClientSendMsg {
+                encapped_public: encapped_public.to_bytes().to_vec().try_into()?,
+                ciphertext,
+            },
+            target_public_key,
+        ))
+    }
+
     /// Decrypt a message from the server targeted at this client.
     pub fn decrypt(
         &mut self,
         msg_bytes: &[u8],
         organization_id: &str,
     ) -> Result<Vec<u8>, EnclaveEncryptError> {
+        let result = self.decrypt_batch(std::iter::once(msg_bytes), organization_id);
+        result.and_then(|mut values| {
+            values
+                .pop()
+                .ok_or(EnclaveEncryptError::FailedToDeserializeData)
+        })
+    }
+
+    fn decrypt_batch<'a>(
+        &mut self,
+        messages: impl IntoIterator<Item = &'a [u8]>,
+        organization_id: &str,
+    ) -> Result<Vec<Vec<u8>>, EnclaveEncryptError> {
+        let encrypted = messages
+            .into_iter()
+            .map(|msg_bytes| self.validate_server_message(msg_bytes, organization_id))
+            .collect::<Result<Vec<_>, _>>()?;
+        let target_private = self
+            .target_private
+            .take()
+            .ok_or(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)?;
+        let target_public = self
+            .target_public
+            .take()
+            .ok_or(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)?;
+
+        encrypted
+            .into_iter()
+            .map(|(encapped_public, ciphertext)| {
+                decrypt(
+                    &encapped_public,
+                    &target_private,
+                    &target_public,
+                    &ciphertext,
+                    TURNKEY_HPKE_INFO,
+                )
+            })
+            .collect()
+    }
+
+    fn validate_server_message(
+        &self,
+        msg_bytes: &[u8],
+        organization_id: &str,
+    ) -> Result<(<Kem as KemTrait>::EncappedKey, Vec<u8>), EnclaveEncryptError> {
         let ciphertext;
         let encapped_public: <Kem as KemTrait>::EncappedKey;
 
@@ -480,24 +649,7 @@ impl EnclaveEncryptClient {
             Some(_) => return Err(EnclaveEncryptError::InvalidDataVersion),
         }
 
-        if let (Some(target_private), Some(target_public)) =
-            (self.target_private.as_ref(), self.target_public.as_ref())
-        {
-            let result = decrypt(
-                &encapped_public,
-                target_private,
-                target_public,
-                &ciphertext,
-                TURNKEY_HPKE_INFO,
-            );
-
-            self.target_public = None;
-            self.target_private = None;
-
-            result
-        } else {
-            Err(EnclaveEncryptError::ClientAlreadyUsedToDecrypt)
-        }
+        Ok((encapped_public, ciphertext))
     }
 
     /// Decrypt a base58 serialized email recovery or auth payload.
@@ -743,6 +895,142 @@ mod test {
                 .decrypt_wallet_mnemonic_phrase(encoded_bundle, "org-id")
                 .unwrap(),
             mnemonic
+        );
+    }
+
+    #[test]
+    fn encrypt_secret_to_organization_scoped_target() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let target_message = enclave.publish_secret_target().unwrap();
+        let target_data: ServerSecretTargetData =
+            serde_json::from_slice(&target_message.data).unwrap();
+        let target = serde_json::to_string(&target_message).unwrap();
+        let mut client = ImportClient::new(&test_quorum_public_key());
+        let encrypted = client
+            .encrypt_secret_with_bundle("super secret", target, "org-id")
+            .unwrap();
+        assert_eq!(
+            encrypted.target_public_key,
+            hex::encode(*target_data.target_public)
+        );
+        let payload: ClientSendMsg = serde_json::from_str(&encrypted.secret_payload).unwrap();
+        assert_eq!(
+            enclave.into_recv().decrypt(&payload).unwrap(),
+            b"super secret"
+        );
+    }
+
+    #[test]
+    fn secret_import_rejects_wrong_organization() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let target = serde_json::to_string(&enclave.publish_secret_target().unwrap()).unwrap();
+        let error = ImportClient::new(&test_quorum_public_key())
+            .encrypt_secret_with_bundle("secret", target, "wrong-org")
+            .unwrap_err();
+        assert_eq!(error, EnclaveEncryptError::InvalidOrganization);
+    }
+
+    #[test]
+    fn secret_import_rejects_invalid_signature_and_malformed_bundle() {
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let mut target = enclave.publish_secret_target().unwrap();
+        target.data_signature.0[0] ^= 1;
+        let error = ImportClient::new(&test_quorum_public_key())
+            .encrypt_secret_with_bundle("secret", serde_json::to_string(&target).unwrap(), "org-id")
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            EnclaveEncryptError::InvalidServerTargetSignature
+                | EnclaveEncryptError::ServerTargetSignatureVerificationFail
+        ));
+        assert_eq!(
+            ImportClient::new(&test_quorum_public_key())
+                .encrypt_secret_with_bundle("secret", "{", "org-id")
+                .unwrap_err(),
+            EnclaveEncryptError::FailedToDeserializeData
+        );
+    }
+
+    #[test]
+    fn decrypts_secret_batch_and_consumes_recipient_key() {
+        let mut client = ExportClient::new(&test_quorum_public_key());
+        let target: P256Public = hex::decode(client.target_public_key().unwrap())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let payloads = ["first", "second"].map(|value| {
+            serde_json::to_string(&enclave.encrypt(&target, value.as_bytes()).unwrap()).unwrap()
+        });
+        assert_eq!(
+            client.decrypt_secret_payloads(&payloads, "org-id").unwrap(),
+            vec!["first".to_string(), "second".to_string()]
+        );
+        assert_eq!(
+            client
+                .decrypt_secret_payloads(&payloads, "org-id")
+                .unwrap_err(),
+            EnclaveEncryptError::ClientAlreadyUsedToDecrypt
+        );
+    }
+
+    #[test]
+    fn decrypts_production_secret_payload_fixture() {
+        let private_key =
+            hex::decode("c46dd7f625a34f43f95014fbc45ddd9afd057207cb7260f0a10b7a450fbef272")
+                .unwrap();
+        let payload = r#"{"version":"v1.0.0","data":"7b22656e6361707065645075626c6963223a2230346430656533333965333264636561376134623537356332383030313766663733653733346436323135396266313337336237633266633763333535623037613364666330313036373666363135326138303163373231316464373639343962636434323835616637333438316135663561333661343837643863306364656132222c2263697068657274657874223a226135653034666539353332383831333039313633636366323266316163613262343331363363656335336162616533653963313430363134336336303932316630343261376566316337623862343139222c226f7267616e697a6174696f6e4964223a2261663734656437352d643366392d346364382d616436642d383235343564336366333264227d","dataSignature":"304502202d1f5ae093d33b0cda2f29a8fe7d0a86e948dabc127442d6f6ffda4b28dde7100221008eeb8d459a1cd19e12996b6c621126366b8a2dabfb6210c84f449ebfa62f2a08","enclaveQuorumPublic":"04cf288fe433cc4e1aa0ce1632feac4ea26bf2f5a09dcfe5a42c398e06898710330f0572882f4dbdf0f5304b8fc8703acd69adca9a4bbf7f5d00d20a5e364b2569"}"#;
+        let mut client = ExportClient::dangerous_from_private_key_bytes(
+            private_key,
+            &QuorumPublicKey::production_signer(),
+        )
+        .unwrap();
+        assert_eq!(
+            client
+                .decrypt_secret_payloads(&[payload], "af74ed75-d3f9-4cd8-ad6d-82545d3cf32d")
+                .unwrap(),
+            vec!["fixture-secret-plaintext".to_string()]
+        );
+    }
+
+    #[test]
+    fn secret_export_rejects_invalid_utf8_and_consumes_key() {
+        let mut client = ExportClient::new(&test_quorum_public_key());
+        let target: P256Public = hex::decode(client.target_public_key().unwrap())
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+            test_quorum_private_key(),
+            "org-id".to_string(),
+            None,
+        );
+        let payload = serde_json::to_string(&enclave.encrypt(&target, &[0xff]).unwrap()).unwrap();
+        assert!(matches!(
+            client.decrypt_secret_payloads(&[payload.as_str()], "org-id"),
+            Err(EnclaveEncryptError::InvalidUtf8Bytes(_))
+        ));
+        assert_eq!(
+            client
+                .decrypt_secret_payloads(&[payload.as_str()], "org-id")
+                .unwrap_err(),
+            EnclaveEncryptError::ClientAlreadyUsedToDecrypt
         );
     }
 

--- a/enclave_encrypt/src/errors.rs
+++ b/enclave_encrypt/src/errors.rs
@@ -67,6 +67,9 @@ pub enum EnclaveEncryptError {
     #[error("Could not deserialize P-256 public key: invalid SEC1 encoding")]
     InvalidP256PublicKeySec1Encoding(String),
 
+    #[error("Could not deserialize P-256 private key")]
+    InvalidP256PrivateKey,
+
     #[error("Invalid base58 encoding")]
     FailedToBase58Decode(String),
 

--- a/enclave_encrypt/src/lib.rs
+++ b/enclave_encrypt/src/lib.rs
@@ -18,6 +18,7 @@ mod quorum_public_key;
 pub mod server;
 
 pub use client::AuthenticationClient;
+pub use client::EncryptedSecret;
 pub use client::ExportClient;
 pub use client::ImportClient;
 pub use quorum_public_key::QuorumPublicKey;
@@ -198,8 +199,18 @@ pub struct ServerTargetData {
     pub target_public: P256Public,
     /// Organization making the request
     pub organization_id: String,
-    /// User making the request
+    /// User making the request.
     pub user_id: String,
+}
+
+/// Organization-scoped target data used by secret import ingress bundles.
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSecretTargetData {
+    /// Target public key for client encryption.
+    pub target_public: P256Public,
+    /// Organization receiving the secret.
+    pub organization_id: String,
 }
 
 /// Message from the client containing ciphertext and the associated

--- a/enclave_encrypt/src/server.rs
+++ b/enclave_encrypt/src/server.rs
@@ -6,9 +6,9 @@ use rand_core::OsRng;
 use zeroize::Zeroizing;
 
 use crate::{
-    ClientSendMsg, DATA_VERSION, Kem, P256Public, ServerSendData, ServerSendMsgV1,
-    ServerTargetData, ServerTargetMsgV1, TURNKEY_HPKE_INFO, compress_p256_public, decrypt, encrypt,
-    errors::EnclaveEncryptError,
+    ClientSendMsg, DATA_VERSION, Kem, P256Public, ServerSecretTargetData, ServerSendData,
+    ServerSendMsgV1, ServerTargetData, ServerTargetMsgV1, TURNKEY_HPKE_INFO, compress_p256_public,
+    decrypt, encrypt, errors::EnclaveEncryptError,
 };
 
 /// An instance of the server side for `EnclaveEncrypt`. This should only be used for either
@@ -137,6 +137,32 @@ impl EnclaveEncryptServer {
             target_public: self.target_public.to_bytes().to_vec().try_into()?,
             organization_id: self.organization_id.clone(),
             user_id,
+        };
+        let data_bytes = serde_json::to_string(&data)
+            .map_err(|_| EnclaveEncryptError::FailedToSerializeData)?
+            .into_bytes();
+        let data_signature: Signature = self.enclave_auth_key.sign(&data_bytes);
+        let enclave_quorum_public_bytes = self
+            .enclave_auth_key
+            .verifying_key()
+            .to_encoded_point(false)
+            .to_bytes()
+            .to_vec();
+        Ok(ServerTargetMsgV1 {
+            version: DATA_VERSION.to_string(),
+            data: data_bytes,
+            data_signature: data_signature.to_der().to_bytes().to_vec().into(),
+            enclave_quorum_public: enclave_quorum_public_bytes.try_into()?,
+        })
+    }
+
+    /// Return the server encryption target for a secret import.
+    ///
+    /// Secret import targets are scoped to an organization but not to a user.
+    pub fn publish_secret_target(&self) -> Result<ServerTargetMsgV1, EnclaveEncryptError> {
+        let data = ServerSecretTargetData {
+            target_public: self.target_public.to_bytes().to_vec().try_into()?,
+            organization_id: self.organization_id.clone(),
         };
         let data_bytes = serde_json::to_string(&data)
             .map_err(|_| EnclaveEncryptError::FailedToSerializeData)?

--- a/proto/activities.json
+++ b/proto/activities.json
@@ -212,6 +212,10 @@
       "intentType": "ImportSecretsIntent",
       "resultType": "ImportSecretsResult"
     },
+    "ACTIVITY_TYPE_EXPORT_SECRETS": {
+      "intentType": "ExportSecretsIntent",
+      "resultType": "ExportSecretsResult"
+    },
     "ACTIVITY_TYPE_OAUTH": {
       "intentType": "OauthIntent",
       "resultType": "OauthResult"

--- a/proto/external/activity/v1/activity.proto
+++ b/proto/external/activity/v1/activity.proto
@@ -2279,6 +2279,24 @@ message ImportSecretsRequest {
   immutable.activity.v1.ImportSecretsIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
+message ExportSecretsRequest {
+  string type = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      enum: ["ACTIVITY_TYPE_EXPORT_SECRETS"]
+    }
+  ];
+  string timestamp_ms = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp (in milliseconds) of the request, used to verify liveness of user requests."}
+  ];
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+  immutable.activity.v1.ExportSecretsIntent parameters = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
 message SparkPrepareTransferRequest {
   string type = 1 [
     (google.api.field_behavior) = REQUIRED,

--- a/proto/external/data/v1/earn.proto
+++ b/proto/external/data/v1/earn.proto
@@ -25,6 +25,20 @@ message EarnVault {
   EarnValueDisplay display = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Normalized TVL values for display purposes only (usd + crypto). Do not do arithmetic with these; use tvl instead."}];
   string name = 8 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Human-readable vault name from the provider (e.g. 'Steakhouse Prime USDC' for Morpho; the reserve symbol for Aave)."}];
   string curator = 9 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Vault curator name(s), comma-separated when a vault has multiple. Empty for providers without curators (e.g. Aave)."}];
+  string liquidity = 10 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Assets currently withdrawable from the vault without a reallocation, in raw on-chain units of the underlying asset. Empty when the provider does not report it."}];
+  EarnValueDisplay liquidity_display = 11 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."}];
+}
+
+// EarnVaultExposure is one underlying market a vault allocates into, and the
+// share of the vault's assets held there.
+message EarnVaultExposure {
+  string market_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Provider-specific identifier for the market (the Morpho Blue market id)."}];
+  string collateral_symbol = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Symbol of the market's collateral asset (e.g. 'cbBTC'). Empty for an idle/uncollateralized market."}];
+  string collateral_caip19 = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "CAIP-19 asset ID of the market's collateral asset. Empty for an idle/uncollateralized market."}];
+  string lltv_pct = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The market's liquidation loan-to-value, expressed as a decimal fraction (e.g. '0.86' for 86%)."}];
+  string supplied = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Assets the vault supplies to this market, in raw on-chain units of the underlying asset."}];
+  EarnValueDisplay display = 6 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Normalized supplied values for display purposes only (usd + crypto). Do not do arithmetic with these; use supplied instead."}];
+  string share_pct = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "This market's share of the vault's supplied assets, as a decimal fraction (e.g. '0.997' for 99.7%)."}];
 }
 
 message EarnEnabledVault {
@@ -43,6 +57,9 @@ message EarnEnabledVault {
   optional string claimable_client_fee = 13 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The client's claimable fee (releasable now), in raw on-chain units of the underlying asset (the caip19 asset). Turnkey's fee is excluded. Only returned to the parent org; unset when a sub-org queries."}];
   EarnValueDisplay claimable_client_fee_display = 14 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Normalized claimable_client_fee for display only (usd + crypto). Do not do arithmetic with these; use claimable_client_fee. Unset when a sub-org queries."}];
   optional string client_fee_wallet = 15 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The wallet address that receives the client's fee payouts on-chain. Unset when a sub-org queries."}];
+  string liquidity = 16 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Assets currently withdrawable from the underlying vault without a reallocation, in raw on-chain units of the underlying asset. This is the vault's liquidity, not the wrapper's balance. Empty when the provider does not report it."}];
+  EarnValueDisplay liquidity_display = 17 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Normalized liquidity values for display purposes only (usd + crypto). Do not do arithmetic with these; use liquidity instead."}];
+  repeated EarnVaultExposure exposures = 18 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The underlying markets the vault allocates into, ranked by supplied amount descending. Only populated when the request sets include_exposure, and only for providers that expose an allocation breakdown (Morpho)."}];
 }
 
 message AssetMetadata {
@@ -52,4 +69,5 @@ message AssetMetadata {
   string logo_url = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The url of the asset logo"}];
   string name = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The asset name"}];
   bool stable = 6 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Whether this asset is on Turnkey's stablecoin list (used for stablepair swap fee pricing)."}];
+  repeated immutable.data.v1.EarnProvider earn_providers = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Earn yield providers with vaults denominated in this asset. Empty when the asset is not supported by Earn."}];
 }

--- a/proto/external/data/v1/tvc.proto
+++ b/proto/external/data/v1/tvc.proto
@@ -209,6 +209,24 @@ message TvcManifest {
   Timestamp updated_at = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
+// ProvisioningState describes the observed quorum-key provisioning progress of
+// a TVC deployment.
+enum ProvisioningState {
+  // The provisioning state was not reported. This value supports responses
+  // produced before provisioning state reporting was introduced.
+  PROVISIONING_STATE_UNSPECIFIED = 0;
+
+  // The deployment is starting up and provisioning details are not yet
+  // available.
+  PROVISIONING_STATE_PENDING = 1;
+
+  // A deployment replica is ready to accept quorum key provisioning.
+  PROVISIONING_STATE_AWAITING_PROVISION = 2;
+
+  // At least one deployment replica has a provisioned quorum key.
+  PROVISIONING_STATE_PROVISIONED = 3;
+}
+
 message DeploymentStatus {
   string deployment_id = 1 [
     (google.api.field_behavior) = REQUIRED,

--- a/proto/external/data/v1/wallet_account.proto
+++ b/proto/external/data/v1/wallet_account.proto
@@ -61,6 +61,10 @@ message WalletAccount {
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Human-readable name for this Wallet Account, unique within the organization."}
   ];
+  optional string caip2_prefix = 14 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The CAIP-2 namespace shared by the chains supported by this account (for example, 'eip155' or 'solana')."}
+  ];
   // TODO(tim): temporarily removing this since it's always "false"
   //bool exported = 12 [
   //  (google.api.field_behavior) = REQUIRED,

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -189,6 +189,7 @@ enum ActivityType {
   ACTIVITY_TYPE_EXECUTE_SWAP_V2 = 160;
   ACTIVITY_TYPE_CREATE_SWAP_QUOTE = 161;
   ACTIVITY_TYPE_IMPORT_SECRETS = 162;
+  ACTIVITY_TYPE_EXPORT_SECRETS = 163;
 }
 
 // The current processing status of an Activity.
@@ -382,6 +383,7 @@ message Intent {
     ExecuteSwapIntentV2 execute_swap_intent_v2 = 161;
     CreateSwapQuoteIntent create_swap_quote_intent = 162;
     ImportSecretsIntent import_secrets_intent = 163;
+    ExportSecretsIntent export_secrets_intent = 164;
   }
   reserved 148;
   reserved "upsert_earn_client_fee_config_intent";
@@ -3584,11 +3586,11 @@ message OtpLoginIntentV2 {
 }
 
 message InitOtpAuthIntent {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Enum to specify whether to send OTP via SMS or email"
+      description: "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
       title: ""
     }
   ];
@@ -3641,11 +3643,11 @@ message InitOtpAuthIntent {
 }
 
 message InitOtpIntent {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+      description: "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
       title: ""
     }
   ];
@@ -3720,11 +3722,11 @@ message InitOtpIntent {
 }
 
 message InitOtpIntentV2 {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+      description: "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
       title: ""
     }
   ];
@@ -3805,11 +3807,11 @@ message InitOtpIntentV2 {
 }
 
 message InitOtpIntentV3 {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+      description: "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
       title: ""
     }
   ];
@@ -3891,11 +3893,11 @@ message InitOtpIntentV3 {
 }
 
 message InitOtpAuthIntentV2 {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Enum to specify whether to send OTP via SMS or email"
+      description: "Enum to specify whether to send OTP via SMS, email, or WhatsApp"
       title: ""
     }
   ];
@@ -3964,11 +3966,11 @@ message InitOtpAuthIntentV2 {
 }
 
 message InitOtpAuthIntentV3 {
-  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL"
+  // @inject_tag: validate:"required,oneof=OTP_TYPE_SMS OTP_TYPE_EMAIL OTP_TYPE_WHATSAPP"
   string otp_type = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Whether to send OTP via SMS or email. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL"
+      description: "Whether to send OTP via SMS, email, or WhatsApp. Possible values: OTP_TYPE_SMS, OTP_TYPE_EMAIL, OTP_TYPE_WHATSAPP"
       title: ""
     }
   ];
@@ -5310,6 +5312,7 @@ message Result {
     EthUndelegate7702Result eth_undelegate7702_result = 141;
     CreateSwapQuoteResult create_swap_quote_result = 142;
     ImportSecretsResult import_secrets_result = 143;
+    ExportSecretsResult export_secrets_result = 144;
   }
   reserved 127;
   reserved "upsert_earn_client_fee_config_result";
@@ -6330,7 +6333,7 @@ message SwapQuote {
   reserved 6;
   optional string slippage_bps = 7 [
     (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Provider-neutral maximum allowed slippage in basis points, echoed from the quote request when set."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Effective total slippage tolerance in basis points for this quote, taken from the provider response when present. When the request omits input slippage_bps, the provider may calculate this value."}
   ];
   string client_fee_bps = 8 [
     (google.api.field_behavior) = REQUIRED,
@@ -7576,6 +7579,39 @@ message ImportSecretsResult {
   repeated string secret_ids = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for each imported secret, in the order the params were specified."}
+  ];
+}
+
+message ExportSecretsIntent {
+  repeated ExportSecretParams secrets = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "A list of secrets to export."}
+  ];
+}
+
+message ExportSecretParams {
+  // @inject_tag: validate:"required,uuid"
+  string secret_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for the secret to export."}
+  ];
+
+  // @inject_tag: validate:"hexadecimal"
+  string target_public_key = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Client-side public key generated by the user, to which the exported secret will be encrypted."}
+  ];
+
+  immutable.models.v1.TransportEncryptionSuite encryption_suite = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Transport encryption suite used for the exported secret."}
+  ];
+}
+
+message ExportSecretsResult {
+  repeated string secret_payloads = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Encryption suite specific payload containing each secret ciphertext, in the order the params were specified. For enclave encrypt v1 each entry is a JSON-encoded ServerSendMsg."}
   ];
 }
 

--- a/proto/services/coordinator/public/v1/public_api.proto
+++ b/proto/services/coordinator/public/v1/public_api.proto
@@ -15,6 +15,7 @@ import "external/options/v1/options.proto";
 import "external/webauthn/v1/webauthn.proto";
 import "immutable/activity/v1/activity.proto";
 import "immutable/data/v1/earn.proto";
+import "immutable/models/v1/models.proto";
 import "immutable/sdk_models/v1/models.proto";
 import "vendor/google/api/annotations.proto";
 import "vendor/google/api/field_behavior.proto";
@@ -1091,7 +1092,7 @@ service PublicApiService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "List all accounts within a wallet."
-      summary: "List wallets accounts"
+      summary: "List wallet accounts"
       tags: "Wallets"
     };
   }
@@ -1841,7 +1842,6 @@ service PublicApiService {
   }
 
   rpc CreateSwapQuote(external.activity.v1.CreateSwapQuoteRequest) returns (ActivityResponse) {
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/submit/create_swap_quote"
       body: "*"
@@ -1866,7 +1866,6 @@ service PublicApiService {
   }
 
   rpc ExecuteSwap(external.activity.v1.ExecuteSwapRequest) returns (ActivityResponse) {
-    option (google.api.method_visibility).restriction = "INTERNAL";
     option (google.api.http) = {
       post: "/public/v1/submit/execute_swap"
       body: "*"
@@ -2043,6 +2042,18 @@ service PublicApiService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Validate a container image URL and pull secret for TVC deployment"
       summary: "Validate Container Image for TVC"
+      tags: "TVC"
+    };
+  }
+
+  rpc GetTvcQosVersions(GetTvcQosVersionsRequest) returns (GetTvcQosVersionsResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/query/get_tvc_qos_versions"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "List QOS versions supported for new TVC deployments and the latest recommended QOS version."
+      summary: "Get TVC QOS versions"
       tags: "TVC"
     };
   }
@@ -2230,6 +2241,30 @@ service PublicApiService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       description: "Import secrets encrypted to target keys returned from InitImportSecrets."
       summary: "Import secrets"
+      tags: "Secrets"
+    };
+  }
+
+  rpc ExportSecrets(external.activity.v1.ExportSecretsRequest) returns (ActivityResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/submit/export_secrets"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "Export secrets encrypted to client-provided target public keys."
+      summary: "Export secrets"
+      tags: "Secrets"
+    };
+  }
+
+  rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
+    option (google.api.http) = {
+      post: "/public/v1/query/list_secrets"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      description: "List secret metadata for an organization."
+      summary: "List secrets"
       tags: "Secrets"
     };
   }
@@ -3145,15 +3180,15 @@ message GetSwapStatusRequest {
 message SwapRefund {
   string asset = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "CAIP-19 asset returned to the user after a failed swap."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "CAIP-19 asset returned by the swap provider after a failed cross-chain fill."}
   ];
   string amount = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Base-unit amount of the refunded asset."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Base-unit amount returned by the swap provider."}
   ];
   optional string tx_hash = 3 [
     (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Transaction that delivered the refunded funds, when applicable."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Transaction that delivered the provider refund, when applicable."}
   ];
 }
 
@@ -3169,6 +3204,10 @@ message SwapError {
   optional TxError origin_tx_error = 3 [
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Origin-chain transaction failure details, present when reason is ORIGIN_TRANSACTION_FAILED and details are available."}
+  ];
+  optional string provider_reason = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional detail from the swap provider about why the fill did not complete, when available."}
   ];
 }
 
@@ -3211,7 +3250,7 @@ message GetSwapStatusResponse {
   ];
   optional SwapRefund refund = 10 [
     (google.api.field_behavior) = OPTIONAL,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Asset and amount returned to the user after a failed swap, when recoverable. Present only on FAILED."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Funds returned by the provider after a successful origin transfer and failed cross-chain fill. Omitted for origin transaction failures and same-chain swaps."}
   ];
   reserved 11, 12, 13;
   string updated_at = 14 [
@@ -3280,6 +3319,7 @@ message ListEarnEnabledVaultsRequest {
   ];
   immutable.data.v1.EarnProvider provider = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional filter: only return enabled vaults from this provider. Leave EARN_PROVIDER_UNSPECIFIED to return all providers."}];
   optional string caip19 = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional filter: only return enabled vaults whose underlying asset matches this CAIP-19 asset ID (e.g. 'eip155:8453/erc20:0x833589...'). The chain is taken from the CAIP-19 identifier."}];
+  bool include_exposure = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "When true, populate each vault's exposures (the underlying markets it allocates into). This costs an extra provider query per vault, so leave it off for list views."}];
 }
 
 message ListEarnEnabledVaultsResponse {
@@ -3623,13 +3663,17 @@ message GetTvcDeploymentProvisioningDetailsRequest {
 }
 
 message GetTvcDeploymentProvisioningDetailsResponse {
-  bytes attestation_document = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The attestation document of the provisioning enclave in a TVC deployment."}
+  optional bytes attestation_document = 1 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The attestation document of the provisioning enclave. Present only when a deployment is awaiting provisioning."}
   ];
-  bytes manifest_envelope = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The manifest envelope containing the TVC deployment's manifest and signatures."}
+  optional bytes manifest_envelope = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The manifest envelope containing the TVC deployment's manifest and signatures. Present only when a deployment is awaiting provisioning."}
+  ];
+  optional external.data.v1.ProvisioningState provisioning_state = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Current provisioning state."}
   ];
 }
 
@@ -4008,6 +4052,45 @@ message EmailEventDetails {
   ];
 }
 
+message ListSecretsRequest {
+  string organization_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for the organization or sub-organization whose secrets are listed."}
+  ];
+  external.options.v1.Pagination pagination_options = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Parameters used for cursor-based pagination."}
+  ];
+}
+
+message ListSecretsResponse {
+  repeated SecretMetadata secrets = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Metadata for each secret in the organization, ordered by most recently created first."}
+  ];
+}
+
+// Metadata view of a secret. Excludes the encrypted payload and
+// cryptographic material.
+message SecretMetadata {
+  string secret_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for the secret."}
+  ];
+  optional string name = 2 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional human-readable name for the secret."}
+  ];
+  repeated immutable.models.v1.KeyValue static_properties = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Policy visible static properties bound to the secret at creation time."}
+  ];
+  uint64 created_at_unix_ms = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unix timestamp in milliseconds for when the secret was created."}
+  ];
+}
+
 message ListEthTransactionHistoryRequest {
   string organization_id = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -4284,5 +4367,23 @@ message TransactionHistoryTurnkey {
   string submitted_at = 3 [
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Timestamp when Turnkey submitted the transaction, in RFC 3339 format."}
+  ];
+}
+
+message GetTvcQosVersionsRequest {
+  string organization_id = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Unique identifier for a given Organization."}
+  ];
+}
+
+message GetTvcQosVersionsResponse {
+  repeated string available_versions = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "QOS versions supported for new TVC deployments."}
+  ];
+  string latest_version = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Latest recommended QOS version for new TVC deployments."}
   ];
 }

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -249,7 +249,13 @@ fn classify_turnkey_client_error(error: &TurnkeyClientError) -> Classification {
         | TurnkeyClientError::MissingActivity
         | TurnkeyClientError::MissingResult
         | TurnkeyClientError::MissingInnerResult
-        | TurnkeyClientError::ExceededRetries(_) => Classification::new(ErrorCode::ApiError, None),
+        | TurnkeyClientError::ExceededRetries(_)
+        | TurnkeyClientError::MissingSecretResult(_)
+        | TurnkeyClientError::SecretPayloadCountMismatch { .. }
+        | TurnkeyClientError::SecretFingerprintMismatch { .. }
+        | TurnkeyClientError::InvalidSecretUtf8(_) => {
+            Classification::new(ErrorCode::ApiError, None)
+        }
         // These failures happen while configuring the client or constructing
         // and signing the request, before a usable API response is available.
         // A reqwest error that is not request/connect/timeout-related also
@@ -258,6 +264,8 @@ fn classify_turnkey_client_error(error: &TurnkeyClientError) -> Classification {
         | TurnkeyClientError::ReqwestBuilder(_)
         | TurnkeyClientError::Http(_)
         | TurnkeyClientError::SerdeJsonFailure(_)
+        | TurnkeyClientError::EnclaveEncrypt(_)
+        | TurnkeyClientError::MalformedSecretsProposal(_)
         | TurnkeyClientError::StamperError(_) => Classification::new(ErrorCode::CommandError, None),
     }
 }

--- a/tvc/src/provisioning.rs
+++ b/tvc/src/provisioning.rs
@@ -95,14 +95,17 @@ fn provisioning_details_from_response(
     let GetTvcDeploymentProvisioningDetailsResponse {
         attestation_document,
         manifest_envelope,
+        provisioning_state: _,
     } = response;
 
-    if attestation_document.is_empty() {
-        bail!("attestation document missing in provisioning details response");
-    }
-    if manifest_envelope.is_empty() {
-        bail!("manifest envelope missing in provisioning details response");
-    }
+    let attestation_document = match attestation_document {
+        Some(attestation_document) if !attestation_document.is_empty() => attestation_document,
+        _ => bail!("attestation document missing in provisioning details response"),
+    };
+    let manifest_envelope = match manifest_envelope {
+        Some(manifest_envelope) if !manifest_envelope.is_empty() => manifest_envelope,
+        _ => bail!("manifest envelope missing in provisioning details response"),
+    };
 
     let manifest_envelope = VersionedManifestEnvelope::try_from_slice_compat(&manifest_envelope)
         .context("failed to parse manifest envelope from provisioning details")?;
@@ -352,8 +355,9 @@ mod tests {
     fn provisioning_response_parses_complete_details() {
         let manifest_envelope = sample_manifest_envelope();
         let response = GetTvcDeploymentProvisioningDetailsResponse {
-            attestation_document: vec![1, 2, 3],
-            manifest_envelope: manifest_envelope.to_storage_vec().unwrap(),
+            attestation_document: Some(vec![1, 2, 3]),
+            manifest_envelope: Some(manifest_envelope.to_storage_vec().unwrap()),
+            provisioning_state: None,
         };
         let expected = FetchedProvisioningDetails::new(
             deployment_id(),
@@ -371,8 +375,9 @@ mod tests {
     fn provisioning_response_rejects_missing_fields() {
         let manifest_envelope = sample_manifest_envelope().to_storage_vec().unwrap();
         let missing_attestation = GetTvcDeploymentProvisioningDetailsResponse {
-            attestation_document: Vec::new(),
-            manifest_envelope: manifest_envelope.clone(),
+            attestation_document: None,
+            manifest_envelope: Some(manifest_envelope.clone()),
+            provisioning_state: None,
         };
         assert_eq!(
             provisioning_details_from_response(deployment_id(), missing_attestation, 1234)
@@ -382,8 +387,9 @@ mod tests {
         );
 
         let missing_manifest = GetTvcDeploymentProvisioningDetailsResponse {
-            attestation_document: vec![1, 2, 3],
-            manifest_envelope: Vec::new(),
+            attestation_document: Some(vec![1, 2, 3]),
+            manifest_envelope: Some(Vec::new()),
+            provisioning_state: None,
         };
         assert_eq!(
             provisioning_details_from_response(deployment_id(), missing_manifest, 1234)
@@ -396,8 +402,9 @@ mod tests {
     #[test]
     fn provisioning_response_rejects_malformed_manifest_envelope() {
         let response = GetTvcDeploymentProvisioningDetailsResponse {
-            attestation_document: vec![1, 2, 3],
-            manifest_envelope: vec![4, 5, 6],
+            attestation_document: Some(vec![1, 2, 3]),
+            manifest_envelope: Some(vec![4, 5, 6]),
+            provisioning_state: None,
         };
 
         let error =


### PR DESCRIPTION
## Summary

Adds high-level Secrets API parity with [JS SDK PR #1479](https://github.com/tkhq/sdk/pull/1479):

- import UTF-8 secret material through signed organization-scoped ingress targets
- list generated secret metadata
- export a secret unilaterally by polling the activity ID returned from submission
- prepare, share, submit, and await canonical multi-party export proposals
- retain fingerprint-based activity discovery as an explicit fallback for participants that did not submit

This PR is stacked on [Rust SDK PR #244](https://github.com/tkhq/rust-sdk/pull/244), which provides the generated Secrets proto surface.

## Implementation notes

- stamps and posts canonical proposal bytes without reserialization
- validates proposal type, organization, secret cardinality, canonical encoding, and `sha256:<hex>` fingerprint
- validates response fingerprints and completed payload cardinality before decryption
- keeps the zeroizing recipient key for one export batch and consumes it for batch decryption
- includes compatibility coverage for a production payload fixture captured by JS SDK PR #1479
- adds structured client errors and explicit TVC error-taxonomy mappings

## Validation

- `RUSTUP_TOOLCHAIN=1.94 make check-generate`
- `RUSTUP_TOOLCHAIN=1.94 make lint`
- `RUSTUP_TOOLCHAIN=1.94 make test`
- `RUSTUP_TOOLCHAIN=1.94 make examples`: locked workspace build succeeds; live `whoami` execution stops because local `TURNKEY_API_PUBLIC_KEY` credentials are not configured

The stacked base does not trigger this repository's `main`-targeted PR workflow. After #244 merges, this should be rebased and retargeted to `main` for normal CI.

Review walkthrough: [Reviews packet](https://reviews.figitaki.dev/r/7Kl6p4Y3)
