### PR TITLE
Re-enable tvc musl builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # Cargo.lock changes should trigger dependency reviewers
 Cargo.lock @tkhq/dependency-reviewers
 
+# TVC's musl build downloads and pins dependencies outside Cargo.lock
+/.github/cross/install-pcsc-lite.sh @tkhq/dependency-reviewers
+/.github/workflows/tvc-pcsc-release-check.yml @tkhq/dependency-reviewers
+
 # We also want this file (COWDEOWNERS file) to trigger dependency reviewers
 # Otherwise anyone can remove dependency reviews!
 /.github/CODEOWNERS @tkhq/dependency-reviewers

--- a/.github/cross/install-pcsc-lite.sh
+++ b/.github/cross/install-pcsc-lite.sh
@@ -87,6 +87,9 @@ tar -xJf "${archive}" -C /tmp
   echo "cpu = '${cpu}'"
   echo "endian = 'little'"
   echo
+  echo '[built-in options]'
+  echo "c_args = ['-D_FORTIFY_SOURCE=2', '-fPIC', '-fstack-protector-strong', '-Wformat', '-Wformat-security', '-Werror=format-security']"
+  echo
   echo '[properties]'
   echo 'needs_exe_wrapper = true'
 } > "${cross_file}"

--- a/.github/cross/install-pcsc-lite.sh
+++ b/.github/cross/install-pcsc-lite.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 target="${1:?missing target triple}"
 version="2.5.1"
 sha512="027851359b38cf56c2ea97a969c0ae8c5eabbb977fc2a86c650c6c8e0e2caba43934f3de35573deb408bf6365e9deb2a9c443b3712b313692069421c77222057"
+meson_version="0.58.2"
+meson_sha256="7634ec32955d3f897d623b88e9d2988451035f43d73c17a29caf767387baedb7"
 
 case "${target}" in
   aarch64-unknown-linux-musl)
@@ -40,7 +42,23 @@ apt-get install --assume-yes --no-install-recommends \
   python3-pip \
   python3-setuptools \
   xz-utils
-python3 -m pip install --no-cache-dir 'meson==0.58.2'
+meson_requirements="/tmp/meson-requirements.txt"
+printf 'meson==%s --hash=sha256:%s\n' \
+  "${meson_version}" \
+  "${meson_sha256}" > "${meson_requirements}"
+pip_build_options=()
+if python3 -m pip install --help |
+  awk '/--no-build-isolation/ { found=1 } END { exit !found }'; then
+  pip_build_options+=(--no-build-isolation)
+fi
+python3 -m pip install \
+  --no-cache-dir \
+  --no-deps \
+  --no-binary=:all: \
+  --require-hashes \
+  "${pip_build_options[@]}" \
+  --requirement "${meson_requirements}"
+rm -f "${meson_requirements}"
 
 archive="/tmp/pcsc-lite-${version}.tar.xz"
 source_dir="/tmp/pcsc-lite-${version}"

--- a/.github/cross/install-pcsc-lite.sh
+++ b/.github/cross/install-pcsc-lite.sh
@@ -2,12 +2,27 @@
 
 set -euo pipefail
 
+# Outcome: install a target-specific static libpcsclite client in the Cross image
+# so TVC's Rust PC/SC dependency can be linked into a portable musl binary. Cross
+# does not provide that target library, so building it here with Cross's musl
+# toolchain keeps its ABI aligned with TVC. The resulting client still talks to
+# the host's pcscd at runtime; this image does not supply the runtime daemon.
+# See https://github.com/cross-rs/cross/wiki/Configuration
+
 target="${1:?missing target triple}"
+
+# These versions and hashes are supply-chain security controls. Review upstream
+# provenance and update each version and digest together; the PC/SC release check
+# only alerts when a newer release exists.
 version="2.5.1"
 sha512="027851359b38cf56c2ea97a969c0ae8c5eabbb977fc2a86c650c6c8e0e2caba43934f3de35573deb408bf6365e9deb2a9c443b3712b313692069421c77222057"
 meson_version="0.58.2"
 meson_sha256="7634ec32955d3f897d623b88e9d2988451035f43d73c17a29caf767387baedb7"
 
+# Keep the accepted targets explicit so Meson cannot silently select a host
+# compiler or wrong machine description. Adding a target requires validating its
+# Cross toolchain and Meson machine settings.
+# See https://mesonbuild.com/Cross-compilation.html
 case "${target}" in
   aarch64-unknown-linux-musl)
     compiler="aarch64-linux-musl-gcc"
@@ -31,6 +46,9 @@ esac
 
 export DEBIAN_FRONTEND=noninteractive
 
+# Install the download and build tools explicitly because the pinned Cross images
+# do not provide all of them. They are only used to produce libpcsclite;
+# --no-install-recommends and the cleanup below keep the derived image smaller.
 apt-get update
 apt-get install --assume-yes --no-install-recommends \
   ca-certificates \
@@ -42,6 +60,11 @@ apt-get install --assume-yes --no-install-recommends \
   python3-pip \
   python3-setuptools \
   xz-utils
+
+# Install the exact Meson source distribution without resolving dependencies.
+# Where pip supports it, disabling build isolation also prevents downloads of
+# additional PEP 517 build requirements. This is a supply-chain security control.
+# See https://pip.pypa.io/en/stable/topics/secure-installs/
 meson_requirements="/tmp/meson-requirements.txt"
 printf 'meson==%s --hash=sha256:%s\n' \
   "${meson_version}" \
@@ -60,12 +83,16 @@ python3 -m pip install \
   --requirement "${meson_requirements}"
 rm -f "${meson_requirements}"
 
+# Keep target artifacts separate from host tools and other targets. Cross.toml
+# points pcsc-sys at this prefix through PKG_CONFIG_PATH.
 archive="/tmp/pcsc-lite-${version}.tar.xz"
 source_dir="/tmp/pcsc-lite-${version}"
 build_dir="/tmp/pcsc-lite-build"
 cross_file="/tmp/pcsc-lite-${target}.ini"
 prefix="/opt/pcsc/${target}"
 
+# Verify the repository-pinned archive bytes before processing any upstream
+# source. Changing the URL, version, or digest requires a supply-chain review.
 curl \
   --fail \
   --location \
@@ -75,6 +102,9 @@ curl \
 echo "${sha512}  ${archive}" | sha512sum --check -
 tar -xJf "${archive}" -C /tmp
 
+# Meson needs an explicit target toolchain and must not try to run target binaries
+# while configuring inside the builder. See the Meson cross-compilation guide:
+# https://mesonbuild.com/Cross-compilation.html
 {
   echo '[binaries]'
   echo "c = '${compiler}'"
@@ -88,12 +118,23 @@ tar -xJf "${archive}" -C /tmp
   echo "endian = 'little'"
   echo
   echo '[built-in options]'
+  # FORTIFY, stack protection, and format checks harden memory-unsafe C linked
+  # into TVC; weakening them requires a security review. -fPIC is required for
+  # link compatibility with position-independent outputs.
+  # See https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
   echo "c_args = ['-D_FORTIFY_SOURCE=2', '-fPIC', '-fstack-protector-strong', '-Wformat', '-Wformat-security', '-Werror=format-security']"
   echo
   echo '[properties]'
   echo 'needs_exe_wrapper = true'
 } > "${cross_file}"
 
+# The release build type enables the optimization required by _FORTIFY_SOURCE,
+# so changing it is security-sensitive. Static output is a portability requirement:
+# TVC must not depend on a target system's shared libpcsclite. The other feature
+# flags remove pcscd's daemon, device-discovery, and policy integrations because
+# TVC consumes only the client archive. Those flags reduce dependencies and image
+# size; they are not security invariants. See the upstream option descriptions:
+# https://github.com/LudovicRousseau/PCSC/blob/2.5.1/meson_options.txt
 meson setup \
   "${build_dir}" \
   "${source_dir}" \
@@ -111,6 +152,8 @@ meson setup \
 meson compile -C "${build_dir}"
 meson install -C "${build_dir}"
 
+# This only reduces the derived Cross image size; it does not affect the released
+# binary's security properties.
 rm -rf \
   "${archive}" \
   "${build_dir}" \

--- a/.github/cross/install-pcsc-lite.sh
+++ b/.github/cross/install-pcsc-lite.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+target="${1:?missing target triple}"
+version="2.5.1"
+sha512="027851359b38cf56c2ea97a969c0ae8c5eabbb977fc2a86c650c6c8e0e2caba43934f3de35573deb408bf6365e9deb2a9c443b3712b313692069421c77222057"
+
+case "${target}" in
+  aarch64-unknown-linux-musl)
+    compiler="aarch64-linux-musl-gcc"
+    archiver="aarch64-linux-musl-ar"
+    stripper="aarch64-linux-musl-strip"
+    cpu_family="aarch64"
+    cpu="aarch64"
+    ;;
+  x86_64-unknown-linux-musl)
+    compiler="x86_64-linux-musl-gcc"
+    archiver="x86_64-linux-musl-ar"
+    stripper="x86_64-linux-musl-strip"
+    cpu_family="x86_64"
+    cpu="x86_64"
+    ;;
+  *)
+    echo "unsupported target: ${target}" >&2
+    exit 1
+    ;;
+esac
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install --assume-yes --no-install-recommends \
+  ca-certificates \
+  curl \
+  flex \
+  ninja-build \
+  perl \
+  pkg-config \
+  python3-pip \
+  python3-setuptools \
+  xz-utils
+python3 -m pip install --no-cache-dir 'meson==0.58.2'
+
+archive="/tmp/pcsc-lite-${version}.tar.xz"
+source_dir="/tmp/pcsc-lite-${version}"
+build_dir="/tmp/pcsc-lite-build"
+cross_file="/tmp/pcsc-lite-${target}.ini"
+prefix="/opt/pcsc/${target}"
+
+curl \
+  --fail \
+  --location \
+  --retry 5 \
+  --output "${archive}" \
+  "https://pcsclite.apdu.fr/files/pcsc-lite-${version}.tar.xz"
+echo "${sha512}  ${archive}" | sha512sum --check -
+tar -xJf "${archive}" -C /tmp
+
+{
+  echo '[binaries]'
+  echo "c = '${compiler}'"
+  echo "ar = '${archiver}'"
+  echo "strip = '${stripper}'"
+  echo
+  echo '[host_machine]'
+  echo "system = 'linux'"
+  echo "cpu_family = '${cpu_family}'"
+  echo "cpu = '${cpu}'"
+  echo "endian = 'little'"
+  echo
+  echo '[properties]'
+  echo 'needs_exe_wrapper = true'
+} > "${cross_file}"
+
+meson setup \
+  "${build_dir}" \
+  "${source_dir}" \
+  --buildtype=release \
+  --cross-file "${cross_file}" \
+  --libdir=lib \
+  --prefix="${prefix}" \
+  -Ddefault_library=static \
+  -Dlibsystemd=false \
+  -Dlibudev=false \
+  -Dlibusb=false \
+  -Dpolkit=false \
+  -Dserial=false \
+  -Dusb=false
+meson compile -C "${build_dir}"
+meson install -C "${build_dir}"
+
+rm -rf \
+  "${archive}" \
+  "${build_dir}" \
+  "${cross_file}" \
+  "${source_dir}" \
+  /var/lib/apt/lists/*

--- a/.github/workflows/tvc-binaries-release.yml
+++ b/.github/workflows/tvc-binaries-release.yml
@@ -115,6 +115,23 @@ jobs:
           fi
           cat "${archive}.sha256"
 
+      - name: Verify musl binary hardening
+        if: matrix.build_tool == 'cross'
+        run: |
+          set -euo pipefail
+          binary="target/${TARGET}/release/tvc"
+          file_header="$(readelf --wide --file-header "${binary}")"
+          program_headers="$(readelf --wide --program-headers "${binary}")"
+
+          printf '%s\n' "${file_header}" | rg 'Type:'
+          printf '%s\n' "${program_headers}" | rg 'GNU_RELRO'
+          printf '%s\n' "${program_headers}" | rg 'GNU_STACK.*RW '
+          if printf '%s\n' "${program_headers}" | rg --quiet 'GNU_STACK.*RWE'; then
+            echo 'musl binary has an executable stack' >&2
+            exit 1
+          fi
+          readelf --wide --symbols "${binary}" | rg '__stack_chk_fail'
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/tvc-binaries-release.yml
+++ b/.github/workflows/tvc-binaries-release.yml
@@ -33,14 +33,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - target: x86_64-unknown-linux-musl
-          #   os: ubuntu-latest
-          #   build_tool: cross
-          #   rustflags: -C target-feature=+crt-static
-          # - target: aarch64-unknown-linux-musl
-          #   os: ubuntu-latest
-          #   build_tool: cross
-          #   rustflags: -C target-feature=+crt-static
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            build_tool: cross
+            rustflags: -C target-feature=+crt-static
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            build_tool: cross
+            rustflags: -C target-feature=+crt-static
           - target: aarch64-apple-darwin
             os: macos-14
             build_tool: cargo

--- a/.github/workflows/tvc-binaries-release.yml
+++ b/.github/workflows/tvc-binaries-release.yml
@@ -123,14 +123,21 @@ jobs:
           file_header="$(readelf --wide --file-header "${binary}")"
           program_headers="$(readelf --wide --program-headers "${binary}")"
 
-          printf '%s\n' "${file_header}" | rg 'Type:'
-          printf '%s\n' "${program_headers}" | rg 'GNU_RELRO'
-          printf '%s\n' "${program_headers}" | rg 'GNU_STACK.*RW '
-          if printf '%s\n' "${program_headers}" | rg --quiet 'GNU_STACK.*RWE'; then
+          # Check the final ELF rather than trusting compiler flags alone. Use
+          # POSIX awk because GitHub runner images do not guarantee ripgrep.
+          printf '%s\n' "${file_header}" |
+            awk '/Type:/ { found = 1; print } END { exit !found }'
+          printf '%s\n' "${program_headers}" |
+            awk '/GNU_RELRO/ { found = 1; print } END { exit !found }'
+          printf '%s\n' "${program_headers}" |
+            awk '/GNU_STACK.*RW / { found = 1; print } END { exit !found }'
+          if printf '%s\n' "${program_headers}" |
+            awk '/GNU_STACK.*RWE/ { found = 1 } END { exit !found }'; then
             echo 'musl binary has an executable stack' >&2
             exit 1
           fi
-          readelf --wide --symbols "${binary}" | rg '__stack_chk_fail'
+          readelf --wide --symbols "${binary}" |
+            awk '/__stack_chk_fail/ { found = 1; print } END { exit !found }'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/tvc-pcsc-release-check.yml
+++ b/.github/workflows/tvc-pcsc-release-check.yml
@@ -1,0 +1,37 @@
+name: Check PC/SC release
+
+on:
+  schedule:
+    - cron: "17 13 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Check for a newer PC/SC release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current="$(sed -n 's/^version="\([^"]*\)"$/\1/p' .github/cross/install-pcsc-lite.sh)"
+          if [[ -z "${current}" ]]; then
+            echo 'could not read the pinned PC/SC version' >&2
+            exit 1
+          fi
+
+          latest="$(gh api repos/LudovicRousseau/PCSC/releases/latest --jq .tag_name)"
+          if [[ "${current}" != "${latest}" ]]; then
+            echo "PC/SC ${latest} is available; the static build pins ${current}" >&2
+            exit 1
+          fi
+
+          echo "PC/SC ${current} is current"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,6 @@
 [target.aarch64-unknown-linux-musl]
+# Resolved from ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5.
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:702154f52b2d8091671aa2c84d5582d849f949977228c735ff8462f93cc0e1e4"
 pre-build = ".github/cross/install-pcsc-lite.sh"
 
 [target.aarch64-unknown-linux-musl.env]
@@ -9,6 +11,8 @@ passthrough = [
 ]
 
 [target.x86_64-unknown-linux-musl]
+# Resolved from ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5.
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99"
 pre-build = ".github/cross/install-pcsc-lite.sh"
 
 [target.x86_64-unknown-linux-musl.env]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,19 @@
+[target.aarch64-unknown-linux-musl]
+pre-build = ".github/cross/install-pcsc-lite.sh"
+
+[target.aarch64-unknown-linux-musl.env]
+passthrough = [
+    "LIBPCSCLITE_STATIC=1",
+    "PKG_CONFIG_ALLOW_CROSS=1",
+    "PKG_CONFIG_PATH=/opt/pcsc/aarch64-unknown-linux-musl/lib/pkgconfig",
+]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = ".github/cross/install-pcsc-lite.sh"
+
+[target.x86_64-unknown-linux-musl.env]
+passthrough = [
+    "LIBPCSCLITE_STATIC=1",
+    "PKG_CONFIG_ALLOW_CROSS=1",
+    "PKG_CONFIG_PATH=/opt/pcsc/x86_64-unknown-linux-musl/lib/pkgconfig",
+]


### PR DESCRIPTION
To ship yubikey support as quickly as possible, we disabbled the musl builds. This re-enables them. Using `Meson` is the official way to build `pcsc-lite`, see the repository workflow: https://github.com/LudovicRousseau/PCSC/blob/aa97f4b65448ede1a073db51195802cb00fc808b/.github/workflows/build_meson.yml

