### PR TITLE
feat(client): minimal singular import_secret / export_secret wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,8 +4179,10 @@ version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "hex",
  "http 0.2.12",
  "mime",
+ "p256 0.13.2",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "reqwest",
@@ -4190,6 +4192,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "turnkey_api_key_stamper",
+ "turnkey_enclave_encrypt",
  "wiremock",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["turnkey", "api", "client", "cryptography"]
 categories = ["api-bindings"]
 
 [dependencies]
+hex.workspace = true
 mime.workspace = true
 chrono.workspace = true
 prost.workspace = true
@@ -23,6 +24,7 @@ serde_with.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 turnkey_api_key_stamper.workspace = true
+turnkey_enclave_encrypt.workspace = true
 
 [features]
 reqwest_native_tls = ["reqwest/native-tls-vendored", "reqwest/native-tls-alpn"]
@@ -34,3 +36,5 @@ reqwest_hickory_dns = ["reqwest/hickory-dns"]
 wiremock.workspace = true
 http.workspace = true
 base64.workspace = true
+hex.workspace = true
+p256 = { workspace = true, features = ["ecdsa", "std"] }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -495,15 +495,13 @@ impl<S: Stamp> TurnkeyClient<S> {
         static_properties: BTreeMap<String, String>,
         signer_quorum_public_key: &QuorumPublicKey,
     ) -> Result<ActivityResult<String>, TurnkeyClientError> {
-        let timestamp_ms = self.current_timestamp();
-
         // `init_import_secrets` is marked INTERNAL in the proto and has no
         // generated client method; submit it directly through `process_activity`.
         let init_activity = self
             .process_activity(
                 generated::external::activity::v1::InitImportSecretsRequest {
                     r#type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS".to_string(),
-                    timestamp_ms: timestamp_ms.to_string(),
+                    timestamp_ms: self.current_timestamp().to_string(),
                     organization_id: organization_id.clone(),
                     parameters: Some(InitImportSecretsIntent {
                         encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
@@ -534,8 +532,11 @@ impl<S: Stamp> TurnkeyClient<S> {
         // `encrypt_secret_bundle` verifies the quorum signature over the target
         // and encrypts to it.
         let target_data = target_data(&target)?;
-        let secret_payload = ImportClient::new(signer_quorum_public_key)
-            .encrypt_secret_bundle(&plaintext, &target, &organization_id)?;
+        let secret_payload = ImportClient::new(signer_quorum_public_key).encrypt_secret_bundle(
+            &plaintext,
+            &target,
+            &organization_id,
+        )?;
         let target_public_key = hex::encode(*target_data.target_public);
 
         let static_properties = static_properties
@@ -546,7 +547,7 @@ impl<S: Stamp> TurnkeyClient<S> {
         let batch = self
             .import_secrets(
                 organization_id,
-                timestamp_ms,
+                self.current_timestamp(),
                 ImportSecretsIntent {
                     secrets: vec![ImportSecretParams {
                         name,
@@ -570,6 +571,10 @@ impl<S: Stamp> TurnkeyClient<S> {
 
     /// Exports secrets and returns their decrypted UTF-8 plaintexts, in the
     /// order of `secret_ids`.
+    ///
+    /// Takes a slice so that any number of secrets exports in a single
+    /// activity. The singular name is only because `export_secrets` is the
+    /// generated method this one is built on.
     pub async fn export_secret(
         &self,
         organization_id: String,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::StatusCode;
@@ -10,10 +11,21 @@ use thiserror::Error;
 use generated::Activity;
 use generated::ActivityResponse;
 use generated::ActivityStatus;
+use generated::ExportSecretParams;
+use generated::ExportSecretsIntent;
+use generated::ImportSecretParams;
+use generated::ImportSecretsIntent;
+use generated::InitImportSecretsIntent;
 use generated::external::data::v1::AppProof;
 use generated::google::rpc::Status;
+use generated::immutable::models::v1::{KeyValue, TransportEncryptionSuite};
+use generated::result::Inner as ActivityResultInner;
 
 use turnkey_api_key_stamper::{Stamp, StampHeader, StamperError};
+use turnkey_enclave_encrypt::errors::EnclaveEncryptError;
+use turnkey_enclave_encrypt::{
+    ExportClient, ImportClient, QuorumPublicKey, ServerTargetData, ServerTargetMsgV1,
+};
 
 /// Result of an activity request, containing both the typed result and activity metadata.
 ///
@@ -137,6 +149,15 @@ pub enum TurnkeyClientError {
 
     #[error("Stamper error")]
     StamperError(#[from] StamperError),
+
+    #[error("Expected exactly one {0} in the activity result, got {1}")]
+    UnexpectedSingletonCount(&'static str, usize),
+
+    #[error("Expected {1} {0} in the activity result, got {2}")]
+    UnexpectedResultCount(&'static str, usize, usize),
+
+    #[error("Enclave-encrypt failure while handling a secret: {0}")]
+    EnclaveEncrypt(#[from] EnclaveEncryptError),
 }
 
 /// Builder for [`TurnkeyClient<S>`].
@@ -462,6 +483,170 @@ impl<S: Stamp> TurnkeyClient<S> {
 
         Ok(response)
     }
+}
+
+impl<S: Stamp> TurnkeyClient<S> {
+    /// Imports one UTF-8 secret and returns the created secret ID.
+    pub async fn import_secret(
+        &self,
+        organization_id: String,
+        name: Option<String>,
+        plaintext: String,
+        static_properties: BTreeMap<String, String>,
+        signer_quorum_public_key: &QuorumPublicKey,
+    ) -> Result<ActivityResult<String>, TurnkeyClientError> {
+        let timestamp_ms = self.current_timestamp();
+
+        // `init_import_secrets` is marked INTERNAL in the proto and has no
+        // generated client method; submit it directly through `process_activity`.
+        let init_activity = self
+            .process_activity(
+                generated::external::activity::v1::InitImportSecretsRequest {
+                    r#type: "ACTIVITY_TYPE_INIT_IMPORT_SECRETS".to_string(),
+                    timestamp_ms: timestamp_ms.to_string(),
+                    organization_id: organization_id.clone(),
+                    parameters: Some(InitImportSecretsIntent {
+                        encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                        num_secrets: 1,
+                    }),
+                },
+                "/public/v1/submit/init_import_secrets".to_string(),
+            )
+            .await?;
+        let init_result = match init_activity
+            .result
+            .ok_or(TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or(TurnkeyClientError::MissingInnerResult)?
+        {
+            ActivityResultInner::InitImportSecretsResult(inner) => inner,
+            other => {
+                return Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                    serde_json::to_string(&other)?,
+                ));
+            }
+        };
+        let target = exactly_one(
+            init_result.enclave_target_messages,
+            "init import target message",
+        )?;
+
+        // `encrypt_wallet_with_bundle` verifies the quorum signature over the
+        // target and encrypts to it. The user ID in a secrets ingress target is
+        // always empty: the flow is scoped to the organization, not to a user.
+        let target_data = target_data(&target)?;
+        let secret_payload = ImportClient::new(signer_quorum_public_key)
+            .encrypt_wallet_with_bundle(&plaintext, &target, &organization_id, "")?;
+        let target_public_key = hex::encode(*target_data.target_public);
+
+        let static_properties = static_properties
+            .into_iter()
+            .map(|(key, value)| KeyValue { key, value })
+            .collect();
+
+        let batch = self
+            .import_secrets(
+                organization_id,
+                timestamp_ms,
+                ImportSecretsIntent {
+                    secrets: vec![ImportSecretParams {
+                        name,
+                        secret_payload,
+                        target_public_key,
+                        encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                        static_properties,
+                    }],
+                },
+            )
+            .await?;
+
+        let secret_id = exactly_one(batch.result.secret_ids, "imported secret ID")?;
+        Ok(ActivityResult {
+            result: secret_id,
+            activity_id: batch.activity_id,
+            status: batch.status,
+            app_proofs: batch.app_proofs,
+        })
+    }
+
+    /// Exports secrets and returns their decrypted UTF-8 plaintexts, in the
+    /// order of `secret_ids`.
+    pub async fn export_secret(
+        &self,
+        organization_id: String,
+        secret_ids: &[impl AsRef<str>],
+        signer_quorum_public_key: &QuorumPublicKey,
+    ) -> Result<ActivityResult<Vec<String>>, TurnkeyClientError> {
+        let timestamp_ms = self.current_timestamp();
+
+        let mut recipients = Vec::with_capacity(secret_ids.len());
+        let mut secrets = Vec::with_capacity(secret_ids.len());
+        for secret_id in secret_ids {
+            let recipient = ExportClient::new(signer_quorum_public_key);
+            secrets.push(ExportSecretParams {
+                secret_id: secret_id.as_ref().to_string(),
+                target_public_key: recipient.target_public_key()?,
+                encryption_suite: TransportEncryptionSuite::EnclaveEncryptV1,
+                request_context: Vec::new(),
+            });
+            recipients.push(recipient);
+        }
+
+        let batch = self
+            .export_secrets(
+                organization_id.clone(),
+                timestamp_ms,
+                ExportSecretsIntent { secrets },
+            )
+            .await?;
+
+        let secret_payloads = batch.result.secret_payloads;
+        if secret_payloads.len() != secret_ids.len() {
+            return Err(TurnkeyClientError::UnexpectedResultCount(
+                "exported secret payloads",
+                secret_ids.len(),
+                secret_payloads.len(),
+            ));
+        }
+
+        let plaintexts = secret_payloads
+            .into_iter()
+            .zip(&mut recipients)
+            .map(|(payload, recipient)| {
+                // Secret payloads are enclave-signed bundles over UTF-8 bytes,
+                // the same shape a wallet export bundle carries.
+                recipient.decrypt_wallet_mnemonic_phrase(payload, &organization_id)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ActivityResult {
+            result: plaintexts,
+            activity_id: batch.activity_id,
+            status: batch.status,
+            app_proofs: batch.app_proofs,
+        })
+    }
+}
+
+/// Reads the signed data out of an enclave ingress bundle.
+fn target_data(bundle: &str) -> Result<ServerTargetData, TurnkeyClientError> {
+    let msg: ServerTargetMsgV1 = serde_json::from_str(bundle)?;
+    Ok(serde_json::from_slice(&msg.data)?)
+}
+
+fn exactly_one<T>(items: Vec<T>, label: &'static str) -> Result<T, TurnkeyClientError> {
+    let mut iter = items.into_iter();
+    let value = iter
+        .next()
+        .ok_or(TurnkeyClientError::UnexpectedSingletonCount(label, 0))?;
+    let extra = iter.count();
+    if extra > 0 {
+        return Err(TurnkeyClientError::UnexpectedSingletonCount(
+            label,
+            1 + extra,
+        ));
+    }
+    Ok(value)
 }
 
 #[cfg(test)]
@@ -1064,6 +1249,181 @@ mod test {
             .await
             .unwrap();
         assert_eq!(res.activity.unwrap().id, "some-activity-id".to_string());
+    }
+
+    mod secrets {
+        use super::*;
+        use crate::generated::ExportSecretsRequest;
+        use p256::ecdsa::SigningKey;
+        use turnkey_enclave_encrypt::server::EnclaveEncryptServer;
+        use turnkey_enclave_encrypt::{P256Public, QuorumPublicKey};
+        use wiremock::matchers::path;
+
+        fn test_quorum_private_key() -> SigningKey {
+            SigningKey::from_slice(
+                &hex::decode("28ebf311b27f34cdf078489584d336423e09c522342f5b067dea36823c2cc5ed")
+                    .unwrap(),
+            )
+            .unwrap()
+        }
+
+        fn test_quorum_public_key() -> QuorumPublicKey {
+            QuorumPublicKey::from_string(concat!(
+                "04",
+                "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899",
+                "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa",
+                "04",
+                "8ee67fa8ae8e5fac0e343c84fa0921ecb3a31a67aee2e6a0880a09072eaaf2ae",
+                "ffa43f73fa021fa4d0b550072ba1f9011ff7cf917e4bf2708670e5ac57a81c78",
+            ))
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn import_secret_runs_init_encrypt_and_import() {
+            let (client, server) = setup_client_and_server().await;
+
+            let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+                test_quorum_private_key(),
+                "org-1".to_string(),
+                Some(String::new()),
+            );
+            let target = serde_json::to_string(&enclave.publish_target().unwrap()).unwrap();
+
+            Mock::given(method("POST"))
+                .and(path("/public/v1/submit/init_import_secrets"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "activity": {
+                        "type": "ACTIVITY_TYPE_INIT_IMPORT_SECRETS",
+                        "status": "ACTIVITY_STATUS_COMPLETED",
+                        "id": "activity-init",
+                        "organizationId": "org-1",
+                        "fingerprint": "fingerprint",
+                        "result": {
+                            "initImportSecretsResult": {
+                                "enclaveTargetMessages": [target],
+                            }
+                        }
+                    }
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            Mock::given(method("POST"))
+                .and(path("/public/v1/submit/import_secrets"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "activity": {
+                        "type": "ACTIVITY_TYPE_IMPORT_SECRETS",
+                        "status": "ACTIVITY_STATUS_COMPLETED",
+                        "id": "activity-import",
+                        "organizationId": "org-1",
+                        "fingerprint": "fingerprint",
+                        "result": {
+                            "importSecretsResult": {"secretIds": ["secret-abc"]}
+                        }
+                    }
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let mut static_properties = BTreeMap::new();
+            static_properties.insert("environment".to_string(), "production".to_string());
+
+            let result = client
+                .import_secret(
+                    "org-1".to_string(),
+                    Some("my-secret".to_string()),
+                    "super secret".to_string(),
+                    static_properties,
+                    &test_quorum_public_key(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.result, "secret-abc");
+
+            let requests = server.received_requests().await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+            let secret = &body["parameters"]["secrets"][0];
+            assert_eq!(
+                secret["targetPublicKey"],
+                hex::encode(*target_data(&target).unwrap().target_public)
+            );
+
+            // The enclave can decrypt what we sent it.
+            let payload = secret["secretPayload"].as_str().unwrap();
+            assert_eq!(
+                enclave
+                    .into_recv()
+                    .decrypt(&serde_json::from_str(payload).unwrap())
+                    .unwrap(),
+                b"super secret",
+            );
+        }
+
+        #[tokio::test]
+        async fn export_secret_decrypts_returned_payloads() {
+            let (client, server) = setup_client_and_server().await;
+
+            Mock::given(method("POST"))
+                .and(path("/public/v1/submit/export_secrets"))
+                .respond_with(|request: &wiremock::Request| {
+                    let export_request: ExportSecretsRequest =
+                        serde_json::from_slice(&request.body).unwrap();
+                    let secrets = export_request.parameters.unwrap().secrets;
+                    assert_eq!(secrets[0].secret_id, "secret-abc");
+                    assert_eq!(secrets[1].secret_id, "secret-def");
+                    // Each secret must get its own one-shot target key.
+                    assert_ne!(secrets[0].target_public_key, secrets[1].target_public_key);
+
+                    let payloads: Vec<String> = secrets
+                        .iter()
+                        .zip([b"super secret".as_slice(), b"other secret".as_slice()])
+                        .map(|(secret, plaintext)| {
+                            let target: P256Public = hex::decode(&secret.target_public_key)
+                                .unwrap()
+                                .try_into()
+                                .unwrap();
+                            let enclave = EnclaveEncryptServer::from_enclave_auth_key(
+                                test_quorum_private_key(),
+                                "org-1".to_string(),
+                                None,
+                            );
+                            serde_json::to_string(&enclave.encrypt(&target, plaintext).unwrap())
+                                .unwrap()
+                        })
+                        .collect();
+
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                        "activity": {
+                            "type": "ACTIVITY_TYPE_EXPORT_SECRETS",
+                            "status": "ACTIVITY_STATUS_COMPLETED",
+                            "id": "activity-export",
+                            "organizationId": "org-1",
+                            "fingerprint": "fingerprint",
+                            "result": {
+                                "exportSecretsResult": {"secretPayloads": payloads},
+                            }
+                        }
+                    }))
+                })
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let result = client
+                .export_secret(
+                    "org-1".to_string(),
+                    &["secret-abc", "secret-def"],
+                    &test_quorum_public_key(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.result, vec!["super secret", "other secret"]);
+        }
     }
 
     mod retry {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -531,12 +531,11 @@ impl<S: Stamp> TurnkeyClient<S> {
             "init import target message",
         )?;
 
-        // `encrypt_wallet_with_bundle` verifies the quorum signature over the
-        // target and encrypts to it. The user ID in a secrets ingress target is
-        // always empty: the flow is scoped to the organization, not to a user.
+        // `encrypt_secret_bundle` verifies the quorum signature over the target
+        // and encrypts to it.
         let target_data = target_data(&target)?;
         let secret_payload = ImportClient::new(signer_quorum_public_key)
-            .encrypt_wallet_with_bundle(&plaintext, &target, &organization_id, "")?;
+            .encrypt_secret_bundle(&plaintext, &target, &organization_id)?;
         let target_public_key = hex::encode(*target_data.target_public);
 
         let static_properties = static_properties
@@ -612,11 +611,7 @@ impl<S: Stamp> TurnkeyClient<S> {
         let plaintexts = secret_payloads
             .into_iter()
             .zip(&mut recipients)
-            .map(|(payload, recipient)| {
-                // Secret payloads are enclave-signed bundles over UTF-8 bytes,
-                // the same shape a wallet export bundle carries.
-                recipient.decrypt_wallet_mnemonic_phrase(payload, &organization_id)
-            })
+            .map(|(payload, recipient)| recipient.decrypt_secret(payload, &organization_id))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(ActivityResult {

--- a/enclave_encrypt/src/client.rs
+++ b/enclave_encrypt/src/client.rs
@@ -164,6 +164,18 @@ impl ExportClient {
             .map_err(|e| EnclaveEncryptError::InvalidUtf8Bytes(e.to_string()))?;
         Ok(phrase.to_string())
     }
+
+    /// Decrypts a secret export bundle.
+    /// Bundles are JSON encoded strings, e.g. "{\"version\":\"v1.0.0\",\"data\":\"7b22656e63617070656450...\"}"
+    /// This function returns the secret as a string.
+    /// - `organization_id` is the expected organization ID. This will be checked against the content of the bundle.
+    pub fn decrypt_secret<S: AsRef<str>, T: AsRef<str>>(
+        &mut self,
+        export_bundle: S,
+        organization_id: T,
+    ) -> Result<String, EnclaveEncryptError> {
+        self.decrypt_wallet_mnemonic_phrase(export_bundle, organization_id)
+    }
 }
 
 /// Abstraction over `EnclaveEncryptClient` for private key or wallet import flows.
@@ -277,6 +289,26 @@ impl ImportClient {
 
         serde_json::to_string(&encrypted)
             .map_err(|e| EnclaveEncryptError::CannotSerializeBundle(e.to_string()))
+    }
+
+    /// Encrypts a secret to the public key contained in a secrets import bundle.
+    ///
+    /// - `secret` is the secret to import, as a string.
+    /// - `import_bundle` is the import bundle as a string. Bundles are JSON-encoded strings (e.g ""{\"version\":\"v1.0.0\", ....")
+    ///   bundles contain a signed public key. The signature over this public key is from Turnkey's signer enclave.
+    /// - `organization_id` is the expected organization ID. This will be checked against the content of the bundle, which contains the organization ID where the import flow started (`INIT_IMPORT_SECRETS` activity)
+    ///
+    /// Unlike wallet and private key imports, secrets ingress is scoped to the
+    /// organization rather than to the user who initiated it.
+    ///
+    /// Returns a string containing the JSON-encoded value, ready-to-use in an `IMPORT_SECRETS` activity
+    pub fn encrypt_secret_bundle<S: AsRef<str>, T: AsRef<str>, U: AsRef<str>>(
+        &mut self,
+        secret: S,
+        import_bundle: T,
+        organization_id: U,
+    ) -> Result<String, EnclaveEncryptError> {
+        self.encrypt_wallet_with_bundle(secret, import_bundle, organization_id, "")
     }
 }
 

--- a/examples/src/bin/secrets.rs
+++ b/examples/src/bin/secrets.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::error::Error;
+use turnkey_enclave_encrypt::QuorumPublicKey;
+use turnkey_examples::{load_api_key_from_env, load_base_url_from_env};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Load API key
+    let api_key = load_api_key_from_env()?;
+
+    // Get organization ID from env
+    let organization_id =
+        env::var("TURNKEY_ORGANIZATION_ID").expect("cannot load TURNKEY_ORGANIZATION_ID");
+
+    // Create our Turnkey client
+    let client = turnkey_client::TurnkeyClient::builder()
+        .api_key(api_key)
+        .base_url(load_base_url_from_env())
+        .build()?;
+
+    // Secrets are encrypted to a Turnkey enclave, so every call is checked
+    // against the signer's quorum public key.
+    let signer = QuorumPublicKey::production_signer();
+
+    // Static properties are plaintext metadata: policies can read them, the
+    // secret value itself stays encrypted end to end.
+    let mut static_properties = BTreeMap::new();
+    static_properties.insert("environment".to_string(), "demo".to_string());
+
+    // Secret names are unique within an organization, so stamp this run.
+    let run = client.current_timestamp();
+    let api_token = "sk-demo-0000000000";
+    let webhook_secret = "whsec-demo-1111111111";
+
+    // Import a secret. `import_secret` runs the whole flow: it initializes the
+    // import to get a signed enclave target, encrypts to it, and submits.
+    let api_token_id = client
+        .import_secret(
+            organization_id.clone(),
+            Some(format!("demo-api-token-{run}")),
+            api_token.to_string(),
+            static_properties.clone(),
+            &signer,
+        )
+        .await?
+        .result;
+
+    let webhook_secret_id = client
+        .import_secret(
+            organization_id.clone(),
+            Some(format!("demo-webhook-secret-{run}")),
+            webhook_secret.to_string(),
+            static_properties,
+            &signer,
+        )
+        .await?
+        .result;
+
+    println!("Imported secrets: {api_token_id}, {webhook_secret_id}");
+
+    // Export both in one activity. Plaintexts come back in the order the IDs
+    // were given, each decrypted with its own single-use transport key.
+    let plaintexts = client
+        .export_secret(
+            organization_id,
+            &[&api_token_id, &webhook_secret_id],
+            &signer,
+        )
+        .await?
+        .result;
+
+    // What came back out is what went in, in the order the IDs were given.
+    assert_eq!(plaintexts, vec![api_token, webhook_secret]);
+
+    for (secret_id, plaintext) in [&api_token_id, &webhook_secret_id].iter().zip(&plaintexts) {
+        println!("Exported {secret_id}: {plaintext}");
+    }
+
+    Ok(())
+}

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -252,6 +252,8 @@ fn classify_turnkey_client_error(error: &TurnkeyClientError) -> Classification {
         | TurnkeyClientError::ActivityFailed(_)
         | TurnkeyClientError::UnexpectedActivityStatus(_)
         | TurnkeyClientError::UnexpectedInnerActivityResult(_)
+        | TurnkeyClientError::UnexpectedSingletonCount(_, _)
+        | TurnkeyClientError::UnexpectedResultCount(_, _, _)
         | TurnkeyClientError::MissingActivity
         | TurnkeyClientError::MissingResult
         | TurnkeyClientError::MissingInnerResult
@@ -264,7 +266,10 @@ fn classify_turnkey_client_error(error: &TurnkeyClientError) -> Classification {
         | TurnkeyClientError::ReqwestBuilder(_)
         | TurnkeyClientError::Http(_)
         | TurnkeyClientError::SerdeJsonFailure(_)
-        | TurnkeyClientError::StamperError(_) => Classification::new(ErrorCode::CommandError, None),
+        | TurnkeyClientError::StamperError(_)
+        | TurnkeyClientError::EnclaveEncrypt(_) => {
+            Classification::new(ErrorCode::CommandError, None)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds two client methods for single-secret import and export. Each folds the whole flow into one call; callers pass only business inputs

Tested demo locally - requires secrets enabled for org since it is still in private beta.
