### PR TITLE
feat(tvc): add YubiKey as a default operator backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,7 @@ dependencies = [
  "assert_cmd",
  "aws-nitro-enclaves-nsm-api",
  "base64 0.22.1",
+ "borsh",
  "chrono",
  "clap",
  "displaydoc",

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -47,6 +47,8 @@ displaydoc = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 hpke = { workspace = true }
+# The software ECDH in the yubikey device fake.
+p256 = { workspace = true, features = ["ecdh"] }
 predicates = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 rexpect = { workspace = true }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { workspace = true }
 anstyle = { workspace = true }
 aws-nitro-enclaves-nsm-api = { workspace = true }
 base64 = { workspace = true }
+borsh = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 hex = { workspace = true }
@@ -37,7 +38,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
-tokio = { workspace = true, features = ["fs", "io-util"] }
+tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
 uuid = { workspace = true }
 zeroize = { workspace = true }
 tracing = { workspace = true }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -277,6 +277,7 @@ impl Commands {
                     args.run(ctx, config).await.map(Into::into)
                 }
                 KeysCommands::ProvisionYubikey(args) => args.run(ctx, config).await.map(Into::into),
+                KeysCommands::RefreshYubikey(args) => args.run(ctx, config).await.map(Into::into),
                 KeysCommands::DeleteYubikey(args) => args.run(ctx, config).await.map(Into::into),
                 KeysCommands::CreateQuorumKey(args) => {
                     commands::keys::create_quorum_key::run(ctx, args, config).await
@@ -442,6 +443,8 @@ enum KeysCommands {
     BackupOperatorKey(commands::keys::backup_operator_key::Args),
     /// Provision a YubiKey with the QuorumOS operator key pair and register its serial.
     ProvisionYubikey(commands::keys::provision_yubikey::Args),
+    /// Refresh the registry's cached operator key for a YubiKey from the device.
+    RefreshYubikey(commands::keys::refresh_yubikey::Args),
     /// Delete a registered YubiKey's QuorumOS key material and registry entry.
     DeleteYubikey(commands::keys::delete_yubikey::Args),
     /// Create a hosted quorum key encrypted to hosted operator keys.
@@ -472,6 +475,7 @@ impl KeysCommands {
         match self {
             KeysCommands::BackupOperatorKey(_) => "keys backup-operator-key",
             KeysCommands::ProvisionYubikey(_) => "keys provision-yubikey",
+            KeysCommands::RefreshYubikey(_) => "keys refresh-yubikey",
             KeysCommands::DeleteYubikey(_) => "keys delete-yubikey",
             KeysCommands::CreateQuorumKey(_) => "keys create-quorum-key",
             KeysCommands::GenerateLocalQuorumKey(_) => "keys generate-local-quorum-key",

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -14,6 +14,7 @@ use crate::{
     prompts::{self, bail_required_in_non_interactive, stdin_can_prompt},
     shell_print, shell_println,
     util::{read_file_to_string, write_file},
+    yubikey::{PcscDevices, pair::PinAcquisition},
 };
 use anyhow::{Context, bail};
 use clap::{ArgGroup, Args as ClapArgs};
@@ -138,6 +139,14 @@ impl Run for Args {
         )
         .await?;
 
+        // The only mode branch: whether a YubiKey PIN prompt is possible is
+        // this endpoint's knowledge; resolution just follows the policy.
+        let pin = if ctx.is_non_interactive() || !stdin_can_prompt() {
+            PinAcquisition::Unavailable
+        } else {
+            PinAcquisition::Prompt
+        };
+
         let inputs = ResolvedApproveInputs {
             manifest,
             operator_seed_source: args.operator_seed_source,
@@ -145,6 +154,7 @@ impl Run for Args {
             approval_out: args.approval_out,
             dry_run: args.dry_run,
             skip_post: args.skip_post,
+            pin,
             post_target,
             posted_approvals: fetched.map(|(_, approvals)| approvals).unwrap_or_default(),
         };
@@ -350,6 +360,7 @@ struct ResolvedApproveInputs<'a> {
     approval_out: Option<PathBuf>,
     dry_run: bool,
     skip_post: bool,
+    pin: PinAcquisition,
     post_target: Option<PostTarget>,
     /// Present only when the manifest came from a deployment fetch: the
     /// already-posted approvals, parsed at that boundary, for validation and
@@ -513,9 +524,11 @@ async fn run_with_resolved_inputs(
 
     let operator = resolve_operator(
         config,
+        PcscDevices,
         inputs.operator_seed_source,
         inputs.operator_id,
         requirement,
+        inputs.pin,
     )
     .await?;
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -7,7 +7,7 @@ use crate::{
     config::turnkey::Config,
     errors::MissingResource,
     local_operator_key::LocalOperatorSeedSource,
-    operator::{SignerRequirement, resolve_operator},
+    operator::SignerRequirement,
     outcome::Outcome,
     output::StdCtx,
     pair::HexSeed,
@@ -522,15 +522,15 @@ async fn run_with_resolved_inputs(
         SignerRequirement::Any
     };
 
-    let operator = resolve_operator(
-        config,
-        yubikey::open,
-        inputs.operator_seed_source,
-        inputs.operator_id,
-        requirement,
-        inputs.pin,
-    )
-    .await?;
+    let operator = config
+        .resolve_operator(
+            yubikey::open,
+            inputs.operator_seed_source,
+            inputs.operator_id,
+            requirement,
+            inputs.pin,
+        )
+        .await?;
 
     let approval = operator.approve_manifest(&inputs.manifest).await?;
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -14,7 +14,7 @@ use crate::{
     prompts::{self, bail_required_in_non_interactive, stdin_can_prompt},
     shell_print, shell_println,
     util::{read_file_to_string, write_file},
-    yubikey::{PcscDevices, pair::PinAcquisition},
+    yubikey::{self, pair::PinAcquisition},
 };
 use anyhow::{Context, bail};
 use clap::{ArgGroup, Args as ClapArgs};
@@ -524,7 +524,7 @@ async fn run_with_resolved_inputs(
 
     let operator = resolve_operator(
         config,
-        PcscDevices,
+        yubikey::open,
         inputs.operator_seed_source,
         inputs.operator_id,
         requirement,

--- a/tvc/src/commands/keys/mod.rs
+++ b/tvc/src/commands/keys/mod.rs
@@ -7,3 +7,4 @@ pub mod generate_local_quorum_key;
 pub mod init_local_quorum_key;
 pub mod provision_yubikey;
 pub mod re_encrypt_local_share;
+pub mod refresh_yubikey;

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -112,22 +112,25 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
         )?;
     }
 
-    let quorum_key_metadata: QuorumKeyMetadata =
-        read_json_file(&args.quorum_key_metadata, "quorum key metadata file").await?;
-    let provision_bundle: ProvisionBundle =
-        read_json_file(&args.provision_bundle, "provision bundle").await?;
-
     // The only mode branch: whether a YubiKey PIN prompt is possible is this
-    // endpoint's knowledge; resolution just follows the policy.
+    // endpoint's knowledge; selection and resolution just follow the policy.
     let pin = if ctx.is_non_interactive() || !stdin_can_prompt() {
         PinAcquisition::Unavailable
     } else {
         PinAcquisition::Prompt
     };
 
-    let operator_pair = config
-        .resolve_operator_pair(yubikey::open, operator_seed_source, pin)
-        .await?;
+    // Backend selection is deterministic from config and mode: an impossible
+    // run is refused before the input files are even read. Device access and
+    // the PIN prompt wait until the inputs are valid.
+    let pair_source = config.select_operator_pair_source(operator_seed_source, pin)?;
+
+    let quorum_key_metadata: QuorumKeyMetadata =
+        read_json_file(&args.quorum_key_metadata, "quorum key metadata file").await?;
+    let provision_bundle: ProvisionBundle =
+        read_json_file(&args.provision_bundle, "provision bundle").await?;
+
+    let operator_pair = pair_source.resolve(&config, yubikey::open).await?;
 
     let output = build_re_encrypted_share_output(
         &quorum_key_metadata,
@@ -256,7 +259,7 @@ mod tests {
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
     use crate::quorum_key_metadata::{EncryptedShareMetadata, QuorumKeyMetadata};
-    use crate::yubikey::pair::PinAcquisition;
+    use crate::yubikey::pair::AvailablePin;
     use crate::yubikey::test_support::{FakeDevice, PIN, serial};
     use crate::yubikey::{Pin, SlotStatus};
     use qos_core::protocol::services::boot::{
@@ -541,7 +544,7 @@ mod tests {
             .resolve_yubikey(
                 serial(),
                 device,
-                PinAcquisition::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap())),
+                AvailablePin::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap())),
             )
             .await
             .unwrap();

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -1,14 +1,16 @@
 //! Re-encrypt local share command.
 
-use crate::config::turnkey::{Config, SelectLocalOperatorError};
-use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
+use crate::config::turnkey::Config;
+use crate::local_operator_key::LocalOperatorSeedSource;
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
 use crate::pair::{HexSeed, Pair};
+use crate::prompts::stdin_can_prompt;
 use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
 use crate::shell_eprintln;
 use crate::util::{read_json_file, write_file};
+use crate::yubikey::{PcscDevices, pair::PinAcquisition};
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, QuorumMember, VersionedManifestEnvelope};
@@ -114,25 +116,23 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
         read_json_file(&args.quorum_key_metadata, "quorum key metadata file").await?;
     let provision_bundle: ProvisionBundle =
         read_json_file(&args.provision_bundle, "provision bundle").await?;
-    let operator_pair = resolve_local_operator(&config, operator_seed_source)
-        .await
-        .map_err(|error| {
-            // Decryption needs local key material a hosted-only org does not
-            // have; point at the hosted counterpart of this operation.
-            match error.downcast_ref::<SelectLocalOperatorError>() {
-                Some(SelectLocalOperatorError::NoLocalOperator) => error.context(
-                    "re-encrypting a local share needs the local operator key the share was \
-                     encrypted to; hosted operators re-encrypt through Turnkey with \
-                     `tvc deploy provision`",
-                ),
-                _ => error,
-            }
-        })?;
+
+    // The only mode branch: whether a YubiKey PIN prompt is possible is this
+    // endpoint's knowledge; resolution just follows the policy.
+    let pin = if ctx.is_non_interactive() || !stdin_can_prompt() {
+        PinAcquisition::Unavailable
+    } else {
+        PinAcquisition::Prompt
+    };
+
+    let operator_pair = config
+        .resolve_operator_pair(PcscDevices, operator_seed_source, pin)
+        .await?;
 
     let output = build_re_encrypted_share_output(
         &quorum_key_metadata,
         &provision_bundle,
-        &operator_pair,
+        operator_pair.as_ref(),
         args.dangerous_skip_verification,
     )
     .await?;
@@ -250,11 +250,15 @@ mod tests {
         ReEncryptedShareGenerated, ReEncryptedShareOutput, build_re_encrypted_share_output,
         ensure_quorum_key_matches_manifest, find_share_set_member,
     };
+    use crate::config::turnkey::Config;
     use crate::outcome::Outcome;
 
     use crate::pair::LocalPair;
     use crate::provisioning::ProvisionBundle;
     use crate::quorum_key_metadata::{EncryptedShareMetadata, QuorumKeyMetadata};
+    use crate::yubikey::pair::PinAcquisition;
+    use crate::yubikey::test_support::{FakeDevice, PIN, serial};
+    use crate::yubikey::{Pin, SlotStatus};
     use qos_core::protocol::services::boot::{
         Approval, Manifest, ManifestEnvelope, ManifestSet, Namespace, NitroConfig, PatchSet,
         PivotConfig, QuorumMember, RestartPolicy, ShareSet, VersionedManifestEnvelope,
@@ -507,6 +511,67 @@ mod tests {
             output.ephemeral_public_key_hex,
             hex::encode(ephemeral_pair.public_key().to_bytes())
         );
+        let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
+        let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
+        assert_eq!(decrypted_share.as_slice(), plaintext_share);
+        assert_eq!(output.share_approval.member, operator_member);
+
+        let approval_public_key =
+            P256Public::from_bytes(&output.share_approval.member.pub_key).unwrap();
+        approval_public_key
+            .verify(
+                &bundle.manifest_envelope().manifest_hash(),
+                &output.share_approval.signature,
+            )
+            .unwrap();
+    }
+
+    /// The full share flow against the device-backed pair: the share is
+    /// encrypted to the composite key, decrypted through the (fake) device's
+    /// key-agreement path, re-encrypted to the ephemeral key, and the
+    /// approval signed by the (fake) signing slot — pinning crypto-format
+    /// compatibility end to end.
+    #[tokio::test]
+    async fn re_encrypt_round_trip_with_a_yubikey_pair() {
+        let device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
+        let composite = device.operator_public_key();
+        let mut config = Config::default();
+        config.register_yubikey(serial(), composite);
+        let operator_pair = config
+            .resolve_yubikey(
+                serial(),
+                device,
+                PinAcquisition::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap())),
+            )
+            .await
+            .unwrap();
+
+        let operator_member = QuorumMember {
+            alias: "operator-1".to_string(),
+            pub_key: composite.as_bytes().to_vec(),
+        };
+        let quorum_pair = P256Pair::generate().unwrap();
+        let ephemeral_pair = P256Pair::generate().unwrap();
+        let plaintext_share = b"arbitrary test share bytes";
+        let composite_public = P256Public::from_bytes(composite.as_bytes()).unwrap();
+        let metadata = QuorumKeyMetadata {
+            quorum_key_public: hex::encode(quorum_pair.public_key().to_bytes()),
+            threshold: 1,
+            shares: vec![EncryptedShareMetadata {
+                operator_public_key: composite.to_string(),
+                share: hex::encode(composite_public.encrypt(plaintext_share).unwrap()),
+            }],
+        };
+        let bundle = bundle_with_ephemeral_key(
+            &ephemeral_pair.public_key(),
+            quorum_pair.public_key().to_bytes(),
+            vec![operator_member.clone()],
+        );
+
+        let output = build_re_encrypted_share_output(&metadata, &bundle, &operator_pair, true)
+            .await
+            .unwrap();
+
         let re_encrypted_share = hex::decode(&output.re_encrypted_share).unwrap();
         let decrypted_share = ephemeral_pair.decrypt(&re_encrypted_share).unwrap();
         assert_eq!(decrypted_share.as_slice(), plaintext_share);

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -10,7 +10,7 @@ use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
 use crate::shell_eprintln;
 use crate::util::{read_json_file, write_file};
-use crate::yubikey::{PcscDevices, pair::PinAcquisition};
+use crate::yubikey::{self, pair::PinAcquisition};
 use anyhow::{Context, anyhow};
 use clap::Args as ClapArgs;
 use qos_core::protocol::services::boot::{Approval, QuorumMember, VersionedManifestEnvelope};
@@ -126,7 +126,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
     };
 
     let operator_pair = config
-        .resolve_operator_pair(PcscDevices, operator_seed_source, pin)
+        .resolve_operator_pair(yubikey::open, operator_seed_source, pin)
         .await?;
 
     let output = build_re_encrypted_share_output(
@@ -536,7 +536,7 @@ mod tests {
         let device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
         let composite = device.operator_public_key();
         let mut config = Config::default();
-        config.register_yubikey(serial(), composite);
+        config.yubikeys.register(serial(), composite);
         let operator_pair = config
             .resolve_yubikey(
                 serial(),

--- a/tvc/src/commands/keys/re_encrypt_local_share.rs
+++ b/tvc/src/commands/keys/re_encrypt_local_share.rs
@@ -4,7 +4,7 @@ use crate::config::turnkey::{Config, SelectLocalOperatorError};
 use crate::local_operator_key::{LocalOperatorSeedSource, resolve_local_operator};
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
-use crate::pair::{HexSeed, LocalPair, Signer};
+use crate::pair::{HexSeed, Pair};
 use crate::provisioning::ProvisionBundle;
 use crate::quorum_key_metadata::QuorumKeyMetadata;
 use crate::shell_eprintln;
@@ -143,9 +143,9 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
 async fn build_re_encrypted_share_output(
     quorum_key_metadata: &QuorumKeyMetadata,
     provision_bundle: &ProvisionBundle,
-    // Concretely local: re-encryption decrypts the share, and decryption
-    // needs local key material.
-    operator_pair: &LocalPair,
+    // Re-encryption decrypts the share, so a [`Signer`] alone is not enough;
+    // the operator's key material must be able to decrypt.
+    operator_pair: &dyn Pair,
     dangerous_skip_verification: bool,
 ) -> anyhow::Result<ReEncryptedShareOutput> {
     ensure_quorum_key_matches_manifest(quorum_key_metadata, provision_bundle)?;
@@ -159,6 +159,7 @@ async fn build_re_encrypted_share_output(
     let re_encrypted_share = {
         let plaintext_share = operator_pair
             .decrypt(&encrypted_share)
+            .await
             .context("failed to decrypt share with operator key")?;
 
         ephemeral_public_key

--- a/tvc/src/commands/keys/refresh_yubikey.rs
+++ b/tvc/src/commands/keys/refresh_yubikey.rs
@@ -1,0 +1,129 @@
+//! YubiKey registry refresh command - re-reads a provisioned device's
+//! operator key and updates the cached registry entry.
+
+use crate::{
+    commands::Run,
+    config::turnkey::{
+        Config, QosOperatorPublicKey, Registration, YubiKeySerial, config_file_path,
+    },
+    outcome::Outcome,
+    output::StdCtx,
+    prompts,
+    yubikey::{self, DeviceOps},
+};
+use anyhow::{Context, Result, bail, ensure};
+use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
+
+/// Refresh the registry's cached operator key from the device itself.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Serial (hex) of the YubiKey to refresh.
+    /// Defaults to the sole connected device.
+    #[arg(long, value_name = "SERIAL")]
+    serial: Option<YubiKeySerial>,
+}
+
+impl Run for Args {
+    type Outcome = YubiKeyRefreshed;
+
+    async fn run(self, ctx: &mut StdCtx, mut config: Config) -> Result<YubiKeyRefreshed> {
+        let connected = ctx.connected_yubikeys()?;
+
+        let serial = match self.serial {
+            Some(serial) => {
+                ensure!(
+                    connected.contains(&serial),
+                    "YubiKey {serial} is not connected{}",
+                    connected_list(&connected)
+                );
+                serial
+            }
+            None => match connected.as_slice() {
+                [] => bail!("no YubiKey is connected"),
+                [sole] => *sole,
+                _ if ctx.is_non_interactive() || !prompts::stdin_can_prompt() => {
+                    return Err(prompts::error_required_in_non_interactive("--serial"));
+                }
+                _ => prompts::select("YubiKey to refresh", connected)?,
+            },
+        };
+
+        // Reading the slot certificates needs neither the PIN nor a touch,
+        // so the refresh itself also runs non-interactively.
+        let mut yubikey = yubikey::open(serial)?;
+        let operator_public_key = yubikey.verified_pair_public_key()?;
+        let registration = config.yubikeys.register(serial, operator_public_key);
+
+        if registration != Registration::Unchanged {
+            let config_path = config_file_path()?;
+            config.save().await.with_context(|| {
+                format!(
+                    r#"the key was read but saving the config failed; register it manually by adding this to {}:
+
+[[yubikeys]]
+serial = "{serial}"
+public_key = "{operator_public_key}""#,
+                    config_path.display(),
+                )
+            })?;
+        }
+
+        Ok(YubiKeyRefreshed {
+            serial,
+            operator_public_key,
+            registration,
+        })
+    }
+}
+
+/// Renders `; connected: a, b` for a mismatch error, or nothing when no
+/// device is present (the bare message already says it all).
+fn connected_list(connected: &[YubiKeySerial]) -> String {
+    if connected.is_empty() {
+        return String::new();
+    }
+
+    let serials: Vec<String> = connected.iter().map(ToString::to_string).collect();
+    format!("; connected: {}", serials.join(", "))
+}
+
+#[derive(Default, Serialize)]
+#[cfg_attr(test, derive(Debug))]
+#[serde(rename_all = "camelCase")]
+pub struct YubiKeyRefreshed {
+    serial: YubiKeySerial,
+    /// The composite `encrypt_public ‖ sign_public` operator key, as read
+    /// from the device.
+    operator_public_key: QosOperatorPublicKey,
+    /// How the registry changed: newly added, stale key refreshed, or
+    /// already current.
+    registration: Registration,
+}
+
+impl From<YubiKeyRefreshed> for Outcome {
+    fn from(refreshed: YubiKeyRefreshed) -> Self {
+        Outcome::YubikeyRefreshed(refreshed)
+    }
+}
+
+impl Display for YubiKeyRefreshed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let summary = match self.registration {
+            Registration::Added => "Serial was not yet registered - added it to the tvc config.",
+            Registration::Updated => "Registry entry refreshed - its cached public key was stale.",
+            Registration::Unchanged => "Registry already matches the device - nothing to update.",
+        };
+
+        write!(
+            f,
+            r#"{summary}
+
+Serial:              {}
+Operator public key: {}"#,
+            self.serial, self.operator_public_key
+        )
+    }
+}

--- a/tvc/src/commands/keys/refresh_yubikey.rs
+++ b/tvc/src/commands/keys/refresh_yubikey.rs
@@ -7,14 +7,15 @@ use crate::{
         Config, QosOperatorPublicKey, Registration, YubiKeySerial, config_file_path,
     },
     outcome::Outcome,
-    output::StdCtx,
+    output::{Ctx, StdCtx},
     prompts,
-    yubikey::{self, DeviceOps},
+    yubikey::{self, DeviceError, DeviceOps},
 };
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
+use std::io::Write;
 
 /// Refresh the registry's cached operator key from the device itself.
 #[derive(Debug, ClapArgs)]
@@ -30,15 +31,76 @@ impl Run for Args {
     type Outcome = YubiKeyRefreshed;
 
     async fn run(self, ctx: &mut StdCtx, mut config: Config) -> Result<YubiKeyRefreshed> {
+        let refreshed = self.refresh(ctx, yubikey::open, &mut config)?;
+
+        // Remediation renders from the typed registration outcome: a fresh
+        // serial is appended, a stale entry is edited in place.
+        let manual_fix = match refreshed.registration {
+            Registration::Unchanged => None,
+            Registration::Added => Some(format!(
+                r#"register it manually by adding this to {}:
+
+[[yubikeys]]
+serial = "{}"
+public_key = "{}""#,
+                config_file_path()?.display(),
+                refreshed.serial,
+                refreshed.operator_public_key,
+            )),
+            Registration::Updated => Some(format!(
+                r#"the cached key is stale; update the existing [[yubikeys]] entry for serial "{}" in {} to:
+
+public_key = "{}""#,
+                refreshed.serial,
+                config_file_path()?.display(),
+                refreshed.operator_public_key,
+            )),
+        };
+
+        if let Some(manual_fix) = manual_fix {
+            config.save().await.with_context(|| {
+                format!("the key was read but saving the config failed; {manual_fix}")
+            })?;
+        }
+
+        Ok(refreshed)
+    }
+}
+
+impl Args {
+    /// The command flow over scripted discovery, any device opener, and any
+    /// shell; [`Run::run`] supplies PC/SC and the real terminal, then
+    /// persists the config.
+    fn refresh<W, W2, D, O>(
+        self,
+        ctx: &mut Ctx<W, W2>,
+        open_device: O,
+        config: &mut Config,
+    ) -> Result<YubiKeyRefreshed>
+    where
+        W: Write,
+        W2: Write,
+        D: DeviceOps,
+        O: FnOnce(YubiKeySerial) -> Result<D, DeviceError>,
+    {
         let connected = ctx.connected_yubikeys()?;
 
         let serial = match self.serial {
             Some(serial) => {
-                ensure!(
-                    connected.contains(&serial),
-                    "YubiKey {serial} is not connected{}",
-                    connected_list(&connected)
-                );
+                if !connected.contains(&serial) {
+                    // Renders `; connected: a, b`, or nothing when no device
+                    // is present (the bare message already says it all).
+                    let connected = if connected.is_empty() {
+                        String::new()
+                    } else {
+                        let serials: Vec<String> =
+                            connected.iter().map(ToString::to_string).collect();
+                        format!("; connected: {}", serials.join(", "))
+                    };
+
+                    bail!("YubiKey {serial} is not connected{connected}");
+                }
+
                 serial
             }
             None => match connected.as_slice() {
@@ -53,23 +115,9 @@ impl Run for Args {
 
         // Reading the slot certificates needs neither the PIN nor a touch,
         // so the refresh itself also runs non-interactively.
-        let mut yubikey = yubikey::open(serial)?;
-        let operator_public_key = yubikey.verified_pair_public_key()?;
+        let mut device = open_device(serial)?;
+        let operator_public_key = device.verified_pair_public_key()?;
         let registration = config.yubikeys.register(serial, operator_public_key);
-
-        if registration != Registration::Unchanged {
-            let config_path = config_file_path()?;
-            config.save().await.with_context(|| {
-                format!(
-                    r#"the key was read but saving the config failed; register it manually by adding this to {}:
-
-[[yubikeys]]
-serial = "{serial}"
-public_key = "{operator_public_key}""#,
-                    config_path.display(),
-                )
-            })?;
-        }
 
         Ok(YubiKeyRefreshed {
             serial,
@@ -77,17 +125,6 @@ public_key = "{operator_public_key}""#,
             registration,
         })
     }
-}
-
-/// Renders `; connected: a, b` for a mismatch error, or nothing when no
-/// device is present (the bare message already says it all).
-fn connected_list(connected: &[YubiKeySerial]) -> String {
-    if connected.is_empty() {
-        return String::new();
-    }
-
-    let serials: Vec<String> = connected.iter().map(ToString::to_string).collect();
-    format!("; connected: {}", serials.join(", "))
 }
 
 #[derive(Default, Serialize)]
@@ -125,5 +162,111 @@ Serial:              {}
 Operator public key: {}"#,
             self.serial, self.operator_public_key
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::TestShell;
+    use crate::yubikey::SlotStatus;
+    use crate::yubikey::test_support::{FakeDevice, serial};
+
+    fn test_ctx() -> Ctx<Vec<u8>, Vec<u8>> {
+        Ctx::new(TestShell::default(), false).with_yubikey_discovery(|| Ok(vec![serial()]))
+    }
+
+    fn provisioned_device() -> FakeDevice {
+        FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned)
+    }
+
+    fn open_fake(
+        device: FakeDevice,
+    ) -> impl FnOnce(YubiKeySerial) -> Result<FakeDevice, DeviceError> {
+        move |requested| {
+            if requested == serial() {
+                Ok(device)
+            } else {
+                Err(DeviceError::NotFound { serial: requested })
+            }
+        }
+    }
+
+    #[test]
+    fn refresh_adds_an_unregistered_serial() {
+        let mut config = Config::default();
+        let device = provisioned_device();
+        let composite = device.operator_public_key();
+
+        let refreshed = Args { serial: None }
+            .refresh(&mut test_ctx(), open_fake(device), &mut config)
+            .unwrap();
+
+        assert_eq!(refreshed.serial, serial());
+        assert_eq!(refreshed.operator_public_key, composite);
+        assert_eq!(refreshed.registration, Registration::Added);
+        assert_eq!(config.yubikeys.get(serial()).unwrap().public_key, composite);
+    }
+
+    #[test]
+    fn refresh_replaces_a_stale_cached_key() {
+        let mut config = Config::default();
+        let stale = QosOperatorPublicKey::try_from([9u8; 130].as_slice()).unwrap();
+        config.yubikeys.register(serial(), stale);
+        let device = provisioned_device();
+        let composite = device.operator_public_key();
+
+        let refreshed = Args { serial: None }
+            .refresh(&mut test_ctx(), open_fake(device), &mut config)
+            .unwrap();
+
+        assert_eq!(refreshed.registration, Registration::Updated);
+        assert_eq!(config.yubikeys.get(serial()).unwrap().public_key, composite);
+    }
+
+    #[test]
+    fn refresh_reports_a_current_registry_as_unchanged() {
+        let mut config = Config::default();
+        let device = provisioned_device();
+        config
+            .yubikeys
+            .register(serial(), device.operator_public_key());
+
+        let refreshed = Args { serial: None }
+            .refresh(&mut test_ctx(), open_fake(device), &mut config)
+            .unwrap();
+
+        assert_eq!(refreshed.registration, Registration::Unchanged);
+    }
+
+    #[test]
+    fn an_unconnected_serial_is_refused_with_the_connected_list() {
+        let error = Args {
+            serial: Some(YubiKeySerial::from(0xdead_beef)),
+        }
+        .refresh(
+            &mut test_ctx(),
+            open_fake(provisioned_device()),
+            &mut Config::default(),
+        )
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            "YubiKey deadbeef is not connected; connected: 01c95c1f"
+        );
+    }
+
+    #[test]
+    fn an_unprovisioned_device_is_refused() {
+        let device = FakeDevice::new(SlotStatus::Empty, SlotStatus::Empty);
+
+        let error = Args { serial: None }
+            .refresh(&mut test_ctx(), open_fake(device), &mut Config::default())
+            .err()
+            .unwrap();
+
+        assert!(format!("{error:#}").contains("holds no QuorumOS key"));
     }
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -401,17 +401,15 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
             let (operator, yubikey) = org_config
                 .select_yubikey_operator()
                 .with_context(|| format!("org '{alias}'"))?;
-            let entry = config
-                .yubikey_registry_entry(yubikey.serial)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "YubiKey {serial} of operator '{name}' is not in the device registry; \
+            let entry = config.yubikeys.get(yubikey.serial).ok_or_else(|| {
+                anyhow!(
+                    "YubiKey {serial} of operator '{name}' is not in the device registry; \
                          run `tvc keys provision-yubikey --serial {serial}` to provision and \
                          register it",
-                        serial = yubikey.serial,
-                        name = operator.name,
-                    )
-                })?;
+                    serial = yubikey.serial,
+                    name = operator.name,
+                )
+            })?;
             shell_println!(
                 ctx,
                 "Using YubiKey operator '{}' (serial {}).",

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -6,8 +6,8 @@ use crate::commands::keys::backup_operator_key::{
 };
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, OperatorKind, OperatorRecordKind,
-    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey, dashboard_base_url,
-    default_api_key_path, default_operator_key_path, default_org_dir,
+    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey, YubiKeySerial,
+    dashboard_base_url, default_api_key_path, default_operator_key_path, default_org_dir,
 };
 use crate::outcome::Outcome;
 use crate::output::StdCtx;
@@ -363,7 +363,8 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     // Login ensures the org's default backend is usable, and never crosses
     // over: a local default finds or generates the registered key file; a
     // hosted default requires the registered hosted operator and has no key
-    // material to generate.
+    // material to generate; a yubikey default requires the registered device
+    // and reads its cached key, without needing the device connected.
     let operator = match org_config.default_operator_kind {
         OperatorKind::Local => {
             let (_, local) = org_config
@@ -394,6 +395,34 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                     "{}{}",
                     hosted.encrypt_public_key, hosted.sign_public_key
                 ),
+            }
+        }
+        OperatorKind::Yubikey => {
+            let (operator, yubikey) = org_config
+                .select_yubikey_operator()
+                .with_context(|| format!("org '{alias}'"))?;
+            let entry = config
+                .yubikey_registry_entry(yubikey.serial)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "YubiKey {serial} of operator '{name}' is not in the device registry; \
+                         run `tvc keys provision-yubikey --serial {serial}` to provision and \
+                         register it",
+                        serial = yubikey.serial,
+                        name = operator.name,
+                    )
+                })?;
+            shell_println!(
+                ctx,
+                "Using YubiKey operator '{}' (serial {}).",
+                operator.name,
+                yubikey.serial
+            )?;
+
+            LoggedInOperator::Yubikey {
+                operator_name: operator.name.clone(),
+                serial: yubikey.serial,
+                operator_public_key: entry.public_key,
             }
         }
     };
@@ -733,8 +762,8 @@ pub struct LoggedIn {
 }
 
 /// The operator backend the login landed on: a local login reports its key
-/// file, a hosted login reports the registered identity. Both carry the qos
-/// composite public key.
+/// file, a hosted login reports the registered identity, a yubikey login
+/// reports the device serial. All carry the qos composite public key.
 #[derive(Serialize)]
 #[serde(
     tag = "operatorKind",
@@ -750,6 +779,11 @@ enum LoggedInOperator {
         operator_name: String,
         operator_id: Uuid,
         operator_public_key: String,
+    },
+    Yubikey {
+        operator_name: String,
+        serial: YubiKeySerial,
+        operator_public_key: QosOperatorPublicKey,
     },
 }
 
@@ -858,6 +892,21 @@ Saved to
   API key:        {}"#,
                 self.config_file_path, self.api_key_path,
             ),
+            LoggedInOperator::Yubikey {
+                operator_name,
+                serial,
+                operator_public_key,
+            } => write!(
+                f,
+                r#"
+  Operator public key:   {operator_public_key}
+  YubiKey operator:      {operator_name} (serial {serial})
+
+Saved to
+  Config file:    {}
+  API key:        {}"#,
+                self.config_file_path, self.api_key_path,
+            ),
         }
     }
 }
@@ -940,6 +989,35 @@ mod tests {
                 "operatorKind": "hosted",
                 "operatorName": "hosted-op",
                 "operatorId": Uuid::from_u128(0x11).to_string(),
+                "operatorPublicKey": composite,
+            })
+        );
+    }
+
+    /// The yubikey outcome reports the device serial and no key path.
+    #[test]
+    fn logged_in_yubikey_json_reports_the_device_serial() {
+        let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
+        let logged_in = logged_in_with(LoggedInOperator::Yubikey {
+            operator_name: "yubikey-op".to_string(),
+            serial: YubiKeySerial::from(0x01c9_5c1f),
+            operator_public_key: composite.parse().unwrap(),
+        });
+
+        assert_eq!(
+            serde_json::to_value(&logged_in).unwrap(),
+            serde_json::json!({
+                "organizationName": "Org",
+                "organizationId": "org-1",
+                "username": "user",
+                "userId": "user-1",
+                "alias": "prod",
+                "apiPublicKey": "api-key",
+                "configFilePath": "/config/tvc.config.toml",
+                "apiKeyPath": "/keys/api_key.json",
+                "operatorKind": "yubikey",
+                "operatorName": "yubikey-op",
+                "serial": "01c95c1f",
                 "operatorPublicKey": composite,
             })
         );

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -276,6 +276,7 @@ pub enum OperatorKind {
     #[default]
     Local,
     Hosted,
+    Yubikey,
 }
 
 impl Display for OperatorKind {
@@ -283,6 +284,7 @@ impl Display for OperatorKind {
         match self {
             Self::Local => "local".fmt(f),
             Self::Hosted => "hosted".fmt(f),
+            Self::Yubikey => "yubikey".fmt(f),
         }
     }
 }
@@ -734,6 +736,7 @@ future_entry = "keep"
 [orgs.default]
 id = "org-123"
 api_key_path = "/keys/api.json"
+default_operator_kind = "yubikey"
 
 [[orgs.default.operators]]
 name = "yubikey"
@@ -753,6 +756,7 @@ serial = "1C95C1F"
         assert_eq!(entry.public_key.to_string(), "07".repeat(130));
 
         let org = &config.orgs["default"];
+        assert_eq!(org.default_operator_kind, OperatorKind::Yubikey);
         let OperatorRecordKind::Yubikey(record) = &org.operators[0].kind else {
             panic!("operator must be a yubikey record");
         };
@@ -762,6 +766,7 @@ serial = "1C95C1F"
         assert!(saved.contains("serial = \"01c95c1f\""));
         assert!(!saved.contains("1C95C1F"));
         assert!(saved.contains("kind = \"yubikey\""));
+        assert!(saved.contains("default_operator_kind = \"yubikey\""));
         assert!(saved.contains("future_entry = \"keep\""));
         assert_eq!(disk::from_toml(&saved).unwrap(), config);
     }

--- a/tvc/src/config/turnkey/mod.rs
+++ b/tvc/src/config/turnkey/mod.rs
@@ -387,6 +387,16 @@ pub enum SelectHostedOperatorError {
     MultipleHostedOperators,
 }
 
+/// Failure modes of selecting the sole YubiKey operator of an organization.
+/// Which organization it was is the caller's context to add.
+#[derive(Debug, Error)]
+pub enum SelectYubiKeyOperatorError {
+    #[error("no YubiKey operator is configured")]
+    NoYubiKeyOperator,
+    #[error("multiple YubiKey operators are configured")]
+    MultipleYubiKeyOperators,
+}
+
 impl OrgConfig {
     /// Select the sole local operator registry entry, with its kind-specific
     /// record. Purely a registry query: whether local is the organization's
@@ -432,6 +442,28 @@ impl OrgConfig {
             (Some(sole), None) => Ok(sole),
             (None, _) => Err(SelectHostedOperatorError::NoHostedOperator),
             (Some(_), Some(_)) => Err(SelectHostedOperatorError::MultipleHostedOperators),
+        }
+    }
+
+    /// Select the sole YubiKey operator registry entry, with its
+    /// kind-specific record. Purely a registry query: whether YubiKey is the
+    /// organization's default backend is resolution policy, decided
+    /// elsewhere.
+    pub(crate) fn select_yubikey_operator(
+        &self,
+    ) -> Result<(&OperatorRecord, &YubiKeyOperatorRecord), SelectYubiKeyOperatorError> {
+        let mut yubikeys = self
+            .operators
+            .iter()
+            .filter_map(|operator| match &operator.kind {
+                OperatorRecordKind::Yubikey(yubikey) => Some((operator, yubikey)),
+                OperatorRecordKind::Local(_) | OperatorRecordKind::Hosted(_) => None,
+            });
+
+        match (yubikeys.next(), yubikeys.next()) {
+            (Some(sole), None) => Ok(sole),
+            (None, _) => Err(SelectYubiKeyOperatorError::NoYubiKeyOperator),
+            (Some(_), Some(_)) => Err(SelectYubiKeyOperatorError::MultipleYubiKeyOperators),
         }
     }
 }

--- a/tvc/src/config/turnkey/qos_operator_key.rs
+++ b/tvc/src/config/turnkey/qos_operator_key.rs
@@ -14,12 +14,13 @@ use tracing::debug;
 /// SEC1 points.
 const QOS_OPERATOR_PUBLIC_KEY_LEN: usize = 130;
 
-/// A stored QOS operator public key, opaque to tvc.
+/// A stored QOS operator public key, near-opaque to tvc.
 ///
 /// The bytes are `qos_p256::P256Public::to_bytes()`'s composite encoding —
-/// `encrypt_public ‖ sign_public`, two 65-byte uncompressed SEC1 points —
-/// but tvc never reads the halves, so it deliberately doesn't model the
-/// split. Hex is the display and serialization form.
+/// `encrypt_public ‖ sign_public`, two 65-byte uncompressed SEC1 points.
+/// The YubiKey operator backend peels off the encryption half for envelope
+/// decryption ([`Self::encrypt_public_bytes`]); beyond that tvc doesn't
+/// model the split. Hex is the display and serialization form.
 ///
 /// TODO(TVC-270): the proper home for this type is qos_p256, as a bytemuck
 /// repr-backed wire form of `P256Public` (which already holds the two keys
@@ -27,6 +28,18 @@ const QOS_OPERATOR_PUBLIC_KEY_LEN: usize = 130;
 /// and store that type here instead.
 #[derive(Clone, Copy, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
 pub struct QosOperatorPublicKey([u8; QOS_OPERATOR_PUBLIC_KEY_LEN]);
+
+impl QosOperatorPublicKey {
+    /// The raw composite bytes.
+    pub fn as_bytes(&self) -> &[u8; QOS_OPERATOR_PUBLIC_KEY_LEN] {
+        &self.0
+    }
+
+    /// The encryption half: the leading uncompressed SEC1 point.
+    pub(crate) fn encrypt_public_bytes(&self) -> &[u8] {
+        &self.0[..QOS_OPERATOR_PUBLIC_KEY_LEN / 2]
+    }
+}
 
 /// Error returned when parsing a [`QosOperatorPublicKey`].
 #[derive(Debug, displaydoc::Display, thiserror::Error)]

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -17,7 +17,7 @@ use crate::{
     local_operator_key::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
-    pair::Signer,
+    pair::{Pair, Signer},
     yubikey::{DeviceOps, pair::PinAcquisition},
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -359,6 +359,57 @@ impl Config {
         }
     }
 
+    /// Resolve the operator key pair for share decryption by the active
+    /// org's default backend. An explicit seed is local, always, and skips
+    /// the config. Hosted operators sign through the API and hold no local
+    /// key material, so a hosted default is redirected to the hosted
+    /// counterpart of the flow.
+    pub(crate) async fn resolve_operator_pair<D: DeviceOps + Send + 'static>(
+        &self,
+        devices: D,
+        explicit: Option<LocalOperatorSeedSource>,
+        pin: PinAcquisition,
+    ) -> Result<Box<dyn Pair>> {
+        if explicit.is_some() {
+            return Ok(Box::new(resolve_local_operator(self, explicit).await?));
+        }
+
+        let (alias, org) = self.active_org_config().ok_or_else(|| {
+            anyhow!(
+                "No active organization. Run `tvc login` first or provide \
+                 --operator-seed or --operator-seed-path."
+            )
+        })?;
+
+        match org.default_operator_kind {
+            OperatorKind::Local => {
+                let (_, local) = org
+                    .select_local_operator()
+                    .with_context(|| format!("org '{alias}'"))?;
+
+                Ok(Box::new(
+                    resolve_registered_local_operator(local.key_path.clone()).await?,
+                ))
+            }
+            OperatorKind::Yubikey => {
+                let (_, yubikey) = org
+                    .select_yubikey_operator()
+                    .with_context(|| format!("org '{alias}'"))?;
+
+                Ok(Box::new(
+                    self.resolve_yubikey(yubikey.serial, devices, pin).await?,
+                ))
+            }
+            // TODO(TVC-202): remove hardcoded user-facing messages mentioning
+            // other commands.
+            OperatorKind::Hosted => bail!(
+                "re-encrypting a local share needs the local operator key the share was \
+                 encrypted to; hosted operators re-encrypt through Turnkey with \
+                 `tvc deploy provision`"
+            ),
+        }
+    }
+
     /// Operator identities known for the active org: registered hosted
     /// operators (config order) then the last `app create`'s manifest-set
     /// operator IDs, deduplicated by ID. Each source keeps one authoritative
@@ -663,6 +714,85 @@ mod tests {
         let rendered = format!("{error:#}");
         assert!(rendered.contains("org 'active'"));
         assert!(rendered.contains("no YubiKey operator is configured"));
+    }
+
+    #[tokio::test]
+    async fn operator_pair_explicit_seed_is_local() {
+        let seed_hex = "ab".repeat(32);
+        let expected = LocalPair::from_hex_seed(&seed_hex).unwrap().public_key();
+
+        // The pair never needs a PIN on the local path, even when none could
+        // be prompted.
+        let pair = Config::default()
+            .resolve_operator_pair(
+                provisioned_fake(),
+                Some(LocalOperatorSeedSource::Value(seed_hex.parse().unwrap())),
+                PinAcquisition::Unavailable,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(pair.public_key(), expected);
+    }
+
+    #[tokio::test]
+    async fn operator_pair_local_default_reads_the_registered_key_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let key_path = temp.path().join("operator.json");
+        let private_key = "ab".repeat(32);
+        std::fs::write(
+            &key_path,
+            serde_json::to_string(&StoredQosOperatorKey {
+                public_key: QosOperatorPublicKey::default(),
+                private_key: private_key.clone(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let config = config_with_operators(vec![OperatorRecord {
+            name: "local".to_string(),
+            kind: OperatorRecordKind::Local(LocalOperatorRecord {
+                key_path,
+                operator_id: None,
+                extra: toml::Table::new(),
+            }),
+        }]);
+        let expected = LocalPair::from_hex_seed(&private_key).unwrap().public_key();
+
+        let pair = config
+            .resolve_operator_pair(provisioned_fake(), None, PinAcquisition::Unavailable)
+            .await
+            .unwrap();
+
+        assert_eq!(pair.public_key(), expected);
+    }
+
+    #[tokio::test]
+    async fn operator_pair_yubikey_default_resolves_the_device_pair() {
+        let device = provisioned_fake();
+        let composite = device.operator_public_key();
+        let config = registered_yubikey_config(&device);
+
+        let pair = config
+            .resolve_operator_pair(device, None, fixed_pin())
+            .await
+            .unwrap();
+
+        assert_eq!(pair.public_key(), composite.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn operator_pair_hosted_default_is_redirected() {
+        let mut config = config_with_operators(vec![hosted_operator("hosted")]);
+        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Hosted;
+
+        let error = config
+            .resolve_operator_pair(provisioned_fake(), None, PinAcquisition::Unavailable)
+            .await
+            .err()
+            .expect("a hosted default cannot decrypt locally");
+
+        assert!(error.to_string().contains("tvc deploy provision"));
     }
 
     #[tokio::test]

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -303,8 +303,9 @@ impl Config {
     /// Best-effort read of the active org's operator public key under its
     /// default backend, as qos composite hex, for prompt and template
     /// defaults. The local backend reads the sole registered key file; the
-    /// hosted backend joins the sole record's stored points. `None` on any
-    /// miss.
+    /// hosted backend joins the sole record's stored points; the yubikey
+    /// backend reads the registry's cached key, so the device need not be
+    /// connected. `None` on any miss.
     pub(crate) async fn default_operator_public_key(&self) -> Option<String> {
         let (_, org) = self.active_org_config()?;
 
@@ -320,6 +321,11 @@ impl Config {
                     "{}{}",
                     hosted.encrypt_public_key, hosted.sign_public_key
                 ))
+            }
+            OperatorKind::Yubikey => {
+                let (_, yubikey) = org.select_yubikey_operator().ok()?;
+                let entry = self.yubikey_registry_entry(yubikey.serial)?;
+                Some(entry.public_key.to_string())
             }
         }
     }
@@ -364,6 +370,7 @@ mod tests {
     use super::*;
     use crate::config::turnkey::{
         HostedOperatorRecord, LocalOperatorRecord, OperatorRecord, OperatorRecordKind, OrgConfig,
+        QosOperatorPublicKey, YubiKeyOperatorRecord, YubiKeySerial,
     };
     use qos_p256::P256Pair;
     use std::{collections::HashMap, path::PathBuf};
@@ -418,6 +425,42 @@ mod tests {
                 extra: toml::Table::new(),
             }),
         }
+    }
+
+    fn yubikey_operator(serial: YubiKeySerial) -> OperatorRecord {
+        OperatorRecord {
+            name: "yubikey".to_string(),
+            kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
+                serial,
+                extra: toml::Table::new(),
+            }),
+        }
+    }
+
+    fn yubikey_default_config(serial: YubiKeySerial) -> Config {
+        let mut config = config_with_operators(vec![yubikey_operator(serial)]);
+        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
+        config
+    }
+
+    #[tokio::test]
+    async fn default_operator_public_key_reads_the_yubikey_registry_cache() {
+        let serial = YubiKeySerial::from(0x01c9_5c1f);
+        let composite = QosOperatorPublicKey::try_from([7u8; 130].as_slice()).unwrap();
+        let mut config = yubikey_default_config(serial);
+        config.register_yubikey(serial, composite);
+
+        assert_eq!(
+            config.default_operator_public_key().await,
+            Some(composite.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn default_operator_public_key_is_none_for_an_unregistered_yubikey() {
+        let config = yubikey_default_config(YubiKeySerial::from(0x01c9_5c1f));
+
+        assert_eq!(config.default_operator_public_key().await, None);
     }
 
     #[test]

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -13,7 +13,7 @@ pub(crate) use hosted::{ResolvedHostedOperator, hosted_activity_error};
 use crate::{
     approvals::ValidatedManifest,
     client::build_client,
-    config::turnkey::{Config, OperatorKind, StoredQosOperatorKey},
+    config::turnkey::{Config, OperatorKind, StoredQosOperatorKey, YubiKeySerial},
     local_operator_key::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
@@ -166,152 +166,6 @@ pub(crate) enum SignerRequirement {
     OfflineApproval,
 }
 
-/// Resolve the operator for an approval. The precedence is deliberate and
-/// preserved exactly; there is no fallback between backends:
-///
-/// 1. An explicit seed is a local operator, always. A hosted `--operator-id`
-///    alongside it is rejected.
-/// 2. An operator ID naming a hosted registry record selects that hosted
-///    operator — even when the org's default operator kind is local.
-/// 3. Otherwise the active org's `default_operator_kind` decides, and never
-///    crosses over: `local` resolves the sole local record (reconciling a
-///    given ID against its configured one); `hosted` resolves the sole
-///    hosted record when no ID names one, and never falls back to the
-///    local key; `yubikey` resolves the sole yubikey record's device by
-///    serial, passing a given ID through for posting.
-///
-/// Config is loaded lazily inside: the explicit-seed path must not depend
-/// on a config file being present or well-formed (pinned by
-/// `explicit_seed_does_not_load_malformed_config`).
-pub(crate) async fn resolve_operator<D, O>(
-    config: &Config,
-    open_device: O,
-    explicit: Option<LocalOperatorSeedSource>,
-    operator_id: Option<Uuid>,
-    requirement: SignerRequirement,
-    pin: PinAcquisition,
-) -> Result<ResolvedOperator>
-where
-    D: DeviceOps + Send + 'static,
-    O: FnOnce(crate::config::turnkey::YubiKeySerial) -> Result<D, DeviceError>,
-{
-    if let Some(explicit) = explicit {
-        if let Some(id) = operator_id {
-            ensure!(
-                config.find_hosted_operator(&id)?.is_none(),
-                "explicit local operator seed cannot be used with a hosted operator ID"
-            );
-        }
-
-        let signer = resolve_local_operator(config, Some(explicit)).await?;
-
-        return Ok(ResolvedOperator {
-            name: None,
-            operator_id,
-            signer: Box::new(signer),
-        });
-    }
-
-    let hosted = operator_id
-        .map(|id| config.find_hosted_operator(&id))
-        .transpose()?
-        .flatten();
-
-    if let Some(hosted) = hosted {
-        // Hosted operators sign through the API, so an offline requirement
-        // is unsatisfiable; refuse before touching credentials.
-        if requirement == SignerRequirement::OfflineApproval {
-            bail!("--skip-post is not supported for hosted operators");
-        }
-
-        let auth = build_client(config).await?;
-        ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
-
-        return Ok(ResolvedOperator {
-            name: Some(hosted.name().to_string()),
-            operator_id: Some(hosted.operator_id()),
-            signer: Box::new(HostedSigner::new(hosted, auth)),
-        });
-    }
-
-    let (alias, org) = config.active_org_config().ok_or_else(|| {
-        anyhow!(
-            "No active organization. Run `tvc login` first or provide \
-             --operator-seed or --operator-seed-path."
-        )
-    })?;
-
-    match org.default_operator_kind {
-        OperatorKind::Hosted => match operator_id {
-            Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
-            None => {
-                // A hosted default cannot satisfy an offline approval;
-                // refuse before selection or credentials.
-                if requirement == SignerRequirement::OfflineApproval {
-                    bail!("--skip-post is not supported for hosted operators");
-                }
-
-                let (name, hosted) = org
-                    .select_hosted_operator()
-                    .with_context(|| format!("org '{alias}'"))?;
-                let hosted = ResolvedHostedOperator::from_registry(org.id.clone(), name, hosted)?;
-                let auth = build_client(config).await?;
-                ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
-
-                Ok(ResolvedOperator {
-                    name: Some(hosted.name().to_string()),
-                    operator_id: Some(hosted.operator_id()),
-                    signer: Box::new(HostedSigner::new(hosted, auth)),
-                })
-            }
-        },
-        OperatorKind::Yubikey => {
-            let (operator, yubikey) = org
-                .select_yubikey_operator()
-                .with_context(|| format!("org '{alias}'"))?;
-            let device = open_device(yubikey.serial)?;
-            let pair = config.resolve_yubikey(yubikey.serial, device, pin).await?;
-
-            Ok(ResolvedOperator {
-                name: Some(operator.name.clone()),
-                operator_id,
-                signer: Box::new(pair),
-            })
-        }
-        OperatorKind::Local => {
-            let (operator, local) = org
-                .select_local_operator()
-                .with_context(|| format!("org '{alias}'"))?;
-
-            let configured_operator_id = local
-                .operator_id
-                .as_deref()
-                .map(|id| {
-                    Uuid::parse_str(id)
-                        .map_err(|_| anyhow!("configured local operator ID must be a UUID"))
-                })
-                .transpose()?;
-
-            let resolved_operator_id = match (configured_operator_id, operator_id) {
-                (Some(configured), Some(requested)) => {
-                    ensure!(
-                        configured == requested,
-                        "requested operator ID ({requested}) does not match configured local operator ID ({configured})"
-                    );
-                    Some(configured)
-                }
-                (configured, requested) => configured.or(requested),
-            };
-
-            Ok(ResolvedOperator {
-                name: Some(operator.name.clone()),
-                operator_id: resolved_operator_id,
-                signer: Box::new(resolve_registered_local_operator(local.key_path.clone()).await?),
-            })
-        }
-    }
-}
-
 /// One operator identity known for the active org, labeled with its registry
 /// name when it has one. The ID stays a string: callers that need a UUID
 /// parse at their own boundary.
@@ -364,6 +218,154 @@ impl Config {
         }
     }
 
+    /// Resolve the operator for an approval. The precedence is deliberate
+    /// and preserved exactly; there is no fallback between backends:
+    ///
+    /// 1. An explicit seed is a local operator, always. A hosted
+    ///    `--operator-id` alongside it is rejected.
+    /// 2. An operator ID naming a hosted registry record selects that hosted
+    ///    operator — even when the org's default operator kind is local.
+    /// 3. Otherwise the active org's `default_operator_kind` decides, and
+    ///    never crosses over: `local` resolves the sole local record
+    ///    (reconciling a given ID against its configured one); `hosted`
+    ///    resolves the sole hosted record when no ID names one, and never
+    ///    falls back to the local key; `yubikey` resolves the sole yubikey
+    ///    record's device by serial, passing a given ID through for posting.
+    ///
+    /// The registry is read lazily inside: the explicit-seed path must not
+    /// depend on an org being configured.
+    pub(crate) async fn resolve_operator<D, O>(
+        &self,
+        open_device: O,
+        explicit: Option<LocalOperatorSeedSource>,
+        operator_id: Option<Uuid>,
+        requirement: SignerRequirement,
+        pin: PinAcquisition,
+    ) -> Result<ResolvedOperator>
+    where
+        D: DeviceOps + Send + 'static,
+        O: FnOnce(YubiKeySerial) -> Result<D, DeviceError>,
+    {
+        if let Some(explicit) = explicit {
+            if let Some(id) = operator_id {
+                ensure!(
+                    self.find_hosted_operator(&id)?.is_none(),
+                    "explicit local operator seed cannot be used with a hosted operator ID"
+                );
+            }
+
+            let signer = resolve_local_operator(self, Some(explicit)).await?;
+
+            return Ok(ResolvedOperator {
+                name: None,
+                operator_id,
+                signer: Box::new(signer),
+            });
+        }
+
+        let hosted = operator_id
+            .map(|id| self.find_hosted_operator(&id))
+            .transpose()?
+            .flatten();
+
+        if let Some(hosted) = hosted {
+            // Hosted operators sign through the API, so an offline requirement
+            // is unsatisfiable; refuse before touching credentials.
+            if requirement == SignerRequirement::OfflineApproval {
+                bail!("--skip-post is not supported for hosted operators");
+            }
+
+            let auth = build_client(self).await?;
+            ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
+
+            return Ok(ResolvedOperator {
+                name: Some(hosted.name().to_string()),
+                operator_id: Some(hosted.operator_id()),
+                signer: Box::new(HostedSigner::new(hosted, auth)),
+            });
+        }
+
+        let (alias, org) = self.active_org_config().ok_or_else(|| {
+            anyhow!(
+                "No active organization. Run `tvc login` first or provide \
+                 --operator-seed or --operator-seed-path."
+            )
+        })?;
+
+        match org.default_operator_kind {
+            OperatorKind::Hosted => match operator_id {
+                Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
+                None => {
+                    // A hosted default cannot satisfy an offline approval;
+                    // refuse before selection or credentials.
+                    if requirement == SignerRequirement::OfflineApproval {
+                        bail!("--skip-post is not supported for hosted operators");
+                    }
+
+                    let (name, hosted) = org
+                        .select_hosted_operator()
+                        .with_context(|| format!("org '{alias}'"))?;
+                    let hosted =
+                        ResolvedHostedOperator::from_registry(org.id.clone(), name, hosted)?;
+                    let auth = build_client(self).await?;
+                    ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
+
+                    Ok(ResolvedOperator {
+                        name: Some(hosted.name().to_string()),
+                        operator_id: Some(hosted.operator_id()),
+                        signer: Box::new(HostedSigner::new(hosted, auth)),
+                    })
+                }
+            },
+            OperatorKind::Yubikey => {
+                let (operator, yubikey) = org
+                    .select_yubikey_operator()
+                    .with_context(|| format!("org '{alias}'"))?;
+                let device = open_device(yubikey.serial)?;
+                let pair = self.resolve_yubikey(yubikey.serial, device, pin).await?;
+
+                Ok(ResolvedOperator {
+                    name: Some(operator.name.clone()),
+                    operator_id,
+                    signer: Box::new(pair),
+                })
+            }
+            OperatorKind::Local => {
+                let (operator, local) = org
+                    .select_local_operator()
+                    .with_context(|| format!("org '{alias}'"))?;
+
+                let configured_operator_id = local
+                    .operator_id
+                    .as_deref()
+                    .map(|id| {
+                        Uuid::parse_str(id)
+                            .map_err(|_| anyhow!("configured local operator ID must be a UUID"))
+                    })
+                    .transpose()?;
+
+                let resolved_operator_id = match (configured_operator_id, operator_id) {
+                    (Some(configured), Some(requested)) => {
+                        ensure!(
+                            configured == requested,
+                            "requested operator ID ({requested}) does not match configured local operator ID ({configured})"
+                        );
+                        Some(configured)
+                    }
+                    (configured, requested) => configured.or(requested),
+                };
+
+                Ok(ResolvedOperator {
+                    name: Some(operator.name.clone()),
+                    operator_id: resolved_operator_id,
+                    signer: Box::new(
+                        resolve_registered_local_operator(local.key_path.clone()).await?,
+                    ),
+                })
+            }
+        }
+    }
+
     /// Resolve the operator key pair for share decryption by the active
     /// org's default backend. An explicit seed is local, always, and skips
     /// the config. Hosted operators sign through the API and hold no local
@@ -377,7 +379,7 @@ impl Config {
     ) -> Result<Box<dyn Pair>>
     where
         D: DeviceOps + Send + 'static,
-        O: FnOnce(crate::config::turnkey::YubiKeySerial) -> Result<D, DeviceError>,
+        O: FnOnce(YubiKeySerial) -> Result<D, DeviceError>,
     {
         if explicit.is_some() {
             return Ok(Box::new(resolve_local_operator(self, explicit).await?));
@@ -592,16 +594,16 @@ mod tests {
         let composite = device.operator_public_key();
         let config = registered_yubikey_config(&device);
 
-        let operator = resolve_operator(
-            &config,
-            open_fake(device),
-            None,
-            None,
-            SignerRequirement::Any,
-            fixed_pin(),
-        )
-        .await
-        .unwrap();
+        let operator = config
+            .resolve_operator(
+                open_fake(device),
+                None,
+                None,
+                SignerRequirement::Any,
+                fixed_pin(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(operator.signer.public_key(), composite.as_bytes());
         assert_eq!(operator.name, Some("yubikey".to_string()));
@@ -613,16 +615,16 @@ mod tests {
         let device = provisioned_fake();
         let config = registered_yubikey_config(&device);
 
-        let operator = resolve_operator(
-            &config,
-            open_fake(device),
-            None,
-            None,
-            SignerRequirement::OfflineApproval,
-            fixed_pin(),
-        )
-        .await
-        .unwrap();
+        let operator = config
+            .resolve_operator(
+                open_fake(device),
+                None,
+                None,
+                SignerRequirement::OfflineApproval,
+                fixed_pin(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(operator.name, Some("yubikey".to_string()));
     }
@@ -633,16 +635,16 @@ mod tests {
         let config = registered_yubikey_config(&device);
         let requested = Uuid::from_u128(0x22);
 
-        let operator = resolve_operator(
-            &config,
-            open_fake(device),
-            None,
-            Some(requested),
-            SignerRequirement::Any,
-            fixed_pin(),
-        )
-        .await
-        .unwrap();
+        let operator = config
+            .resolve_operator(
+                open_fake(device),
+                None,
+                Some(requested),
+                SignerRequirement::Any,
+                fixed_pin(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(operator.id(), Some(requested));
     }
@@ -655,16 +657,16 @@ mod tests {
         let seed: HexSeed = seed_hex.parse().unwrap();
         let expected = LocalPair::from_hex_seed(&seed_hex).unwrap().public_key();
 
-        let operator = resolve_operator(
-            &config,
-            open_fake(device),
-            Some(LocalOperatorSeedSource::Value(seed)),
-            None,
-            SignerRequirement::Any,
-            fixed_pin(),
-        )
-        .await
-        .unwrap();
+        let operator = config
+            .resolve_operator(
+                open_fake(device),
+                Some(LocalOperatorSeedSource::Value(seed)),
+                None,
+                SignerRequirement::Any,
+                fixed_pin(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(operator.signer.public_key(), expected);
         assert_eq!(operator.name, None);
@@ -681,16 +683,16 @@ mod tests {
             .operators
             .push(hosted_operator("hosted"));
 
-        let error = resolve_operator(
-            &config,
-            open_fake(device),
-            None,
-            Some(HOSTED_ID.parse().unwrap()),
-            SignerRequirement::OfflineApproval,
-            fixed_pin(),
-        )
-        .await
-        .unwrap_err();
+        let error = config
+            .resolve_operator(
+                open_fake(device),
+                None,
+                Some(HOSTED_ID.parse().unwrap()),
+                SignerRequirement::OfflineApproval,
+                fixed_pin(),
+            )
+            .await
+            .unwrap_err();
 
         // The hosted-by-id branch fired (pinning its rewording), so the
         // yubikey default never resolved.
@@ -705,16 +707,16 @@ mod tests {
         let device = provisioned_fake();
         let config = registered_yubikey_config(&device);
 
-        let error = resolve_operator(
-            &config,
-            open_fake(device),
-            None,
-            None,
-            SignerRequirement::Any,
-            PinAcquisition::Unavailable,
-        )
-        .await
-        .unwrap_err();
+        let error = config
+            .resolve_operator(
+                open_fake(device),
+                None,
+                None,
+                SignerRequirement::Any,
+                PinAcquisition::Unavailable,
+            )
+            .await
+            .unwrap_err();
 
         assert!(format!("{error:#}").contains("interactive prompt"));
     }
@@ -724,16 +726,16 @@ mod tests {
         let mut config = config_with_operators(Vec::new());
         config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
 
-        let error = resolve_operator(
-            &config,
-            open_fake(provisioned_fake()),
-            None,
-            None,
-            SignerRequirement::Any,
-            fixed_pin(),
-        )
-        .await
-        .unwrap_err();
+        let error = config
+            .resolve_operator(
+                open_fake(provisioned_fake()),
+                None,
+                None,
+                SignerRequirement::Any,
+                fixed_pin(),
+            )
+            .await
+            .unwrap_err();
 
         let rendered = format!("{error:#}");
         assert!(rendered.contains("org 'active'"));
@@ -834,16 +836,16 @@ mod tests {
             config_with_operators(vec![yubikey_operator(serial), yubikey_operator(serial)]);
         config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
 
-        let error = resolve_operator(
-            &config,
-            open_fake(provisioned_fake()),
-            None,
-            None,
-            SignerRequirement::Any,
-            fixed_pin(),
-        )
-        .await
-        .unwrap_err();
+        let error = config
+            .resolve_operator(
+                open_fake(provisioned_fake()),
+                None,
+                None,
+                SignerRequirement::Any,
+                fixed_pin(),
+            )
+            .await
+            .unwrap_err();
 
         assert!(format!("{error:#}").contains("multiple YubiKey operators are configured"));
     }

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -18,7 +18,10 @@ use crate::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
     pair::{Pair, Signer},
-    yubikey::{DeviceError, DeviceOps, pair::PinAcquisition},
+    yubikey::{
+        DeviceError, DeviceOps,
+        pair::{AvailablePin, PinAcquisition},
+    },
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hosted::HostedSigner;
@@ -26,6 +29,7 @@ use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
 use qos_core::protocol::services::boot::Approval;
 use std::{
     fmt::{self, Debug, Display, Formatter},
+    path::PathBuf,
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -184,6 +188,48 @@ impl Display for OperatorCandidate {
     }
 }
 
+/// A share-decryption backend selected by
+/// [`Config::select_operator_pair_source`] from config and interaction mode
+/// alone. [`Self::resolve`] performs the I/O: file reads, device
+/// verification, and the PIN prompt.
+pub(crate) enum OperatorPairSource {
+    /// An explicit seed from the command line.
+    Seed(LocalOperatorSeedSource),
+    /// The sole registered local operator's key file.
+    RegisteredKeyFile(PathBuf),
+    /// The sole registered yubikey operator's device.
+    Yubikey {
+        serial: YubiKeySerial,
+        pin: AvailablePin,
+    },
+}
+
+impl OperatorPairSource {
+    /// Resolve the selected backend into a usable pair.
+    pub(crate) async fn resolve<D, O>(
+        self,
+        config: &Config,
+        open_device: O,
+    ) -> Result<Box<dyn Pair>>
+    where
+        D: DeviceOps + Send + 'static,
+        O: FnOnce(YubiKeySerial) -> Result<D, DeviceError>,
+    {
+        match self {
+            Self::Seed(source) => Ok(Box::new(
+                resolve_local_operator(config, Some(source)).await?,
+            )),
+            Self::RegisteredKeyFile(path) => {
+                Ok(Box::new(resolve_registered_local_operator(path).await?))
+            }
+            Self::Yubikey { serial, pin } => {
+                let device = open_device(serial)?;
+                Ok(Box::new(config.resolve_yubikey(serial, device, pin).await?))
+            }
+        }
+    }
+}
+
 /// Operator semantics of the registry [`Config`] holds; the methods live
 /// here, with the rest of operator resolution, rather than in the config
 /// module.
@@ -321,6 +367,7 @@ impl Config {
                 let (operator, yubikey) = org
                     .select_yubikey_operator()
                     .with_context(|| format!("org '{alias}'"))?;
+                let pin = pin.into_available()?;
                 let device = open_device(yubikey.serial)?;
                 let pair = self.resolve_yubikey(yubikey.serial, device, pin).await?;
 
@@ -366,23 +413,20 @@ impl Config {
         }
     }
 
-    /// Resolve the operator key pair for share decryption by the active
-    /// org's default backend. An explicit seed is local, always, and skips
-    /// the config. Hosted operators sign through the API and hold no local
-    /// key material, so a hosted default is redirected to the hosted
-    /// counterpart of the flow.
-    pub(crate) async fn resolve_operator_pair<D, O>(
+    /// Select the share-decryption backend from config and interaction mode
+    /// alone — deterministic and I/O-free, so endpoints refuse impossible
+    /// runs before doing unrelated work; [`OperatorPairSource::resolve`]
+    /// performs the I/O. An explicit seed is local, always, and skips the
+    /// config. Hosted operators sign through the API and hold no local key
+    /// material, so a hosted default is redirected to the hosted counterpart
+    /// of the flow.
+    pub(crate) fn select_operator_pair_source(
         &self,
-        open_device: O,
         explicit: Option<LocalOperatorSeedSource>,
         pin: PinAcquisition,
-    ) -> Result<Box<dyn Pair>>
-    where
-        D: DeviceOps + Send + 'static,
-        O: FnOnce(YubiKeySerial) -> Result<D, DeviceError>,
-    {
-        if explicit.is_some() {
-            return Ok(Box::new(resolve_local_operator(self, explicit).await?));
+    ) -> Result<OperatorPairSource> {
+        if let Some(explicit) = explicit {
+            return Ok(OperatorPairSource::Seed(explicit));
         }
 
         let (alias, org) = self.active_org_config().ok_or_else(|| {
@@ -398,19 +442,19 @@ impl Config {
                     .select_local_operator()
                     .with_context(|| format!("org '{alias}'"))?;
 
-                Ok(Box::new(
-                    resolve_registered_local_operator(local.key_path.clone()).await?,
+                Ok(OperatorPairSource::RegisteredKeyFile(
+                    local.key_path.clone(),
                 ))
             }
             OperatorKind::Yubikey => {
                 let (_, yubikey) = org
                     .select_yubikey_operator()
                     .with_context(|| format!("org '{alias}'"))?;
-                let device = open_device(yubikey.serial)?;
 
-                Ok(Box::new(
-                    self.resolve_yubikey(yubikey.serial, device, pin).await?,
-                ))
+                Ok(OperatorPairSource::Yubikey {
+                    serial: yubikey.serial,
+                    pin: pin.into_available()?,
+                })
             }
             // TODO(TVC-202): remove hardcoded user-facing messages mentioning
             // other commands.
@@ -749,12 +793,15 @@ mod tests {
 
         // The pair never needs a PIN on the local path, even when none could
         // be prompted.
-        let pair = Config::default()
-            .resolve_operator_pair(
-                open_fake(provisioned_fake()),
+        let config = Config::default();
+        let source = config
+            .select_operator_pair_source(
                 Some(LocalOperatorSeedSource::Value(seed_hex.parse().unwrap())),
                 PinAcquisition::Unavailable,
             )
+            .unwrap();
+        let pair = source
+            .resolve(&config, open_fake(provisioned_fake()))
             .await
             .unwrap();
 
@@ -785,12 +832,11 @@ mod tests {
         }]);
         let expected = LocalPair::from_hex_seed(&private_key).unwrap().public_key();
 
-        let pair = config
-            .resolve_operator_pair(
-                open_fake(provisioned_fake()),
-                None,
-                PinAcquisition::Unavailable,
-            )
+        let source = config
+            .select_operator_pair_source(None, PinAcquisition::Unavailable)
+            .unwrap();
+        let pair = source
+            .resolve(&config, open_fake(provisioned_fake()))
             .await
             .unwrap();
 
@@ -803,26 +849,34 @@ mod tests {
         let composite = device.operator_public_key();
         let config = registered_yubikey_config(&device);
 
-        let pair = config
-            .resolve_operator_pair(open_fake(device), None, fixed_pin())
-            .await
+        let source = config
+            .select_operator_pair_source(None, fixed_pin())
             .unwrap();
+        let pair = source.resolve(&config, open_fake(device)).await.unwrap();
 
         assert_eq!(pair.public_key(), composite.as_bytes());
     }
 
-    #[tokio::test]
-    async fn operator_pair_hosted_default_is_redirected() {
+    #[test]
+    fn operator_pair_yubikey_default_without_a_pin_is_refused_at_selection() {
+        let device = provisioned_fake();
+        let config = registered_yubikey_config(&device);
+
+        let error = config
+            .select_operator_pair_source(None, PinAcquisition::Unavailable)
+            .err()
+            .expect("selection must refuse an unavailable PIN");
+
+        assert!(format!("{error:#}").contains("interactive prompt"));
+    }
+
+    #[test]
+    fn operator_pair_hosted_default_is_redirected() {
         let mut config = config_with_operators(vec![hosted_operator("hosted")]);
         config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Hosted;
 
         let error = config
-            .resolve_operator_pair(
-                open_fake(provisioned_fake()),
-                None,
-                PinAcquisition::Unavailable,
-            )
-            .await
+            .select_operator_pair_source(None, PinAcquisition::Unavailable)
             .err()
             .expect("a hosted default cannot decrypt locally");
 

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -18,13 +18,14 @@ use crate::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
     pair::Signer,
+    yubikey::{DeviceOps, pair::PinAcquisition},
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hosted::HostedSigner;
 use p256::{PublicKey, elliptic_curve::sec1::ToEncodedPoint};
 use qos_core::protocol::services::boot::Approval;
 use std::{
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -90,6 +91,17 @@ pub(crate) struct ResolvedOperator {
     /// Always present for hosted operators and optional for local operators.
     operator_id: Option<Uuid>,
     signer: Box<dyn Signer>,
+}
+
+// The signer is a trait object with nothing printable, so the derive is off
+// the table; the identity fields keep test failures readable.
+impl Debug for ResolvedOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedOperator")
+            .field("name", &self.name)
+            .field("operator_id", &self.operator_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ResolvedOperator {
@@ -165,16 +177,19 @@ pub(crate) enum SignerRequirement {
 ///    crosses over: `local` resolves the sole local record (reconciling a
 ///    given ID against its configured one); `hosted` resolves the sole
 ///    hosted record when no ID names one, and never falls back to the
-///    local key.
+///    local key; `yubikey` resolves the sole yubikey record's device by
+///    serial, passing a given ID through for posting.
 ///
 /// Config is loaded lazily inside: the explicit-seed path must not depend
 /// on a config file being present or well-formed (pinned by
 /// `explicit_seed_does_not_load_malformed_config`).
-pub(crate) async fn resolve_operator(
+pub(crate) async fn resolve_operator<D: DeviceOps + Send + 'static>(
     config: &Config,
+    devices: D,
     explicit: Option<LocalOperatorSeedSource>,
     operator_id: Option<Uuid>,
     requirement: SignerRequirement,
+    pin: PinAcquisition,
 ) -> Result<ResolvedOperator> {
     if let Some(explicit) = explicit {
         if let Some(id) = operator_id {
@@ -202,7 +217,7 @@ pub(crate) async fn resolve_operator(
         // Hosted operators sign through the API, so an offline requirement
         // is unsatisfiable; refuse before touching credentials.
         if requirement == SignerRequirement::OfflineApproval {
-            bail!("--skip-post is only supported for local operators");
+            bail!("--skip-post is not supported for hosted operators");
         }
 
         let auth = build_client(config).await?;
@@ -222,14 +237,14 @@ pub(crate) async fn resolve_operator(
         )
     })?;
 
-    if org.default_operator_kind == OperatorKind::Hosted {
-        match operator_id {
+    match org.default_operator_kind {
+        OperatorKind::Hosted => match operator_id {
             Some(id) => bail!("hosted operator ID '{id}' was not found in org '{alias}'"),
             None => {
                 // A hosted default cannot satisfy an offline approval;
                 // refuse before selection or credentials.
                 if requirement == SignerRequirement::OfflineApproval {
-                    bail!("--skip-post is only supported for local operators");
+                    bail!("--skip-post is not supported for hosted operators");
                 }
 
                 let (name, hosted) = org
@@ -239,43 +254,57 @@ pub(crate) async fn resolve_operator(
                 let auth = build_client(config).await?;
                 ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
 
-                return Ok(ResolvedOperator {
+                Ok(ResolvedOperator {
                     name: Some(hosted.name().to_string()),
                     operator_id: Some(hosted.operator_id()),
                     signer: Box::new(HostedSigner::new(hosted, auth)),
-                });
+                })
             }
+        },
+        OperatorKind::Yubikey => {
+            let (operator, yubikey) = org
+                .select_yubikey_operator()
+                .with_context(|| format!("org '{alias}'"))?;
+            let pair = config.resolve_yubikey(yubikey.serial, devices, pin).await?;
+
+            Ok(ResolvedOperator {
+                name: Some(operator.name.clone()),
+                operator_id,
+                signer: Box::new(pair),
+            })
+        }
+        OperatorKind::Local => {
+            let (operator, local) = org
+                .select_local_operator()
+                .with_context(|| format!("org '{alias}'"))?;
+
+            let configured_operator_id = local
+                .operator_id
+                .as_deref()
+                .map(|id| {
+                    Uuid::parse_str(id)
+                        .map_err(|_| anyhow!("configured local operator ID must be a UUID"))
+                })
+                .transpose()?;
+
+            let resolved_operator_id = match (configured_operator_id, operator_id) {
+                (Some(configured), Some(requested)) => {
+                    ensure!(
+                        configured == requested,
+                        "requested operator ID ({requested}) does not match configured local operator ID ({configured})"
+                    );
+                    Some(configured)
+                }
+                (configured, requested) => configured.or(requested),
+            };
+
+            Ok(ResolvedOperator {
+                name: Some(operator.name.clone()),
+                operator_id: resolved_operator_id,
+                signer: Box::new(resolve_registered_local_operator(local.key_path.clone()).await?),
+            })
         }
     }
-
-    let (operator, local) = org
-        .select_local_operator()
-        .with_context(|| format!("org '{alias}'"))?;
-
-    let configured_operator_id = local
-        .operator_id
-        .as_deref()
-        .map(|id| {
-            Uuid::parse_str(id).map_err(|_| anyhow!("configured local operator ID must be a UUID"))
-        })
-        .transpose()?;
-
-    let resolved_operator_id = match (configured_operator_id, operator_id) {
-        (Some(configured), Some(requested)) => {
-            ensure!(
-                configured == requested,
-                "requested operator ID ({requested}) does not match configured local operator ID ({configured})"
-            );
-            Some(configured)
-        }
-        (configured, requested) => configured.or(requested),
-    };
-
-    Ok(ResolvedOperator {
-        name: Some(operator.name.clone()),
-        operator_id: resolved_operator_id,
-        signer: Box::new(resolve_registered_local_operator(local.key_path.clone()).await?),
-    })
 }
 
 /// One operator identity known for the active org, labeled with its registry
@@ -372,6 +401,9 @@ mod tests {
         HostedOperatorRecord, LocalOperatorRecord, OperatorRecord, OperatorRecordKind, OrgConfig,
         QosOperatorPublicKey, YubiKeyOperatorRecord, YubiKeySerial,
     };
+    use crate::pair::{HexSeed, LocalPair};
+    use crate::yubikey::test_support::{self, FakeDevice};
+    use crate::yubikey::{Pin, SlotStatus};
     use qos_p256::P256Pair;
     use std::{collections::HashMap, path::PathBuf};
 
@@ -461,6 +493,197 @@ mod tests {
         let config = yubikey_default_config(YubiKeySerial::from(0x01c9_5c1f));
 
         assert_eq!(config.default_operator_public_key().await, None);
+    }
+
+    fn provisioned_fake() -> FakeDevice {
+        FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned)
+    }
+
+    fn fixed_pin() -> PinAcquisition {
+        PinAcquisition::Fixed(Pin::from(
+            String::from_utf8(test_support::PIN.to_vec()).unwrap(),
+        ))
+    }
+
+    fn registered_yubikey_config(device: &FakeDevice) -> Config {
+        let mut config = yubikey_default_config(test_support::serial());
+        config.register_yubikey(test_support::serial(), device.operator_public_key());
+        config
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_resolves_a_device_backed_signer() {
+        let device = provisioned_fake();
+        let composite = device.operator_public_key();
+        let config = registered_yubikey_config(&device);
+
+        let operator = resolve_operator(
+            &config,
+            device,
+            None,
+            None,
+            SignerRequirement::Any,
+            fixed_pin(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(operator.signer.public_key(), composite.as_bytes());
+        assert_eq!(operator.name, Some("yubikey".to_string()));
+        assert_eq!(operator.id(), None);
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_satisfies_an_offline_approval() {
+        let device = provisioned_fake();
+        let config = registered_yubikey_config(&device);
+
+        let operator = resolve_operator(
+            &config,
+            device,
+            None,
+            None,
+            SignerRequirement::OfflineApproval,
+            fixed_pin(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(operator.name, Some("yubikey".to_string()));
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_passes_a_given_operator_id_through() {
+        let device = provisioned_fake();
+        let config = registered_yubikey_config(&device);
+        let requested = Uuid::from_u128(0x22);
+
+        let operator = resolve_operator(
+            &config,
+            device,
+            None,
+            Some(requested),
+            SignerRequirement::Any,
+            fixed_pin(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(operator.id(), Some(requested));
+    }
+
+    #[tokio::test]
+    async fn an_explicit_seed_beats_a_yubikey_default() {
+        let device = provisioned_fake();
+        let config = registered_yubikey_config(&device);
+        let seed_hex = "ab".repeat(32);
+        let seed: HexSeed = seed_hex.parse().unwrap();
+        let expected = LocalPair::from_hex_seed(&seed_hex).unwrap().public_key();
+
+        let operator = resolve_operator(
+            &config,
+            device,
+            Some(LocalOperatorSeedSource::Value(seed)),
+            None,
+            SignerRequirement::Any,
+            fixed_pin(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(operator.signer.public_key(), expected);
+        assert_eq!(operator.name, None);
+    }
+
+    #[tokio::test]
+    async fn a_hosted_operator_id_beats_a_yubikey_default() {
+        let device = provisioned_fake();
+        let mut config = registered_yubikey_config(&device);
+        config
+            .orgs
+            .get_mut("active")
+            .unwrap()
+            .operators
+            .push(hosted_operator("hosted"));
+
+        let error = resolve_operator(
+            &config,
+            device,
+            None,
+            Some(HOSTED_ID.parse().unwrap()),
+            SignerRequirement::OfflineApproval,
+            fixed_pin(),
+        )
+        .await
+        .unwrap_err();
+
+        // The hosted-by-id branch fired (pinning its rewording), so the
+        // yubikey default never resolved.
+        assert_eq!(
+            error.to_string(),
+            "--skip-post is not supported for hosted operators"
+        );
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_without_a_pin_bails_actionably() {
+        let device = provisioned_fake();
+        let config = registered_yubikey_config(&device);
+
+        let error = resolve_operator(
+            &config,
+            device,
+            None,
+            None,
+            SignerRequirement::Any,
+            PinAcquisition::Unavailable,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("interactive prompt"));
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_without_a_record_names_the_org() {
+        let mut config = config_with_operators(Vec::new());
+        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
+
+        let error = resolve_operator(
+            &config,
+            provisioned_fake(),
+            None,
+            None,
+            SignerRequirement::Any,
+            fixed_pin(),
+        )
+        .await
+        .unwrap_err();
+
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("org 'active'"));
+        assert!(rendered.contains("no YubiKey operator is configured"));
+    }
+
+    #[tokio::test]
+    async fn yubikey_default_with_multiple_records_is_refused() {
+        let serial = test_support::serial();
+        let mut config =
+            config_with_operators(vec![yubikey_operator(serial), yubikey_operator(serial)]);
+        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
+
+        let error = resolve_operator(
+            &config,
+            provisioned_fake(),
+            None,
+            None,
+            SignerRequirement::Any,
+            fixed_pin(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("multiple YubiKey operators are configured"));
     }
 
     #[test]

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -18,7 +18,7 @@ use crate::{
         LocalOperatorSeedSource, resolve_local_operator, resolve_registered_local_operator,
     },
     pair::{Pair, Signer},
-    yubikey::{DeviceOps, pair::PinAcquisition},
+    yubikey::{DeviceError, DeviceOps, pair::PinAcquisition},
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hosted::HostedSigner;
@@ -183,14 +183,18 @@ pub(crate) enum SignerRequirement {
 /// Config is loaded lazily inside: the explicit-seed path must not depend
 /// on a config file being present or well-formed (pinned by
 /// `explicit_seed_does_not_load_malformed_config`).
-pub(crate) async fn resolve_operator<D: DeviceOps + Send + 'static>(
+pub(crate) async fn resolve_operator<D, O>(
     config: &Config,
-    devices: D,
+    open_device: O,
     explicit: Option<LocalOperatorSeedSource>,
     operator_id: Option<Uuid>,
     requirement: SignerRequirement,
     pin: PinAcquisition,
-) -> Result<ResolvedOperator> {
+) -> Result<ResolvedOperator>
+where
+    D: DeviceOps + Send + 'static,
+    O: FnOnce(crate::config::turnkey::YubiKeySerial) -> Result<D, DeviceError>,
+{
     if let Some(explicit) = explicit {
         if let Some(id) = operator_id {
             ensure!(
@@ -265,7 +269,8 @@ pub(crate) async fn resolve_operator<D: DeviceOps + Send + 'static>(
             let (operator, yubikey) = org
                 .select_yubikey_operator()
                 .with_context(|| format!("org '{alias}'"))?;
-            let pair = config.resolve_yubikey(yubikey.serial, devices, pin).await?;
+            let device = open_device(yubikey.serial)?;
+            let pair = config.resolve_yubikey(yubikey.serial, device, pin).await?;
 
             Ok(ResolvedOperator {
                 name: Some(operator.name.clone()),
@@ -353,7 +358,7 @@ impl Config {
             }
             OperatorKind::Yubikey => {
                 let (_, yubikey) = org.select_yubikey_operator().ok()?;
-                let entry = self.yubikey_registry_entry(yubikey.serial)?;
+                let entry = self.yubikeys.get(yubikey.serial)?;
                 Some(entry.public_key.to_string())
             }
         }
@@ -364,12 +369,16 @@ impl Config {
     /// the config. Hosted operators sign through the API and hold no local
     /// key material, so a hosted default is redirected to the hosted
     /// counterpart of the flow.
-    pub(crate) async fn resolve_operator_pair<D: DeviceOps + Send + 'static>(
+    pub(crate) async fn resolve_operator_pair<D, O>(
         &self,
-        devices: D,
+        open_device: O,
         explicit: Option<LocalOperatorSeedSource>,
         pin: PinAcquisition,
-    ) -> Result<Box<dyn Pair>> {
+    ) -> Result<Box<dyn Pair>>
+    where
+        D: DeviceOps + Send + 'static,
+        O: FnOnce(crate::config::turnkey::YubiKeySerial) -> Result<D, DeviceError>,
+    {
         if explicit.is_some() {
             return Ok(Box::new(resolve_local_operator(self, explicit).await?));
         }
@@ -395,9 +404,10 @@ impl Config {
                 let (_, yubikey) = org
                     .select_yubikey_operator()
                     .with_context(|| format!("org '{alias}'"))?;
+                let device = open_device(yubikey.serial)?;
 
                 Ok(Box::new(
-                    self.resolve_yubikey(yubikey.serial, devices, pin).await?,
+                    self.resolve_yubikey(yubikey.serial, device, pin).await?,
                 ))
             }
             // TODO(TVC-202): remove hardcoded user-facing messages mentioning
@@ -531,7 +541,7 @@ mod tests {
         let serial = YubiKeySerial::from(0x01c9_5c1f);
         let composite = QosOperatorPublicKey::try_from([7u8; 130].as_slice()).unwrap();
         let mut config = yubikey_default_config(serial);
-        config.register_yubikey(serial, composite);
+        config.yubikeys.register(serial, composite);
 
         assert_eq!(
             config.default_operator_public_key().await,
@@ -550,6 +560,18 @@ mod tests {
         FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned)
     }
 
+    fn open_fake(
+        device: FakeDevice,
+    ) -> impl FnOnce(YubiKeySerial) -> Result<FakeDevice, DeviceError> {
+        move |serial| {
+            if serial == test_support::serial() {
+                Ok(device)
+            } else {
+                Err(DeviceError::NotFound { serial })
+            }
+        }
+    }
+
     fn fixed_pin() -> PinAcquisition {
         PinAcquisition::Fixed(Pin::from(
             String::from_utf8(test_support::PIN.to_vec()).unwrap(),
@@ -558,7 +580,9 @@ mod tests {
 
     fn registered_yubikey_config(device: &FakeDevice) -> Config {
         let mut config = yubikey_default_config(test_support::serial());
-        config.register_yubikey(test_support::serial(), device.operator_public_key());
+        config
+            .yubikeys
+            .register(test_support::serial(), device.operator_public_key());
         config
     }
 
@@ -570,7 +594,7 @@ mod tests {
 
         let operator = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             None,
             None,
             SignerRequirement::Any,
@@ -591,7 +615,7 @@ mod tests {
 
         let operator = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             None,
             None,
             SignerRequirement::OfflineApproval,
@@ -611,7 +635,7 @@ mod tests {
 
         let operator = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             None,
             Some(requested),
             SignerRequirement::Any,
@@ -633,7 +657,7 @@ mod tests {
 
         let operator = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             Some(LocalOperatorSeedSource::Value(seed)),
             None,
             SignerRequirement::Any,
@@ -659,7 +683,7 @@ mod tests {
 
         let error = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             None,
             Some(HOSTED_ID.parse().unwrap()),
             SignerRequirement::OfflineApproval,
@@ -683,7 +707,7 @@ mod tests {
 
         let error = resolve_operator(
             &config,
-            device,
+            open_fake(device),
             None,
             None,
             SignerRequirement::Any,
@@ -702,7 +726,7 @@ mod tests {
 
         let error = resolve_operator(
             &config,
-            provisioned_fake(),
+            open_fake(provisioned_fake()),
             None,
             None,
             SignerRequirement::Any,
@@ -725,7 +749,7 @@ mod tests {
         // be prompted.
         let pair = Config::default()
             .resolve_operator_pair(
-                provisioned_fake(),
+                open_fake(provisioned_fake()),
                 Some(LocalOperatorSeedSource::Value(seed_hex.parse().unwrap())),
                 PinAcquisition::Unavailable,
             )
@@ -760,7 +784,11 @@ mod tests {
         let expected = LocalPair::from_hex_seed(&private_key).unwrap().public_key();
 
         let pair = config
-            .resolve_operator_pair(provisioned_fake(), None, PinAcquisition::Unavailable)
+            .resolve_operator_pair(
+                open_fake(provisioned_fake()),
+                None,
+                PinAcquisition::Unavailable,
+            )
             .await
             .unwrap();
 
@@ -774,7 +802,7 @@ mod tests {
         let config = registered_yubikey_config(&device);
 
         let pair = config
-            .resolve_operator_pair(device, None, fixed_pin())
+            .resolve_operator_pair(open_fake(device), None, fixed_pin())
             .await
             .unwrap();
 
@@ -787,7 +815,11 @@ mod tests {
         config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Hosted;
 
         let error = config
-            .resolve_operator_pair(provisioned_fake(), None, PinAcquisition::Unavailable)
+            .resolve_operator_pair(
+                open_fake(provisioned_fake()),
+                None,
+                PinAcquisition::Unavailable,
+            )
             .await
             .err()
             .expect("a hosted default cannot decrypt locally");
@@ -804,7 +836,7 @@ mod tests {
 
         let error = resolve_operator(
             &config,
-            provisioned_fake(),
+            open_fake(provisioned_fake()),
             None,
             None,
             SignerRequirement::Any,

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -55,8 +55,9 @@ pub enum Outcome {
     AppDeleted(app::delete::AppDeleted),
     OperatorKeyBackedUp(keys::backup_operator_key::OperatorKeyBackedUp),
     // Spelled Yubikey, not YubiKey: the variant name IS the reason (see the
-    // module docs), and the wire strings are yubikey_provisioned/_deleted.
+    // module docs), and the wire strings are yubikey_provisioned/_refreshed/_deleted.
     YubikeyProvisioned(keys::provision_yubikey::YubiKeyProvisioned),
+    YubikeyRefreshed(keys::refresh_yubikey::YubiKeyRefreshed),
     YubikeyDeleted(keys::delete_yubikey::YubiKeyDeleted),
     QuorumKeyCreated(keys::create_quorum_key::QuorumKeyCreated),
     QuorumKeyGenerated(keys::generate_local_quorum_key::QuorumKeyGenerated),
@@ -95,6 +96,7 @@ impl Display for Outcome {
             Outcome::AppDeleted(msg) => msg.fmt(f),
             Outcome::OperatorKeyBackedUp(msg) => msg.fmt(f),
             Outcome::YubikeyProvisioned(msg) => msg.fmt(f),
+            Outcome::YubikeyRefreshed(msg) => msg.fmt(f),
             Outcome::YubikeyDeleted(msg) => msg.fmt(f),
             Outcome::QuorumKeyCreated(msg) => msg.fmt(f),
             Outcome::QuorumKeyGenerated(msg) => msg.fmt(f),

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -26,6 +26,15 @@ pub trait Signer: Send + Sync {
     fn public_key(&self) -> Vec<u8>;
 }
 
+/// A signer whose key material can also decrypt locally — a seed in memory
+/// or a hardware device. Hosted operators sign through the API and can never
+/// implement this.
+pub trait Pair: Signer {
+    /// Decrypt a qos p256 envelope addressed to this operator's
+    /// encryption key.
+    fn decrypt(&self, ciphertext: &[u8]) -> SignerFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>>;
+}
+
 /// A 32-byte master seed parsed from hex. Accepts surrounding whitespace and
 /// an optional `0x` prefix. Zeroized on drop.
 #[derive(Clone)]
@@ -80,15 +89,6 @@ impl LocalPair {
             pair: Arc::new(pair),
         })
     }
-
-    /// Decrypt the given ciphertext. Decryption needs the private key
-    /// material, so it lives on the concrete local pair rather than
-    /// [`Signer`].
-    pub fn decrypt(&self, ciphertext: &[u8]) -> anyhow::Result<Zeroizing<Vec<u8>>> {
-        self.pair
-            .decrypt(ciphertext)
-            .map_err(|_| anyhow!("failed to decrypt with local signer"))
-    }
 }
 
 impl Signer for LocalPair {
@@ -104,6 +104,19 @@ impl Signer for LocalPair {
 
     fn public_key(&self) -> Vec<u8> {
         self.pair.public_key().to_bytes()
+    }
+}
+
+impl Pair for LocalPair {
+    fn decrypt(&self, ciphertext: &[u8]) -> SignerFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>> {
+        // Local decryption is CPU-bound and quick; blocking the executor is
+        // fine for the same reason it is in [`Signer::sign`] above.
+        let plaintext = self
+            .pair
+            .decrypt(ciphertext)
+            .map_err(|_| anyhow!("failed to decrypt with local signer"));
+
+        Box::pin(async move { plaintext })
     }
 }
 

--- a/tvc/src/pair.rs
+++ b/tvc/src/pair.rs
@@ -1,6 +1,6 @@
 use crate::util::read_file_to_string;
-use anyhow::anyhow;
-use qos_p256::P256Pair;
+use anyhow::{Context, anyhow};
+use qos_p256::{P256Error, P256Pair};
 use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::path::Path;
@@ -34,6 +34,15 @@ pub trait Pair: Signer {
     /// encryption key.
     fn decrypt(&self, ciphertext: &[u8]) -> SignerFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>>;
 }
+
+/// A `qos_p256` failure. The inner error implements neither `Display` nor
+/// `Error`, so it is carried by value and rendered from `Debug`; callers
+/// attach the operation context.
+// TODO: derive Display + Error in qos_p256 and chain the inner error as a
+// #[source] instead.
+#[derive(Debug, thiserror::Error)]
+#[error("{0:?}")]
+pub(crate) struct QosP256Error(pub(crate) P256Error);
 
 /// A 32-byte master seed parsed from hex. Accepts surrounding whitespace and
 /// an optional `0x` prefix. Zeroized on drop.
@@ -114,7 +123,8 @@ impl Pair for LocalPair {
         let plaintext = self
             .pair
             .decrypt(ciphertext)
-            .map_err(|_| anyhow!("failed to decrypt with local signer"));
+            .map_err(QosP256Error)
+            .context("failed to decrypt with local signer");
 
         Box::pin(async move { plaintext })
     }

--- a/tvc/src/yubikey.rs
+++ b/tvc/src/yubikey.rs
@@ -23,6 +23,8 @@
 //! behind until the slot is reprovisioned, and TVC never resets a device.
 
 use crate::config::turnkey::{QosOperatorPublicKey, QosOperatorPublicKeyParseError, YubiKeySerial};
+use p256::PublicKey;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
 use qos_client::{
     yubikey::{KEY_AGREEMENT_SLOT, SIGNING_SLOT, YubiKeyError},
     yubikey_crate as yubikey,
@@ -297,13 +299,12 @@ pub(crate) trait DeviceOps {
     /// Requires the PIN and a physical touch.
     fn sign(&mut self, pin: &Pin, message: &[u8]) -> Result<Vec<u8>, DeviceError>;
 
-    /// Raw ECDH between the key-agreement slot key and `sender_public`, an
-    /// uncompressed SEC1-encoded P-256 point. Requires the PIN and a
-    /// physical touch.
+    /// Raw ECDH between the key-agreement slot key and `sender_public`.
+    /// Requires the PIN and a physical touch.
     fn key_agreement(
         &mut self,
         pin: &Pin,
-        sender_public: &[u8],
+        sender_public: PublicKey,
     ) -> Result<Zeroizing<Vec<u8>>, DeviceError>;
 
     /// Verify both QuorumOS slots hold TVC-provisioned keys and return the
@@ -383,16 +384,18 @@ impl DeviceOps for YubiKey {
     fn key_agreement(
         &mut self,
         pin: &Pin,
-        sender_public: &[u8],
+        sender_public: PublicKey,
     ) -> Result<Zeroizing<Vec<u8>>, DeviceError> {
-        qos_client::yubikey::key_agreement(self, sender_public, pin.as_bytes()).map_err(|error| {
-            match error {
+        let sender_point = sender_public.to_encoded_point(false);
+
+        qos_client::yubikey::key_agreement(self, sender_point.as_bytes(), pin.as_bytes()).map_err(
+            |error| match error {
                 YubiKeyError::FailedToVerifyPin(PivError::WrongPin { tries }) => {
                     DeviceError::WrongPin { tries }
                 }
                 error => DeviceError::KeyAgreement { error },
-            }
-        })
+            },
+        )
     }
 
     fn delete_qos_certificate(&mut self, slot: QosSlot) -> Result<(), DeviceError> {
@@ -630,7 +633,7 @@ mod tests {
         let sender = P256Pair::generate().unwrap();
 
         let secret = device
-            .key_agreement(&default_pin(), &sender.public_key().to_bytes()[..65])
+            .key_agreement(&default_pin(), sender.encryption_key().public_key())
             .unwrap();
 
         let composite = hex::decode(device.operator_public_key().to_string()).unwrap();
@@ -646,9 +649,10 @@ mod tests {
     #[test]
     fn key_agreement_requires_a_provisioned_key_agreement_slot() {
         let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::Empty);
+        let sender = P256Pair::generate().unwrap();
 
         let error = device
-            .key_agreement(&default_pin(), &[4u8; 65])
+            .key_agreement(&default_pin(), sender.encryption_key().public_key())
             .unwrap_err();
 
         assert!(matches!(
@@ -780,7 +784,7 @@ mod tests {
 
         let sender = P256Pair::generate().unwrap();
         let secret = yubikey
-            .key_agreement(&pin, &sender.public_key().to_bytes()[..65])
+            .key_agreement(&pin, sender.encryption_key().public_key())
             .unwrap();
         let device_encrypt_public = PublicKey::from_sec1_bytes(&composite[..65]).unwrap();
         let expected = diffie_hellman(

--- a/tvc/src/yubikey.rs
+++ b/tvc/src/yubikey.rs
@@ -414,6 +414,8 @@ impl DeviceOps for YubiKey {
     }
 }
 
+pub(crate) mod pair;
+
 #[cfg(test)]
 pub(crate) mod test_support;
 

--- a/tvc/src/yubikey.rs
+++ b/tvc/src/yubikey.rs
@@ -159,8 +159,8 @@ impl DeviceStatus {
     }
 }
 
-/// A YubiKey PIV PIN, held only for the duration of a provisioning call and
-/// zeroized on drop. Never persisted.
+/// A YubiKey PIV PIN, held only for the duration of device-backed operations
+/// and zeroized on drop. Never persisted.
 pub(crate) struct Pin(Zeroizing<Vec<u8>>);
 
 impl From<String> for Pin {
@@ -213,10 +213,15 @@ pub(crate) enum DeviceError {
         "the {slot} slot holds a non-QuorumOS certificate ({subject}); refusing to touch this device"
     )]
     ForeignSlot { slot: QosSlot, subject: String },
+    /// The slot holds no key; the device is not fully provisioned.
+    #[error("the {slot} slot holds no QuorumOS key")]
+    EmptySlot { slot: QosSlot },
     #[error(
         "the {slot} slot no longer holds a QuorumOS certificate; the device changed since it was inspected"
     )]
     ChangedSinceInspection { slot: QosSlot },
+    #[error("the YubiKey PIN was rejected; {tries} attempts remain before the PIN locks")]
+    WrongPin { tries: u8 },
     // qos_client's YubiKeyError implements neither Display nor Error, so it
     // is rendered by value instead of chained as a source.
     // TODO: derive those in qos_client and turn these fields into #[source].
@@ -224,6 +229,14 @@ pub(crate) enum DeviceError {
     Provision { slot: QosSlot, error: YubiKeyError },
     #[error("failed to read the operator public key from the device: {error:?}")]
     ReadPairPublicKey { error: YubiKeyError },
+    #[error(
+        "failed to sign with the YubiKey (a missed touch while it blinks times out): {error:?}"
+    )]
+    Sign { error: YubiKeyError },
+    #[error(
+        "failed to compute the YubiKey shared secret (a missed touch while it blinks times out): {error:?}"
+    )]
+    KeyAgreement { error: YubiKeyError },
     #[error("device returned a malformed operator public key")]
     MalformedPairPublicKey(#[source] QosOperatorPublicKeyParseError),
     #[error("failed to authenticate with the default PIV management key")]
@@ -278,6 +291,37 @@ pub(crate) trait DeviceOps {
     /// the two slot certificates.
     fn pair_public_key(&mut self) -> Result<QosOperatorPublicKey, DeviceError>;
 
+    /// Sign `message` with the signing-slot key: the message is SHA-256
+    /// digested on the way in and the signature comes back as raw 64-byte
+    /// `r ‖ s`, verified against the slot certificate before returning.
+    /// Requires the PIN and a physical touch.
+    fn sign(&mut self, pin: &Pin, message: &[u8]) -> Result<Vec<u8>, DeviceError>;
+
+    /// Raw ECDH between the key-agreement slot key and `sender_public`, an
+    /// uncompressed SEC1-encoded P-256 point. Requires the PIN and a
+    /// physical touch.
+    fn key_agreement(
+        &mut self,
+        pin: &Pin,
+        sender_public: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, DeviceError>;
+
+    /// Verify both QuorumOS slots hold TVC-provisioned keys and return the
+    /// device's composite operator key. Refuses on foreign or empty slots.
+    fn verified_pair_public_key(&mut self) -> Result<QosOperatorPublicKey, DeviceError> {
+        let status = self.device_status()?;
+
+        if let Some(error) = status.unprovisionable_slot() {
+            return Err(error);
+        }
+
+        if let Some(slot) = status.slots_with(SlotStatus::Empty).into_iter().next() {
+            return Err(DeviceError::EmptySlot { slot });
+        }
+
+        self.pair_public_key()
+    }
+
     /// Delete one slot's certificate.
     ///
     /// Gated on what this handle reads immediately beforehand: the slot must
@@ -327,6 +371,30 @@ impl DeviceOps for YubiKey {
             .map_err(DeviceError::MalformedPairPublicKey)
     }
 
+    fn sign(&mut self, pin: &Pin, message: &[u8]) -> Result<Vec<u8>, DeviceError> {
+        qos_client::yubikey::sign_data(self, message, pin.as_bytes()).map_err(|error| match error {
+            YubiKeyError::FailedToVerifyPin(PivError::WrongPin { tries }) => {
+                DeviceError::WrongPin { tries }
+            }
+            error => DeviceError::Sign { error },
+        })
+    }
+
+    fn key_agreement(
+        &mut self,
+        pin: &Pin,
+        sender_public: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, DeviceError> {
+        qos_client::yubikey::key_agreement(self, sender_public, pin.as_bytes()).map_err(|error| {
+            match error {
+                YubiKeyError::FailedToVerifyPin(PivError::WrongPin { tries }) => {
+                    DeviceError::WrongPin { tries }
+                }
+                error => DeviceError::KeyAgreement { error },
+            }
+        })
+    }
+
     fn delete_qos_certificate(&mut self, slot: QosSlot) -> Result<(), DeviceError> {
         match self.slot_status(slot)? {
             SlotStatus::QosProvisioned => {}
@@ -347,8 +415,29 @@ impl DeviceOps for YubiKey {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support;
+
+#[cfg(test)]
 mod tests {
+    use super::test_support::{FakeDevice, PIN};
     use super::*;
+    use p256::PublicKey;
+    use p256::ecdh::diffie_hellman;
+    use qos_p256::{P256Pair, P256Public};
+
+    fn default_pin() -> Pin {
+        Pin::from(String::from_utf8(PIN.to_vec()).unwrap())
+    }
+
+    fn sole_connected_serial() -> YubiKeySerial {
+        let connected = connected_serials().unwrap();
+
+        let [serial] = connected.as_slice() else {
+            panic!("connect exactly one YubiKey; found {connected:?}");
+        };
+
+        *serial
+    }
 
     fn qos_subject() -> Result<String, PivError> {
         Ok(QOS_CERTIFICATE_SUBJECT.to_string())
@@ -494,6 +583,118 @@ mod tests {
         );
     }
 
+    #[test]
+    fn sign_produces_a_signature_verifiable_with_the_composite_key() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
+        let message = b"manifest hash stand-in";
+
+        let signature = device.sign(&default_pin(), message).unwrap();
+
+        let composite = hex::decode(device.operator_public_key().to_string()).unwrap();
+        P256Public::from_bytes(&composite)
+            .unwrap()
+            .verify(message, &signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn sign_rejects_a_wrong_pin_with_the_retry_count() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
+
+        let error = device
+            .sign(&Pin::from("999999".to_string()), b"message")
+            .unwrap_err();
+
+        assert!(matches!(error, DeviceError::WrongPin { tries: 3 }));
+    }
+
+    #[test]
+    fn sign_requires_a_provisioned_signing_slot() {
+        let mut device = FakeDevice::new(SlotStatus::Empty, SlotStatus::QosProvisioned);
+
+        let error = device.sign(&default_pin(), b"message").unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeviceError::EmptySlot {
+                slot: QosSlot::Signing
+            }
+        ));
+    }
+
+    #[test]
+    fn key_agreement_matches_a_software_shared_secret() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
+        let sender = P256Pair::generate().unwrap();
+
+        let secret = device
+            .key_agreement(&default_pin(), &sender.public_key().to_bytes()[..65])
+            .unwrap();
+
+        let composite = hex::decode(device.operator_public_key().to_string()).unwrap();
+        let device_encrypt_public = PublicKey::from_sec1_bytes(&composite[..65]).unwrap();
+        let expected = diffie_hellman(
+            sender.encryption_key().to_nonzero_scalar(),
+            device_encrypt_public.as_affine(),
+        );
+
+        assert_eq!(secret.as_slice(), expected.raw_secret_bytes().as_slice());
+    }
+
+    #[test]
+    fn key_agreement_requires_a_provisioned_key_agreement_slot() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::Empty);
+
+        let error = device
+            .key_agreement(&default_pin(), &[4u8; 65])
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeviceError::EmptySlot {
+                slot: QosSlot::KeyAgreement
+            }
+        ));
+    }
+
+    #[test]
+    fn verified_pair_public_key_returns_the_composite() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned);
+
+        let key = device.verified_pair_public_key().unwrap();
+
+        assert_eq!(key, device.operator_public_key());
+    }
+
+    #[test]
+    fn verified_pair_public_key_refuses_a_foreign_slot() {
+        let mut device = FakeDevice::new(foreign(), SlotStatus::QosProvisioned);
+
+        let error = device.verified_pair_public_key().unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeviceError::ForeignSlot {
+                slot: QosSlot::Signing,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verified_pair_public_key_refuses_an_empty_slot() {
+        let mut device = FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::Empty);
+
+        let error = device.verified_pair_public_key().unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeviceError::EmptySlot {
+                slot: QosSlot::KeyAgreement
+            }
+        ));
+    }
+
     /// Full provision-inspect-delete cycle against real hardware.
     ///
     /// DESTRUCTIVE: generates keys in, and deletes the certificates from,
@@ -504,12 +705,8 @@ mod tests {
     #[test]
     #[ignore = "requires a connected YubiKey with default PIN/management key; overwrites its QuorumOS slots"]
     fn hardware_provision_and_delete_cycle() {
-        let connected = connected_serials().unwrap();
-        let [serial] = connected.as_slice() else {
-            panic!("connect exactly one YubiKey; found {connected:?}");
-        };
-        let mut yubikey = open(*serial).unwrap();
-        let pin = Pin::from(String::from_utf8(qos_client::yubikey::DEFAULT_PIN.to_vec()).unwrap());
+        let mut yubikey = open(sole_connected_serial()).unwrap();
+        let pin = default_pin();
 
         let status = yubikey.device_status().unwrap();
 
@@ -543,5 +740,71 @@ mod tests {
                 key_agreement: SlotStatus::KeyWithoutCertificate,
             }
         );
+    }
+
+    /// Signing and key agreement against real hardware.
+    ///
+    /// DESTRUCTIVE: provisions the QuorumOS slots of the sole connected
+    /// YubiKey when they are empty, and leaves them provisioned. Requires
+    /// the factory-default PIN and management key; sign and key agreement
+    /// each need a touch while the device blinks. Run manually:
+    /// `cargo test -p tvc --lib -- --ignored hardware_`
+    #[test]
+    #[ignore = "requires a connected YubiKey with default PIN/management key; provisions its QuorumOS slots"]
+    fn hardware_sign_and_key_agreement() {
+        let mut yubikey = open(sole_connected_serial()).unwrap();
+        let pin = default_pin();
+
+        let absent = YubiKeySerial::from(0x0000_0001);
+        assert!(matches!(open(absent), Err(DeviceError::NotFound { .. })));
+
+        let status = yubikey.device_status().unwrap();
+
+        status
+            .slots_with(SlotStatus::Empty)
+            .iter()
+            .try_for_each(|slot| yubikey.provision_slot(*slot, &pin))
+            .unwrap();
+
+        let verified = yubikey.verified_pair_public_key().unwrap();
+        let composite = hex::decode(verified.to_string()).unwrap();
+
+        let message = b"tvc hardware signing test";
+        let signature = yubikey.sign(&pin, message).unwrap();
+        P256Public::from_bytes(&composite)
+            .unwrap()
+            .verify(message, &signature)
+            .unwrap();
+
+        let sender = P256Pair::generate().unwrap();
+        let secret = yubikey
+            .key_agreement(&pin, &sender.public_key().to_bytes()[..65])
+            .unwrap();
+        let device_encrypt_public = PublicKey::from_sec1_bytes(&composite[..65]).unwrap();
+        let expected = diffie_hellman(
+            sender.encryption_key().to_nonzero_scalar(),
+            device_encrypt_public.as_affine(),
+        );
+        assert_eq!(secret.as_slice(), expected.raw_secret_bytes().as_slice());
+    }
+
+    /// Wrong-PIN reporting against real hardware.
+    ///
+    /// Burns one PIN retry with a deliberately wrong PIN, then restores the
+    /// counter by signing with the factory-default PIN (one touch). Requires
+    /// a provisioned device — run `hardware_sign_and_key_agreement` first.
+    #[test]
+    #[ignore = "requires a provisioned YubiKey with default PIN; burns and restores one PIN retry"]
+    fn hardware_wrong_pin_reports_retries() {
+        let mut yubikey = open(sole_connected_serial()).unwrap();
+
+        let error = yubikey
+            .sign(&Pin::from("999999".to_string()), b"wrong pin probe")
+            .unwrap_err();
+        assert!(matches!(error, DeviceError::WrongPin { .. }));
+
+        yubikey
+            .sign(&default_pin(), b"restore the retry counter")
+            .unwrap();
     }
 }

--- a/tvc/src/yubikey/pair.rs
+++ b/tvc/src/yubikey/pair.rs
@@ -35,15 +35,19 @@ pub(crate) enum PinAcquisition {
 }
 
 /// A [`PinAcquisition`] with the [`PinAcquisition::Unavailable`] case
-/// refused, so device I/O only starts once a PIN can definitely follow.
-enum AvailablePin {
+/// refused: holding one is proof that device I/O can start because a PIN
+/// can definitely follow.
+pub(crate) enum AvailablePin {
     Prompt,
     #[cfg(test)]
     Fixed(Pin),
 }
 
 impl PinAcquisition {
-    fn into_available(self) -> anyhow::Result<AvailablePin> {
+    /// Refuse the [`PinAcquisition::Unavailable`] case. Deterministic from
+    /// interaction mode alone, so callers convert before starting any other
+    /// work an impossible run would waste.
+    pub(crate) fn into_available(self) -> anyhow::Result<AvailablePin> {
         match self {
             Self::Prompt => Ok(AvailablePin::Prompt),
             Self::Unavailable => bail!(
@@ -157,18 +161,16 @@ impl<D: DeviceOps + Send + 'static> Pair for YubiKeyPair<D> {
 impl Config {
     /// Resolve a registered serial into a usable operator pair.
     ///
-    /// Refusals come in resolution order: a PIN that can never be collected,
-    /// an unregistered serial, an unprovisioned device, and a registry cache
-    /// that no longer matches the device. The PIN prompt runs last, after the
-    /// device checks, so nothing is typed at a device that cannot be used.
+    /// Refusals come in resolution order: an unregistered serial, an
+    /// unprovisioned device, and a registry cache that no longer matches the
+    /// device. The PIN prompt runs last, after the device checks, so nothing
+    /// is typed at a device that cannot be used.
     pub(crate) async fn resolve_yubikey<D: DeviceOps + Send + 'static>(
         &self,
         serial: YubiKeySerial,
         device: D,
-        pin: PinAcquisition,
+        pin: AvailablePin,
     ) -> anyhow::Result<YubiKeyPair<D>> {
-        let pin = pin.into_available()?;
-
         let cached_public_key = self
             .yubikeys
             .get(serial)
@@ -236,12 +238,12 @@ mod tests {
         config
     }
 
-    fn fixed_pin() -> PinAcquisition {
-        PinAcquisition::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap()))
+    fn fixed_pin() -> AvailablePin {
+        AvailablePin::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap()))
     }
 
-    fn wrong_pin() -> PinAcquisition {
-        PinAcquisition::Fixed(Pin::from("999999".to_string()))
+    fn wrong_pin() -> AvailablePin {
+        AvailablePin::Fixed(Pin::from("999999".to_string()))
     }
 
     fn rendered(error: &anyhow::Error) -> String {
@@ -320,19 +322,9 @@ mod tests {
         assert!(rendered(&error).contains("refresh-yubikey"));
     }
 
-    #[tokio::test]
-    async fn an_unavailable_pin_is_refused_before_anything_else() {
-        // The registry is empty and the device is unprovisioned: reaching
-        // either would produce a different error, so the PIN message proves
-        // the refusal came first.
-        let error = Config::default()
-            .resolve_yubikey(
-                serial(),
-                FakeDevice::new(SlotStatus::Empty, SlotStatus::Empty),
-                PinAcquisition::Unavailable,
-            )
-            .await
-            .unwrap_err();
+    #[test]
+    fn an_unavailable_pin_is_refused_at_conversion() {
+        let error = PinAcquisition::Unavailable.into_available().err().unwrap();
 
         assert!(rendered(&error).contains("interactive prompt"));
     }
@@ -414,7 +406,7 @@ mod tests {
         let mut config = Config::default();
         config.yubikeys.register(serial, key);
 
-        let pin = PinAcquisition::Fixed(Pin::from(
+        let pin = AvailablePin::Fixed(Pin::from(
             String::from_utf8(qos_client::yubikey::DEFAULT_PIN.to_vec()).unwrap(),
         ));
         let pair = config.resolve_yubikey(serial, device, pin).await.unwrap();

--- a/tvc/src/yubikey/pair.rs
+++ b/tvc/src/yubikey/pair.rs
@@ -1,0 +1,449 @@
+//! The YubiKey-backed operator pair.
+//!
+//! [`YubiKeyPair`] implements the [`Signer`] and [`Pair`] ports over a
+//! provisioned device: signing uses the signing-slot key, and decryption
+//! runs the key-agreement slot's ECDH under the qos p256 envelope scheme.
+//! PC/SC calls block, so they run on the blocking thread pool, and a mutex
+//! serializes access to the one device.
+
+use super::{DeviceError, DeviceOps, Pin};
+use crate::config::turnkey::{Config, QosOperatorPublicKey, YubiKeySerial};
+use crate::pair::{Pair, Signer, SignerFuture};
+use crate::prompts;
+use anyhow::{Context, anyhow, bail, ensure};
+use qos_p256::encrypt::{Envelope, P256EncryptPublic};
+use std::fmt::{self, Debug, Formatter};
+use std::sync::{Arc, Mutex, PoisonError};
+use tokio::task::spawn_blocking;
+use zeroize::Zeroizing;
+
+/// How the operator PIN is obtained when a device-backed pair is resolved.
+///
+/// Endpoints decide the policy from their interaction mode; the shared
+/// resolution path only branches on the variant. The PIN is prompt-only by
+/// design: never read from config or the environment.
+pub(crate) enum PinAcquisition {
+    /// Prompt on the terminal at the moment the pair needs its PIN.
+    Prompt,
+    /// No PIN can be collected: the command runs non-interactively or stdin
+    /// cannot prompt.
+    Unavailable,
+    /// A caller-supplied PIN for tests, which cannot prompt.
+    #[cfg(test)]
+    Fixed(Pin),
+}
+
+/// A [`PinAcquisition`] with the [`PinAcquisition::Unavailable`] case
+/// refused, so device I/O only starts once a PIN can definitely follow.
+enum AvailablePin {
+    Prompt,
+    #[cfg(test)]
+    Fixed(Pin),
+}
+
+impl PinAcquisition {
+    fn into_available(self) -> anyhow::Result<AvailablePin> {
+        match self {
+            Self::Prompt => Ok(AvailablePin::Prompt),
+            Self::Unavailable => bail!(
+                "a YubiKey operator needs its PIN typed at an interactive prompt; \
+                 the PIN is never read from config or the environment"
+            ),
+            #[cfg(test)]
+            Self::Fixed(pin) => Ok(AvailablePin::Fixed(pin)),
+        }
+    }
+}
+
+impl AvailablePin {
+    fn acquire(self) -> anyhow::Result<Pin> {
+        match self {
+            Self::Prompt => Ok(Pin::from(prompts::password(
+                "YubiKey PIV PIN (touch the device each time it blinks)",
+            )?)),
+            #[cfg(test)]
+            Self::Fixed(pin) => Ok(pin),
+        }
+    }
+}
+
+/// A resolved, device-verified YubiKey operator pair.
+pub(crate) struct YubiKeyPair<D> {
+    device: Arc<Mutex<D>>,
+    serial: YubiKeySerial,
+    /// The device-verified composite `encrypt_public ‖ sign_public` key.
+    public_key: QosOperatorPublicKey,
+    pin: Arc<Pin>,
+}
+
+// The PIN must never reach debug output, so the derive is off the table.
+impl<D> Debug for YubiKeyPair<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("YubiKeyPair")
+            .field("serial", &self.serial)
+            .field("public_key", &self.public_key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<D: DeviceOps + Send + 'static> YubiKeyPair<D> {
+    /// Run one blocking device operation on the blocking thread pool; the
+    /// mutex serializes access to the device.
+    async fn device_op<T: Send + 'static>(
+        device: Arc<Mutex<D>>,
+        operation: impl FnOnce(&mut D) -> Result<T, DeviceError> + Send + 'static,
+    ) -> anyhow::Result<T> {
+        let result = spawn_blocking(move || {
+            let mut device = device.lock().unwrap_or_else(PoisonError::into_inner);
+            operation(&mut device)
+        })
+        .await
+        .context("YubiKey device task failed")?;
+
+        Ok(result?)
+    }
+}
+
+impl<D: DeviceOps + Send + 'static> Signer for YubiKeyPair<D> {
+    fn sign(&self, message: &[u8]) -> SignerFuture<'_, anyhow::Result<Vec<u8>>> {
+        let device = Arc::clone(&self.device);
+        let pin = Arc::clone(&self.pin);
+        let message = message.to_vec();
+
+        Box::pin(
+            async move { Self::device_op(device, move |device| device.sign(&pin, &message)).await },
+        )
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        self.public_key.as_bytes().to_vec()
+    }
+}
+
+impl<D: DeviceOps + Send + 'static> Pair for YubiKeyPair<D> {
+    fn decrypt(&self, ciphertext: &[u8]) -> SignerFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>> {
+        let device = Arc::clone(&self.device);
+        let pin = Arc::clone(&self.pin);
+        let public_key = self.public_key;
+        let ciphertext = ciphertext.to_vec();
+
+        Box::pin(async move {
+            // Parse before any device I/O, so a malformed envelope fails
+            // before the device demands its PIN and a touch.
+            let envelope = borsh::from_slice::<Envelope>(&ciphertext)
+                .context("ciphertext is not a qos p256 encryption envelope")?;
+
+            let shared_secret = Self::device_op(device, move |device| {
+                device.key_agreement(&pin, &envelope.ephemeral_sender_public)
+            })
+            .await?;
+
+            let encrypt_public = P256EncryptPublic::from_bytes(public_key.encrypt_public_bytes())
+                .map_err(|error| {
+                anyhow!("operator key is not a valid encryption point: {error:?}")
+            })?;
+
+            encrypt_public
+                .decrypt_from_shared_secret(&ciphertext, &shared_secret)
+                .map_err(|error| {
+                    anyhow!(
+                        "failed to decrypt the envelope with the YubiKey shared secret: {error:?}"
+                    )
+                })
+        })
+    }
+}
+
+/// YubiKey resolution semantics of the registry [`Config`] holds; the method
+/// lives here, with the pair it produces.
+impl Config {
+    /// Resolve a registered serial into a usable operator pair.
+    ///
+    /// Refusals come in resolution order: a PIN that can never be collected,
+    /// an unregistered serial, an unprovisioned device, and a registry cache
+    /// that no longer matches the device. The PIN prompt runs last, after the
+    /// device checks, so nothing is typed at a device that cannot be used.
+    pub(crate) async fn resolve_yubikey<D: DeviceOps + Send + 'static>(
+        &self,
+        serial: YubiKeySerial,
+        device: D,
+        pin: PinAcquisition,
+    ) -> anyhow::Result<YubiKeyPair<D>> {
+        let pin = pin.into_available()?;
+
+        let cached_public_key = self
+            .yubikeys
+            .get(serial)
+            .map(|entry| entry.public_key)
+            .ok_or_else(|| {
+                anyhow!(
+                    "YubiKey {serial} is not in the device registry; run \
+                     `tvc keys provision-yubikey --serial {serial}` to provision and register it"
+                )
+            })?;
+
+        let device = Arc::new(Mutex::new(device));
+        let public_key = {
+            let device = Arc::clone(&device);
+
+            YubiKeyPair::device_op(device, DeviceOps::verified_pair_public_key)
+                .await
+                .map_err(|error| match error.downcast_ref::<DeviceError>() {
+                    Some(DeviceError::EmptySlot { .. }) => error.context(format!(
+                        "YubiKey {serial} is not fully provisioned; run \
+                     `tvc keys provision-yubikey --serial {serial}`"
+                    )),
+                    _ => error,
+                })?
+        };
+
+        ensure!(
+            public_key == cached_public_key,
+            "YubiKey {serial} holds operator key {public_key} but the registry caches \
+             {cached_public_key}; run `tvc keys refresh-yubikey --serial {serial}` to refresh it"
+        );
+
+        let pin = pin.acquire()?;
+
+        Ok(YubiKeyPair {
+            device,
+            serial,
+            public_key,
+            pin: Arc::new(pin),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::yubikey::SlotStatus;
+    use crate::yubikey::test_support::{FakeDevice, PIN, serial};
+    use qos_p256::P256Public;
+
+    fn provisioned_device() -> FakeDevice {
+        FakeDevice::new(SlotStatus::QosProvisioned, SlotStatus::QosProvisioned)
+    }
+
+    fn registered_config(device: &FakeDevice) -> Config {
+        let mut config = Config::default();
+        config
+            .yubikeys
+            .register(serial(), device.operator_public_key());
+        config
+    }
+
+    fn fixed_pin() -> PinAcquisition {
+        PinAcquisition::Fixed(Pin::from(String::from_utf8(PIN.to_vec()).unwrap()))
+    }
+
+    fn wrong_pin() -> PinAcquisition {
+        PinAcquisition::Fixed(Pin::from("999999".to_string()))
+    }
+
+    fn rendered(error: &anyhow::Error) -> String {
+        format!("{error:#}")
+    }
+
+    #[tokio::test]
+    async fn resolves_a_registered_provisioned_device() {
+        let device = provisioned_device();
+        let composite = device.operator_public_key();
+        let config = registered_config(&device);
+
+        let pair = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap();
+
+        assert_eq!(pair.public_key(), composite.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn an_unregistered_serial_points_at_provisioning() {
+        let error = Config::default()
+            .resolve_yubikey(serial(), provisioned_device(), fixed_pin())
+            .await
+            .unwrap_err();
+
+        assert!(rendered(&error).contains("not in the device registry"));
+        assert!(rendered(&error).contains("provision-yubikey"));
+    }
+
+    #[tokio::test]
+    async fn an_unprovisioned_device_points_at_provisioning() {
+        let device = FakeDevice::new(SlotStatus::Empty, SlotStatus::Empty);
+        let config = registered_config(&device);
+
+        let error = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap_err();
+
+        assert!(rendered(&error).contains("not fully provisioned"));
+        assert!(rendered(&error).contains("provision-yubikey"));
+    }
+
+    #[tokio::test]
+    async fn a_foreign_slot_is_refused() {
+        let device = FakeDevice::new(
+            SlotStatus::Foreign {
+                subject: "CN=SomeoneElse".to_string(),
+            },
+            SlotStatus::QosProvisioned,
+        );
+        let config = registered_config(&device);
+
+        let error = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap_err();
+
+        assert!(rendered(&error).contains("non-QuorumOS certificate"));
+    }
+
+    #[tokio::test]
+    async fn a_stale_registry_cache_is_a_hard_error_naming_the_refresh_command() {
+        let device = provisioned_device();
+        let mut config = Config::default();
+        let stale = QosOperatorPublicKey::try_from([9u8; 130].as_slice()).unwrap();
+        config.yubikeys.register(serial(), stale);
+
+        let error = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap_err();
+
+        assert!(rendered(&error).contains("refresh-yubikey"));
+    }
+
+    #[tokio::test]
+    async fn an_unavailable_pin_is_refused_before_anything_else() {
+        // The registry is empty and the device is unprovisioned: reaching
+        // either would produce a different error, so the PIN message proves
+        // the refusal came first.
+        let error = Config::default()
+            .resolve_yubikey(
+                serial(),
+                FakeDevice::new(SlotStatus::Empty, SlotStatus::Empty),
+                PinAcquisition::Unavailable,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(rendered(&error).contains("interactive prompt"));
+    }
+
+    #[tokio::test]
+    async fn a_wrong_pin_surfaces_on_first_use_with_the_retry_count() {
+        let device = provisioned_device();
+        let config = registered_config(&device);
+        let pair = config
+            .resolve_yubikey(serial(), device, wrong_pin())
+            .await
+            .unwrap();
+
+        let error = pair.sign(b"message").await.unwrap_err();
+
+        assert!(rendered(&error).contains("PIN was rejected"));
+    }
+
+    #[tokio::test]
+    async fn signs_a_message_verifiable_with_the_composite_key() {
+        let device = provisioned_device();
+        let composite = device.operator_public_key();
+        let config = registered_config(&device);
+        let pair = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap();
+        let message = b"manifest hash stand-in";
+
+        let signature = pair.sign(message).await.unwrap();
+
+        P256Public::from_bytes(composite.as_bytes())
+            .unwrap()
+            .verify(message, &signature)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn decrypts_an_envelope_addressed_to_the_operator() {
+        let device = provisioned_device();
+        let composite = device.operator_public_key();
+        let config = registered_config(&device);
+        let pair = config
+            .resolve_yubikey(serial(), device, fixed_pin())
+            .await
+            .unwrap();
+        let plaintext = b"quorum share bytes";
+        let ciphertext = P256Public::from_bytes(composite.as_bytes())
+            .unwrap()
+            .encrypt(plaintext)
+            .unwrap();
+
+        let decrypted = pair.decrypt(&ciphertext).await.unwrap();
+
+        assert_eq!(decrypted.as_slice(), plaintext);
+    }
+
+    /// Resolution and the full pair round-trip against real hardware.
+    ///
+    /// Requires a provisioned YubiKey with the factory-default PIN (run
+    /// `tvc keys provision-yubikey`, or the yubikey module's
+    /// `hardware_sign_and_key_agreement` first). Sign and decrypt each need
+    /// a touch while the device blinks. Run manually:
+    /// `cargo test -p tvc --lib -- --ignored hardware_`
+    #[tokio::test]
+    #[ignore = "requires a provisioned YubiKey with default PIN; sign and decrypt each need a touch"]
+    async fn hardware_resolve_sign_and_decrypt_roundtrip() {
+        use crate::yubikey::{connected_serials, open};
+
+        let connected = connected_serials().unwrap();
+
+        let [serial] = connected.as_slice() else {
+            panic!("connect exactly one YubiKey; found {connected:?}");
+        };
+
+        let serial = *serial;
+        let mut device = open(serial).unwrap();
+        let key = device.verified_pair_public_key().unwrap();
+        let mut config = Config::default();
+        config.yubikeys.register(serial, key);
+
+        let pin = PinAcquisition::Fixed(Pin::from(
+            String::from_utf8(qos_client::yubikey::DEFAULT_PIN.to_vec()).unwrap(),
+        ));
+        let pair = config.resolve_yubikey(serial, device, pin).await.unwrap();
+
+        let message = b"tvc hardware pair test";
+        let signature = pair.sign(message).await.unwrap();
+        P256Public::from_bytes(key.as_bytes())
+            .unwrap()
+            .verify(message, &signature)
+            .unwrap();
+
+        let ciphertext = P256Public::from_bytes(key.as_bytes())
+            .unwrap()
+            .encrypt(b"share")
+            .unwrap();
+        let decrypted = pair.decrypt(&ciphertext).await.unwrap();
+        assert_eq!(decrypted.as_slice(), b"share");
+    }
+
+    #[tokio::test]
+    async fn a_malformed_envelope_fails_before_the_device_is_touched() {
+        // The pair holds a wrong PIN: had decryption reached the device, the
+        // PIN rejection would surface instead of the envelope parse error.
+        let device = provisioned_device();
+        let config = registered_config(&device);
+        let pair = config
+            .resolve_yubikey(serial(), device, wrong_pin())
+            .await
+            .unwrap();
+
+        let error = pair.decrypt(b"not an envelope").await.unwrap_err();
+
+        assert!(rendered(&error).contains("envelope"));
+    }
+}

--- a/tvc/src/yubikey/pair.rs
+++ b/tvc/src/yubikey/pair.rs
@@ -8,9 +8,10 @@
 
 use super::{DeviceError, DeviceOps, Pin};
 use crate::config::turnkey::{Config, QosOperatorPublicKey, YubiKeySerial};
-use crate::pair::{Pair, Signer, SignerFuture};
+use crate::pair::{Pair, QosP256Error, Signer, SignerFuture};
 use crate::prompts;
 use anyhow::{Context, anyhow, bail, ensure};
+use p256::PublicKey;
 use qos_p256::encrypt::{Envelope, P256EncryptPublic};
 use std::fmt::{self, Debug, Formatter};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -73,6 +74,9 @@ pub(crate) struct YubiKeyPair<D> {
     serial: YubiKeySerial,
     /// The device-verified composite `encrypt_public ‖ sign_public` key.
     public_key: QosOperatorPublicKey,
+    /// The composite's encryption half, parsed once at resolution — holding
+    /// the pair is proof its key is a valid P-256 point.
+    encrypt_public: P256EncryptPublic,
     pin: Arc<Pin>,
 }
 
@@ -124,32 +128,26 @@ impl<D: DeviceOps + Send + 'static> Pair for YubiKeyPair<D> {
     fn decrypt(&self, ciphertext: &[u8]) -> SignerFuture<'_, anyhow::Result<Zeroizing<Vec<u8>>>> {
         let device = Arc::clone(&self.device);
         let pin = Arc::clone(&self.pin);
-        let public_key = self.public_key;
+        let encrypt_public = &self.encrypt_public;
         let ciphertext = ciphertext.to_vec();
 
         Box::pin(async move {
-            // Parse before any device I/O, so a malformed envelope fails
-            // before the device demands its PIN and a touch.
+            // Parse everything before any device I/O, so malformed input
+            // fails before the device demands its PIN and a touch.
             let envelope = borsh::from_slice::<Envelope>(&ciphertext)
                 .context("ciphertext is not a qos p256 encryption envelope")?;
+            let sender_public = PublicKey::from_sec1_bytes(&envelope.ephemeral_sender_public)
+                .context("the envelope's ephemeral sender key is not a valid P-256 point")?;
 
             let shared_secret = Self::device_op(device, move |device| {
-                device.key_agreement(&pin, &envelope.ephemeral_sender_public)
+                device.key_agreement(&pin, sender_public)
             })
             .await?;
 
-            let encrypt_public = P256EncryptPublic::from_bytes(public_key.encrypt_public_bytes())
-                .map_err(|error| {
-                anyhow!("operator key is not a valid encryption point: {error:?}")
-            })?;
-
             encrypt_public
                 .decrypt_from_shared_secret(&ciphertext, &shared_secret)
-                .map_err(|error| {
-                    anyhow!(
-                        "failed to decrypt the envelope with the YubiKey shared secret: {error:?}"
-                    )
-                })
+                .map_err(QosP256Error)
+                .context("failed to decrypt the envelope with the YubiKey shared secret")
         })
     }
 }
@@ -203,12 +201,17 @@ impl Config {
              {cached_public_key}; run `tvc keys refresh-yubikey --serial {serial}` to refresh it"
         );
 
+        let encrypt_public = P256EncryptPublic::from_bytes(public_key.encrypt_public_bytes())
+            .map_err(QosP256Error)
+            .context("the device's operator key is not a valid encryption point")?;
+
         let pin = pin.acquire()?;
 
         Ok(YubiKeyPair {
             device,
             serial,
             public_key,
+            encrypt_public,
             pin: Arc::new(pin),
         })
     }

--- a/tvc/src/yubikey/test_support.rs
+++ b/tvc/src/yubikey/test_support.rs
@@ -2,9 +2,8 @@
 
 use super::{DeviceError, DeviceOps, DeviceStatus, Pin, QosSlot, SlotStatus};
 use crate::config::turnkey::{QosOperatorPublicKey, YubiKeySerial};
-use p256::PublicKey;
-use p256::ecdh::diffie_hellman;
-use qos_client::yubikey::YubiKeyError;
+use p256::{PublicKey, ecdh::diffie_hellman};
+use qos_client::{yubikey::YubiKeyError, yubikey_crate as yubikey};
 use qos_p256::P256Pair;
 use zeroize::Zeroizing;
 
@@ -123,17 +122,13 @@ impl DeviceOps for FakeDevice {
     fn key_agreement(
         &mut self,
         pin: &Pin,
-        sender_public: &[u8],
+        sender_public: PublicKey,
     ) -> Result<Zeroizing<Vec<u8>>, DeviceError> {
         self.checked_slot(pin, QosSlot::KeyAgreement)?;
 
-        let sender =
-            PublicKey::from_sec1_bytes(sender_public).map_err(|_| DeviceError::KeyAgreement {
-                error: YubiKeyError::KeyAgreementFailed,
-            })?;
         let secret = diffie_hellman(
             self.pair.encryption_key().to_nonzero_scalar(),
-            sender.as_affine(),
+            sender_public.as_affine(),
         );
 
         Ok(Zeroizing::new(secret.raw_secret_bytes().to_vec()))

--- a/tvc/src/yubikey/test_support.rs
+++ b/tvc/src/yubikey/test_support.rs
@@ -1,0 +1,163 @@
+//! In-memory device fake shared by unit tests across the crate.
+
+use super::{DeviceError, DeviceOps, DeviceStatus, Pin, QosSlot, SlotStatus};
+use crate::config::turnkey::{QosOperatorPublicKey, YubiKeySerial};
+use p256::PublicKey;
+use p256::ecdh::diffie_hellman;
+use qos_client::yubikey::YubiKeyError;
+use qos_p256::P256Pair;
+use zeroize::Zeroizing;
+
+/// The PIN the fake accepts — the factory default, matching the hardware
+/// tests.
+pub(crate) const PIN: &[u8] = qos_client::yubikey::DEFAULT_PIN;
+
+/// Stable serial used by tests that register the fake as a device.
+pub(crate) fn serial() -> YubiKeySerial {
+    YubiKeySerial::from(0x01c9_5c1f)
+}
+
+/// In-memory [`DeviceOps`] implementation: per-slot state and a software
+/// P-256 pair standing in for the on-device keys, plus scriptable primitive
+/// failures, recording every mutating call.
+pub(crate) struct FakeDevice {
+    status: DeviceStatus,
+    pair: P256Pair,
+    pub(crate) fail_provision: Option<QosSlot>,
+    pub(crate) fail_delete: Option<QosSlot>,
+    pub(crate) provision_calls: Vec<QosSlot>,
+    pub(crate) delete_calls: Vec<QosSlot>,
+}
+
+impl FakeDevice {
+    pub(crate) fn new(signing: SlotStatus, key_agreement: SlotStatus) -> Self {
+        Self {
+            status: DeviceStatus {
+                signing,
+                key_agreement,
+            },
+            pair: P256Pair::generate().expect("software key generation"),
+            fail_provision: None,
+            fail_delete: None,
+            provision_calls: Vec::new(),
+            delete_calls: Vec::new(),
+        }
+    }
+
+    /// The composite operator key of the fake's on-device pair.
+    pub(crate) fn operator_public_key(&self) -> QosOperatorPublicKey {
+        QosOperatorPublicKey::try_from(self.pair.public_key().to_bytes().as_slice())
+            .expect("software composite key is well-formed")
+    }
+
+    fn slot_status_mut(&mut self, slot: QosSlot) -> &mut SlotStatus {
+        match slot {
+            QosSlot::Signing => &mut self.status.signing,
+            QosSlot::KeyAgreement => &mut self.status.key_agreement,
+        }
+    }
+
+    fn checked_slot(&mut self, pin: &Pin, slot: QosSlot) -> Result<(), DeviceError> {
+        match self.slot_status(slot)? {
+            SlotStatus::QosProvisioned => {}
+            SlotStatus::Empty => return Err(DeviceError::EmptySlot { slot }),
+            SlotStatus::KeyWithoutCertificate => {
+                return Err(DeviceError::OccupiedWithoutCertificate { slot });
+            }
+            SlotStatus::Foreign { subject } => {
+                return Err(DeviceError::ForeignSlot { slot, subject });
+            }
+        }
+
+        if pin.as_bytes() != PIN {
+            return Err(DeviceError::WrongPin { tries: 3 });
+        }
+
+        Ok(())
+    }
+}
+
+impl DeviceOps for FakeDevice {
+    fn slot_status(&mut self, slot: QosSlot) -> Result<SlotStatus, DeviceError> {
+        Ok(self.slot_status_mut(slot).clone())
+    }
+
+    fn device_status(&mut self) -> Result<DeviceStatus, DeviceError> {
+        Ok(self.status.clone())
+    }
+
+    fn provision_slot(&mut self, slot: QosSlot, _pin: &Pin) -> Result<(), DeviceError> {
+        self.provision_calls.push(slot);
+
+        if self.fail_provision == Some(slot) {
+            return Err(DeviceError::Provision {
+                slot,
+                error: YubiKeyError::WillNotOverwriteSlot,
+            });
+        }
+
+        *self.slot_status_mut(slot) = SlotStatus::QosProvisioned;
+        Ok(())
+    }
+
+    fn pair_public_key(&mut self) -> Result<QosOperatorPublicKey, DeviceError> {
+        if self.status
+            == (DeviceStatus {
+                signing: SlotStatus::QosProvisioned,
+                key_agreement: SlotStatus::QosProvisioned,
+            })
+        {
+            Ok(self.operator_public_key())
+        } else {
+            Err(DeviceError::ReadPairPublicKey {
+                error: YubiKeyError::CannotFindSigningKey,
+            })
+        }
+    }
+
+    fn sign(&mut self, pin: &Pin, message: &[u8]) -> Result<Vec<u8>, DeviceError> {
+        self.checked_slot(pin, QosSlot::Signing)?;
+        Ok(self.pair.sign(message).expect("software P-256 signing"))
+    }
+
+    fn key_agreement(
+        &mut self,
+        pin: &Pin,
+        sender_public: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, DeviceError> {
+        self.checked_slot(pin, QosSlot::KeyAgreement)?;
+
+        let sender =
+            PublicKey::from_sec1_bytes(sender_public).map_err(|_| DeviceError::KeyAgreement {
+                error: YubiKeyError::KeyAgreementFailed,
+            })?;
+        let secret = diffie_hellman(
+            self.pair.encryption_key().to_nonzero_scalar(),
+            sender.as_affine(),
+        );
+
+        Ok(Zeroizing::new(secret.raw_secret_bytes().to_vec()))
+    }
+
+    fn delete_qos_certificate(&mut self, slot: QosSlot) -> Result<(), DeviceError> {
+        self.delete_calls.push(slot);
+
+        if self.fail_delete == Some(slot) {
+            return Err(DeviceError::DeleteCertificate {
+                slot,
+                source: yubikey::Error::GenericError,
+            });
+        }
+
+        match self.slot_status(slot)? {
+            SlotStatus::QosProvisioned => {
+                *self.slot_status_mut(slot) = SlotStatus::KeyWithoutCertificate;
+                Ok(())
+            }
+            SlotStatus::Foreign { subject } => Err(DeviceError::ForeignSlot { slot, subject }),
+            SlotStatus::Empty | SlotStatus::KeyWithoutCertificate => {
+                Err(DeviceError::ChangedSinceInspection { slot })
+            }
+        }
+    }
+}

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -158,7 +158,9 @@ pub fn write_yubikey_only_config(home: &Path, alias: &str, org_id: &str) {
             serial,
             public_key,
             extra: toml::Table::new(),
-        }],
+        }]
+        .try_into()
+        .unwrap(),
         last_created_app_id: HashMap::new(),
         last_operator_ids: HashMap::new(),
         extra: toml::Table::new(),

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -10,7 +10,8 @@ use std::{
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use tvc::config::turnkey::{
     Config, HostedOperatorRecord, KeyCurve, OperatorKind, OperatorRecord, OperatorRecordKind,
-    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey,
+    OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
+    YubiKeyRegistryEntry, YubiKeySerial,
 };
 
 /// Dead port: connection attempts fail immediately, so commands stop at their
@@ -103,6 +104,61 @@ pub fn write_hosted_only_config(home: &Path, alias: &str, org_id: &str) {
             },
         )]),
         yubikeys: Default::default(),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+        extra: toml::Table::new(),
+    };
+
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+}
+
+/// Write a v1 `tvc.config.toml` under `home` whose sole, active organization
+/// defaults to the yubikey backend: one serial-only operator record plus the
+/// top-level registry entry caching a real generated composite key. Flows
+/// that read the cache need no device; device-touching flows fail at their
+/// first PC/SC step.
+pub fn write_yubikey_only_config(home: &Path, alias: &str, org_id: &str) {
+    let turnkey_dir = home.join(".config/turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+
+    let serial = YubiKeySerial::from(0x01c9_5c1f);
+    let public_key = QosOperatorPublicKey::try_from(
+        qos_p256::P256Pair::generate()
+            .unwrap()
+            .public_key()
+            .to_bytes()
+            .as_slice(),
+    )
+    .unwrap();
+
+    let config = Config {
+        active_org: Some(alias.to_string()),
+        orgs: HashMap::from([(
+            alias.to_string(),
+            OrgConfig {
+                id: org_id.to_string(),
+                api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+                default_operator_kind: OperatorKind::Yubikey,
+                operators: vec![OperatorRecord {
+                    name: "yubikey-op".to_string(),
+                    kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
+                        serial,
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        )]),
+        yubikeys: vec![YubiKeyRegistryEntry {
+            serial,
+            public_key,
+            extra: toml::Table::new(),
+        }],
         last_created_app_id: HashMap::new(),
         last_operator_ids: HashMap::new(),
         extra: toml::Table::new(),

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use qos_p256::P256Pair;
@@ -113,7 +115,29 @@ fn hosted_default_rejects_skip_post_without_operator_id() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--skip-post is only supported for local operators",
+            "--skip-post is not supported for hosted operators",
+        ));
+}
+
+/// A yubikey org in a non-interactive run refuses during resolution: the PIN
+/// can only be typed at a prompt. No device is touched, so this needs no USB.
+#[test]
+fn yubikey_default_without_a_prompt_reports_the_pin_requirement() {
+    let temp = TempDir::new().unwrap();
+    common::write_yubikey_only_config(temp.path(), "test", "org-test");
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .arg("deploy")
+        .arg("approve")
+        .arg("--manifest")
+        .arg("fixtures/manifest.json")
+        .arg("--skip-post")
+        .arg("--dangerous-skip-interactive")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "a YubiKey operator needs its PIN typed at an interactive prompt",
         ));
 }
 
@@ -181,7 +205,7 @@ fn hosted_operator_rejects_skip_post_before_api_activity() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--skip-post is only supported for local operators",
+            "--skip-post is not supported for hosted operators",
         ));
 }
 

--- a/tvc/tests/keys_re_encrypt_local_share.rs
+++ b/tvc/tests/keys_re_encrypt_local_share.rs
@@ -121,7 +121,8 @@ fn re_encrypt_local_share_requires_metadata_and_provision_bundle() {
 
 /// Without explicit seed flags the operator comes from the active org's
 /// registry, and a hosted-only org has no local key to decrypt with: the
-/// failure explains that and points at the hosted counterpart.
+/// refusal fires during backend selection, before the input files are even
+/// read (they do not exist here), and points at the hosted counterpart.
 #[test]
 fn hosted_only_org_is_pointed_at_deploy_provision() {
     let temp = TempDir::new().unwrap();
@@ -131,44 +132,15 @@ fn hosted_only_org_is_pointed_at_deploy_provision() {
         "88888888-8888-4888-8888-888888888888",
     );
 
-    // Parseable metadata and bundle: both are read before the operator is
-    // resolved, which is where this run must fail.
-    let metadata_path = temp.path().join("quorum_key_metadata.json");
-    let provision_bundle_path = temp.path().join("provision_bundle.json");
-    let quorum_pair = P256Pair::generate().unwrap();
-    let manifest_envelope = sample_manifest_envelope(quorum_pair.public_key().to_bytes(), vec![]);
-    fs::write(
-        &metadata_path,
-        serde_json::to_vec_pretty(&json!({
-            "quorumKeyPublic": hex::encode(quorum_pair.public_key().to_bytes()),
-            "threshold": 1,
-            "shares": [],
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-    fs::write(
-        &provision_bundle_path,
-        serde_json::to_vec_pretty(&json!({
-            "attestationDocumentCoseSign1Base64": "not parsed before operator resolution",
-            "manifestEnvelope": manifest_envelope,
-            "fetchedAtUnixMs": 1_712_345_678_901_u64,
-            "deploymentId": "deploy-123",
-            "ephemeralPublicKeyHex": hex::encode(quorum_pair.public_key().to_bytes()),
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
         .env_remove("TVC_OPERATOR_SEED")
         .arg("keys")
         .arg("re-encrypt-local-share")
         .arg("--quorum-key-metadata")
-        .arg(&metadata_path)
+        .arg(temp.path().join("does_not_exist_metadata.json"))
         .arg("--provision-bundle")
-        .arg(&provision_bundle_path)
+        .arg(temp.path().join("does_not_exist_bundle.json"))
         .arg("--dangerous-skip-verification")
         .assert()
         .failure()
@@ -178,9 +150,10 @@ fn hosted_only_org_is_pointed_at_deploy_provision() {
         .stderr(predicate::str::contains("tvc deploy provision"));
 }
 
-/// A yubikey org in a non-interactive run refuses during operator
-/// resolution: the PIN can only be typed at a prompt. No device is touched,
-/// so this needs no USB.
+/// A yubikey org in a non-interactive run refuses during backend selection:
+/// the PIN can only be typed at a prompt. The refusal fires before the input
+/// files are even read (they do not exist here) and no device is touched, so
+/// this needs no USB.
 #[test]
 fn yubikey_org_without_a_prompt_reports_the_pin_requirement() {
     let temp = TempDir::new().unwrap();
@@ -190,44 +163,15 @@ fn yubikey_org_without_a_prompt_reports_the_pin_requirement() {
         "99999999-9999-4999-8999-999999999999",
     );
 
-    // Parseable metadata and bundle: both are read before the operator is
-    // resolved, which is where this run must fail.
-    let metadata_path = temp.path().join("quorum_key_metadata.json");
-    let provision_bundle_path = temp.path().join("provision_bundle.json");
-    let quorum_pair = P256Pair::generate().unwrap();
-    let manifest_envelope = sample_manifest_envelope(quorum_pair.public_key().to_bytes(), vec![]);
-    fs::write(
-        &metadata_path,
-        serde_json::to_vec_pretty(&json!({
-            "quorumKeyPublic": hex::encode(quorum_pair.public_key().to_bytes()),
-            "threshold": 1,
-            "shares": [],
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-    fs::write(
-        &provision_bundle_path,
-        serde_json::to_vec_pretty(&json!({
-            "attestationDocumentCoseSign1Base64": "not parsed before operator resolution",
-            "manifestEnvelope": manifest_envelope,
-            "fetchedAtUnixMs": 1_712_345_678_901_u64,
-            "deploymentId": "deploy-123",
-            "ephemeralPublicKeyHex": hex::encode(quorum_pair.public_key().to_bytes()),
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
         .env_remove("TVC_OPERATOR_SEED")
         .arg("keys")
         .arg("re-encrypt-local-share")
         .arg("--quorum-key-metadata")
-        .arg(&metadata_path)
+        .arg(temp.path().join("does_not_exist_metadata.json"))
         .arg("--provision-bundle")
-        .arg(&provision_bundle_path)
+        .arg(temp.path().join("does_not_exist_bundle.json"))
         .arg("--dangerous-skip-verification")
         .assert()
         .failure()

--- a/tvc/tests/keys_re_encrypt_local_share.rs
+++ b/tvc/tests/keys_re_encrypt_local_share.rs
@@ -178,6 +178,64 @@ fn hosted_only_org_is_pointed_at_deploy_provision() {
         .stderr(predicate::str::contains("tvc deploy provision"));
 }
 
+/// A yubikey org in a non-interactive run refuses during operator
+/// resolution: the PIN can only be typed at a prompt. No device is touched,
+/// so this needs no USB.
+#[test]
+fn yubikey_org_without_a_prompt_reports_the_pin_requirement() {
+    let temp = TempDir::new().unwrap();
+    common::write_yubikey_only_config(
+        temp.path(),
+        "yubikey-org",
+        "99999999-9999-4999-8999-999999999999",
+    );
+
+    // Parseable metadata and bundle: both are read before the operator is
+    // resolved, which is where this run must fail.
+    let metadata_path = temp.path().join("quorum_key_metadata.json");
+    let provision_bundle_path = temp.path().join("provision_bundle.json");
+    let quorum_pair = P256Pair::generate().unwrap();
+    let manifest_envelope = sample_manifest_envelope(quorum_pair.public_key().to_bytes(), vec![]);
+    fs::write(
+        &metadata_path,
+        serde_json::to_vec_pretty(&json!({
+            "quorumKeyPublic": hex::encode(quorum_pair.public_key().to_bytes()),
+            "threshold": 1,
+            "shares": [],
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        &provision_bundle_path,
+        serde_json::to_vec_pretty(&json!({
+            "attestationDocumentCoseSign1Base64": "not parsed before operator resolution",
+            "manifestEnvelope": manifest_envelope,
+            "fetchedAtUnixMs": 1_712_345_678_901_u64,
+            "deploymentId": "deploy-123",
+            "ephemeralPublicKeyHex": hex::encode(quorum_pair.public_key().to_bytes()),
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env_remove("TVC_OPERATOR_SEED")
+        .arg("keys")
+        .arg("re-encrypt-local-share")
+        .arg("--quorum-key-metadata")
+        .arg(&metadata_path)
+        .arg("--provision-bundle")
+        .arg(&provision_bundle_path)
+        .arg("--dangerous-skip-verification")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "a YubiKey operator needs its PIN typed at an interactive prompt",
+        ));
+}
+
 #[test]
 fn re_encrypt_local_share_round_trips_metadata_share() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
Stacked on #254.

Adds `yubikey` as a default operator kind. Org records reference a registered device by serial only; resolution opens that exact serial, verifies the QuorumOS slots, and returns a `qos_client`-backed `Pair` — `sign` for manifest approval, `decrypt` for local-style share provisioning. Blocking PC/SC work runs off the async threads, one device at a time; the PIN goes through the existing secure prompt and is never stored.

Also adds `keys refresh-yubikey` to resync the registry's cached public key from the device.

Unit tests run against the fake device boundary and a fake `Pair`; real-hardware coverage stays in an ignored, opt-in suite.

Closes TVC-307.