### PR TITLE
Am/add tvc deployments skill

### DIFF
--- a/tvc/AGENTS.md
+++ b/tvc/AGENTS.md
@@ -2,6 +2,22 @@
 
 Default guidance for coding-agent runs in this repository.
 
+## Agent skills
+
+- `skills/` holds agent skills in the open Agent Skills format (SKILL.md plus
+  `references/`). They are embedded into the binary and installed into a
+  skills directory by `tvc skills save`, so the skill a user has always
+  documents the CLI at their installed version. If you are *using* the tvc
+  CLI rather than developing it, install the skill with `tvc skills save` and
+  follow it.
+- When changing the CLI surface or behavior — commands, flags, outcome
+  `reason`s, error `code`s, output fields — update `skills/tvc-deployments/`
+  in the same change. The skill is user-facing documentation of exactly this
+  crate; letting it drift defeats the version pinning.
+- A new file under `skills/` must also be registered in `EMBEDDED_SKILL_FILES`
+  (`src/commands/skills/save.rs`); a unit test enforces parity with the
+  on-disk tree. `evals/` directories are deliberately excluded from embedding.
+
 ## Coding style
 
 - Prefer raw string literals (`r#"..."#`) over escaped quotation marks (`\"`) or

--- a/tvc/skills/tvc-deployments/SKILL.md
+++ b/tvc/skills/tvc-deployments/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: tvc-deployments
+description: "Build, deploy, and maintain Turnkey Verifiable Cloud (TVC) apps with the `tvc` CLI: create apps and deployments, approve manifests, set the live deployment, check runtime status, tail debug logs, and consume the NDJSON output contract. Drives the CLI (not the HTTP API); use for scripting and agent-driven TVC workflows."
+license: Apache-2.0
+compatibility: "Requires the `tvc` CLI on PATH (install: `cargo install tvc`) and TVC API credentials, supplied via TVC_* environment variables or a prior `tvc login`. This skill drives the CLI, not the Turnkey HTTP API."
+metadata:
+  author: turnkey
+  tags: "tvc verifiable-cloud cli deploy deployment enclave operator manifest quorum ndjson"
+---
+
+# TVC Deployments
+
+> **This skill drives the `tvc` CLI, not the HTTP API.** Unlike the other Turnkey skills (which call `POST /public/v1/...` with `TURNKEY_API_*` credentials), everything here runs `tvc <command> --message-format json` and reads NDJSON from stdout. Auth uses `TVC_*` env vars, a different set. Do not mix the two.
+>
+> **Scope:** this skill covers driving the CLI programmatically, editing/maintaining an already-established TVC project, and carrying TVC knowledge into any repo (install once, invoke anywhere). First-time human onboarding (org setup, `tvc login`, dashboard key registration) is owned by the [TVC quickstart](https://docs.turnkey.com/features/verifiable-cloud/quickstart).
+
+## When to use
+
+Use this skill when driving the `tvc` CLI: building or shipping a TVC deployment, editing/maintaining an established TVC project, cutting traffic to a new version, checking runtime status, or scripting any of the above in CI or an agent loop. For first-time human onboarding (org setup, `tvc login`), point the user at the [TVC quickstart](https://docs.turnkey.com/features/verifiable-cloud/quickstart). For Turnkey wallet/signing/policy work over the HTTP API, use the other Turnkey skills instead, this one is CLI-only.
+
+## Overview
+
+Turnkey Verifiable Cloud (TVC) runs your container inside a verifiable enclave. The `tvc` CLI is the interface for provisioning operators, creating apps, and shipping deployments. The full lifecycle from an empty directory to a live deployment is:
+
+```
+app init → (operator create, only if the scaffold shows a sentinel) → (edit) → app create → deploy init → (edit) → deploy create → deploy approve → poll deploy get-status
+# (the first deployment auto-goes-live on approval; app set-live-deploy is only for switching to a new version)
+```
+
+| What you want to do | Command(s) |
+|---|---|
+| Authenticate | `tvc login`, or set `TVC_*` env vars |
+| Create a hosted operator (approver; only when the `app.json` scaffold lacks a prefilled operator key) | `tvc operator create` |
+| Scaffold + create an app | `tvc app init` → edit → `tvc app create` |
+| Scaffold + create a deployment | `tvc deploy init` → edit → `tvc deploy create` |
+| Approve a deployment's manifest | `tvc deploy approve` |
+| Switch traffic to a new deployment | `tvc app set-live-deploy` (the first deployment auto-targets on approval) |
+| Check if a deployment is live | `tvc deploy get-status` (poll) |
+| Inspect an app / list apps | `tvc app status`, `tvc app list` |
+| Tail logs (debug-mode deploys) | `tvc deploy debug-logs` |
+| Roll back / clean up | `tvc deploy restore`, `tvc deploy delete`, `tvc app delete` |
+
+For the exact command-by-command happy path with expected outputs and the polling idiom, read **[references/deploy-lifecycle.md](references/deploy-lifecycle.md)**.
+
+## Authentication
+
+The CLI reads three credentials, **all required together**:
+
+```env
+TVC_ORG_ID=            # Turnkey organization UUID
+TVC_API_KEY_PUBLIC=    # API key public component (hex)
+TVC_API_KEY_PRIVATE=   # API key private component (hex)
+TVC_API_BASE_URL=      # optional, defaults to https://api.turnkey.com
+```
+
+Resolution order:
+1. **All three env vars set** → env auth is used (the CI / agent path). Empty strings count as unset.
+2. **None set** → the CLI falls back to disk config at `~/.config/turnkey/`, which requires a prior `tvc login`.
+3. **Partial** (some but not all three) → the CLI errors and names the missing variable. Set all three or none.
+
+For interactive/local setup, `tvc login --org <alias> --api-base-url <url>` persists a profile to disk. Env vars always win over disk config when all three are present.
+
+Credentials cannot be created non-interactively: `tvc login`'s key generation needs a human (TTY prompts plus manual dashboard registration). If neither env vars nor a profile are provisioned, stop and ask the user, do not retry `tvc login`.
+
+## Output contract (read this before parsing anything)
+
+Add `--message-format json` to **every** command in scripts and agents:
+
+- Stdout becomes **NDJSON**: exactly one JSON object per line. Parse line by line.
+- **JSON mode forces non-interactive.** A command that would otherwise prompt for a missing value instead fails fast with an error line (`missing_required_input` or `usage_error`) rather than hanging. Provide every required value up front.
+- Each success line carries a `reason` naming the outcome (e.g. `app_created`, `deployment_created`, `manifest_approval_posted`, `live_deployment_set`, `deployment_runtime_status`). One command → one terminal outcome line (except streaming commands like `deploy debug-logs`, which emit `debug_log_line` events).
+- Errors are a single line: `{ "reason": "command_error", "code": "<code>", "httpStatus"?: <n>, "message": "<full chain>" }`. Branch on `code`, not on `message` text. See **[references/error-reference.md](references/error-reference.md)** for the full taxonomy and recovery per code.
+
+Exit codes: `0` success, `1` runtime error, `2` usage error.
+
+## Core workflows
+
+### Build and deploy (happy path)
+
+Summarized here; full commands and outputs in **[references/deploy-lifecycle.md](references/deploy-lifecycle.md)**.
+
+**Before you run anything, confirm you have these four values.** None can be obtained from the `tvc` CLI or discovered with `--help`; they come from the container image you built and published:
+
+| Value | Source |
+|---|---|
+| `pivotContainerImageUrl` | a `linux/amd64` OCI image in a registry TVC can pull, referenced **by digest** |
+| `pivotPath` | the path of the pivot binary *inside* that image |
+| `expectedPivotDigest` | sha256 of that pivot binary, **not** the image digest, they are different fields |
+| `pivotArgs` | the app's own argument contract (often none) |
+
+If any are missing, **ask for them before step 2**. `app init` is local-only, but everything from `app create` onward (and `operator create`, when needed) creates real resources, so discovering the gap at step 3 leaves an app already provisioned. Never guess a digest: a plausible wrong value passes every local check and only fails once the enclave refuses to start. See **[references/config-files.md](references/config-files.md)** for how each is derived and what the image must satisfy.
+
+1. `tvc app init --output app.json` → `app_config_created`. Check `manifestSetParams.newOperators[0].publicKey`: a **prefilled real key** means your profile already has an operator — keep it and skip `operator create`; a **`<FILL_IN_OPERATOR_PUBLIC_KEY>` sentinel** means run `tvc operator create --message-format json` → `operator_created` and paste its `compositePublicKey` into that field.
+2. Fill the remaining `<FILL_IN_*>` sentinels → `tvc app create --config-file app.json --message-format json` → `app_created` (save `appId` **and** `manifestSetOperatorIds` — the operator ids allowed to approve this app's deployments; nothing returns them later)
+3. `tvc deploy init --output deploy.json` → edit `deploy.json` (pivot image, ports) → `tvc deploy create --config-file deploy.json --app-id <APP_ID> --message-format json` → `deployment_created` (save `deploymentId`)
+4. `tvc deploy approve --deploy-id <DEPLOY_ID> --operator-id <OPERATOR_ID> --dangerous-skip-interactive --message-format json` → `manifest_approval_posted`. `<OPERATOR_ID>` must be one of the app's `manifestSetOperatorIds` from step 2 — the id from `operator create` qualifies only if its key was wired into the manifest set. Its `quorumReached` field is a nullable boolean — tri-state: `true` = quorum met, `false` = more approvals needed, `null`/absent = unknown (not a failure; proceed to polling). A repeat approval by the same operator returns `manifest_approval_already_posted`, which is safe to treat as success.
+5. Poll `tvc deploy get-status --deploy-id <DEPLOY_ID> --message-format json` until it returns state, then read `isTargeted`. The **first** deployment of an app auto-targets once approval quorum is reached, so `isTargeted` is already `true` and no set-live call is needed.
+6. **Only if `isTargeted == false`** (switching traffic to a new deployment while an older one is live): `tvc app set-live-deploy --deploy-id <DEPLOY_ID> --message-format json`, then poll again. Live == `isTargeted == true` && `replicas.ready == replicas.desired` (see the polling rule below).
+
+Once live, get the app's hostname from `tvc app list --message-format json`: each entry in `apps_listed` carries a `publicDomain` field. **Read it rather than constructing it.** The key is omitted when its value is empty, which is the only "absent" signal the API has; treat that as "no domain available right now" and poll again before assuming the app has none. Never construct the hostname: the pattern is environment-specific (`app-<APP_ID>.turnkey.cloud` in production, a different domain entirely in dev), so a guessed hostname is a dead end. Use the hostname to hit the app's health endpoint (e.g. `curl https://<publicDomain>/health`; the exact path and response are app-specific).
+
+Config-file shapes and the scaffold-then-edit pattern are in **[references/config-files.md](references/config-files.md)**.
+
+### Maintain an established project
+
+- **Find your app:** `tvc app list --message-format json` (optionally `-n <name>`, a substring match) → `apps_listed`. `tvc app status --app-id <APP_ID>` → `app_status` for the app-wide view.
+- **Enumerate an app's deployments:** `tvc app status --app-id <APP_ID>` → `app_status`, whose `deployments[]` array gives `deploymentId` and `replicas{ready,desired}` for each, with `targetedDeploymentId` naming the live one. This is the only way to list deployments; ids are returned bare (the CLI strips the API's `deploy` prefix).
+- **Inspect a deployment:** `tvc deploy get-status --deploy-id <ID>` for one deployment's runtime readiness (`deployment_runtime_status`); `tvc deploy status --deploy-id <ID>` for config-level info like manifest id, QOS version, debug-mode, marked-for-deletion (`deployment_status`).
+- **Debug a deployment** (must be deployed in debug mode): `tvc deploy debug-logs --deploy-id <ID> --tail-lines 200 --message-format json`. Add `--poll` to stream; it never self-terminates, so always bound it with a timeout wrapper. Debug mode is gated at **two** levels: the app must have been created with `--dangerous-enable-debug-mode-deployments` (permanent, decided at `app create`, cannot be added later) *and* the deployment created with `--dangerous-deploy-debug-mode`. An existing non-debug deployment can never produce logs — do not retry; if the app allows it, ship a new debug-mode deployment instead.
+- **Ship a new version:** create a new deployment (`deploy create`), approve it, then `app set-live-deploy` to cut traffic over. Use `deploy init --from-deployment <OLD_ID>` to base the new config on an existing deployment.
+- **Roll back / clean up:** `tvc deploy restore --deploy-id <ID>` undoes a `deploy delete`. `tvc deploy delete` and `tvc app delete` are destructive (see Rules).
+
+## Rules
+
+1. **Always pass `--message-format json`** for programmatic use. It gives you NDJSON and guarantees non-interactive behavior (no hangs).
+2. **`deploy approve` requires `--dangerous-skip-interactive` in JSON/non-interactive mode.** There is no machine-readable manifest review yet, so non-interactive approval is unavoidably blind. Only approve deployments you created and whose inputs (`appId`, image, digest) you control. Surface this to the human when it matters.
+3. **"Is it live?" is a manual poll, and set-live is conditional.** There is no `--wait` or lifecycle-phase field. After approve, poll `tvc deploy get-status`; a deployment is live when `isTargeted == true` and `replicas.ready == replicas.desired`. The **first** deployment of an app auto-targets on approval, so do not call `app set-live-deploy` for it, calling set-live on an already-targeted deployment fails with `api_error` (HTTP 400) "already set as the live deployment". Only call `set-live-deploy` when `isTargeted == false` (cutting traffic over to a new deployment). Right after approval, `get-status` may return `replicas: null`, a 404 `not_found` ("app status not found"), or a run of transient `api_error` HTTP 500s — all mean "not ready yet," not a real failure, keep polling. Back off between polls (e.g. 5s) with an overall timeout. If the timeout passes with `isTargeted == true` but `replicas.ready` pinned at 0, stop and escalate to a human with the last status and the exact config — the causes (bad digest, wrong health-check port, cluster-side issues) are invisible to the CLI and not agent-recoverable.
+4. **Destructive commands have no undo except where noted.** `tvc app delete` removes the app **and all its deployments**. `tvc deploy delete` can be reversed with `tvc deploy restore`; `app delete` cannot. Confirm the exact `--app-id` / `--deploy-id` before running, and require explicit human confirmation for deletes.
+5. **Branch on `code`, never on `message` text.** Error messages carry the full server chain and will change; the `code` is the stable contract.
+6. **Bound every streaming command.** `deploy debug-logs --poll` runs until killed. Always wrap with a timeout or use `--tail-lines` for a one-shot read.
+
+## Current limitations (as of this writing)
+
+Do not assume these exist, they do not, and inventing them will fail:
+
+- **No `tvc deploy list` subcommand**, but deployments *are* enumerable per app: `tvc app status --app-id <APP_ID>` returns a `deployments[]` array of `{deploymentId, replicas{ready,desired}, lastUpdated}` plus `targetedDeploymentId`. Use it to recover deployment ids you no longer have. Caveat: that array reflects runtime state, so a freshly created deployment that has not been approved yet may not appear in it. Still save `deploymentId` at create time. `app list` is the app-level view and carries only `liveDeploymentId`, which is by definition already approved.
+- **No `tvc operator list`** and **no `tvc whoami`.** Save `operatorId` at creation time, and save `manifestSetOperatorIds` from `app create` output — they are the ids that can approve the app's deployments, and no later command returns them.
+- **No `--wait` / phase flag.** Poll `deploy get-status` (Rule 3).
+- **No `--version` flag.** Use the `tvc version` subcommand instead.
+- **`code: invalid_input`** is in the taxonomy but not currently emitted by the classifier.
+
+If a workflow needs one of these, script around it (save IDs, poll manually), do not call a nonexistent command.
+
+## Troubleshooting
+
+Errors classify into a `code`. Common ones and first move:
+
+- **`missing_required_input`** — a required flag/value was absent in non-interactive mode. The message names it; supply the flag or its `TVC_*` env var.
+- **`usage_error`** — bad flag or subcommand (clap parse error), exit 2. Re-check the command against this skill.
+- **`unauthorized`** (HTTP 401/403) — credential or permission problem. Verify `TVC_ORG_ID`/`TVC_API_KEY_*` or your `tvc login` profile, and that the key has permission for the action.
+- **`not_found`** (HTTP 404) — wrong `--app-id`/`--deploy-id`, or the resource has no state yet. Confirm the ID.
+- **`approval_required`** — the manifest needs more approvals before it can proceed. Collect additional operator approvals.
+- **`network_error`** — connect/timeout/DNS; the request never reached the server. Check `TVC_API_BASE_URL` and connectivity, then retry.
+- **`api_error`** — other non-2xx from the API; read the `message` (it now carries the server's error body).
+- **`client_version_too_old`** — the backend refuses `tvc` releases below its minimum version. Upgrade the binary (`cargo install tvc`); do not retry or touch the config.
+
+Full per-code recovery is in **[references/error-reference.md](references/error-reference.md)**.
+
+## Related Skills
+
+- [TVC quickstart](https://docs.turnkey.com/features/verifiable-cloud/quickstart) — first-time human onboarding (org setup, `tvc login`, first app). Use this skill for CLI-driven, maintenance, and cross-repo work.
+- `getting-started` — Turnkey HTTP API onboarding (separate `TURNKEY_API_*` credential model; not TVC).

--- a/tvc/skills/tvc-deployments/evals/evals.json
+++ b/tvc/skills/tvc-deployments/evals/evals.json
@@ -1,0 +1,105 @@
+{
+  "skill_name": "tvc-deployments",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need to ship a TVC app end to end with the tvc CLI, from creating the app through to confirming it is serving traffic. This runs unattended in CI, so nothing can prompt for input.",
+      "expected_output": "Runs the CLI with --message-format json (which also puts it in non-interactive mode), follows operator create -> app create -> deploy create -> deploy approve -> poll deploy get-status, and passes --dangerous-skip-interactive to approve since non-interactive mode requires it. Treats set-live-deploy as conditional on isTargeted, because the first deployment auto-targets on approval.",
+      "files": ["skills/tvc-deployments/references/deploy-lifecycle.md"],
+      "assertions": [
+        { "type": "contains", "value": "--message-format json" },
+        { "type": "regex", "value": "deploy[\"'\\s,]+approve", "comment": "tolerates both shell form (deploy approve) and argv arrays (\"deploy\", \"approve\")" },
+        { "type": "contains", "value": "--dangerous-skip-interactive" },
+        { "type": "contains", "value": "set-live-deploy" },
+        { "type": "regex", "value": "isTargeted", "comment": "set-live-deploy must be conditional: the first deployment auto-targets on approval, and calling it on an already-targeted deployment fails with HTTP 400" },
+        { "type": "regex", "value": "deploy get-status|get-status" },
+        {
+          "type": "not_regex",
+          "pattern": "^\\s*\\$?\\s*tvc\\s+deploy\\s+list\\b",
+          "flags": "m",
+          "comment": "Must not INVOKE `tvc deploy list` (it does not exist). Matches only command position, so correctly saying 'there is no deploy list' still passes."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "How do I check whether my TVC deployment is live and serving traffic from the CLI?",
+      "expected_output": "Polls tvc deploy get-status and checks isTargeted true and replicas.ready == replicas.desired; notes there is no --wait flag",
+      "files": ["skills/tvc-deployments/SKILL.md"],
+      "gradeFullResponse": true,
+      "assertions": [
+        { "type": "contains", "value": "get-status" },
+        { "type": "contains", "value": "isTargeted" },
+        { "type": "regex", "value": "replicas" },
+        {
+          "type": "not_regex",
+          "pattern": "^\\s*\\$?\\s*tvc\\s[^\\n]*--wait\\b",
+          "flags": "m",
+          "comment": "Must not USE a --wait flag on a tvc command (there is none). Correctly stating 'there is no --wait flag' still passes."
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "List all my TVC deployments with the tvc CLI so I can pick one to approve.",
+      "expected_output": "Points at `tvc app status --app-id <APP_ID>`, whose `deployments[]` array enumerates the app's deployments, and uses `targetedDeploymentId` to identify the already-live one (which needs no approval). There is no `tvc deploy list` subcommand. Notes that deployment IDs should still be saved at create time, since the status array reflects runtime state and a freshly created, unapproved deployment may not appear in it.",
+      "files": ["skills/tvc-deployments/SKILL.md"],
+      "gradeFullResponse": true,
+      "assertions": [
+        { "type": "regex", "value": "app[\"'\\s,]+status", "comment": "tolerates both shell form and argv arrays" },
+        { "type": "regex", "value": "deployments" },
+        { "type": "regex", "value": "targetedDeploymentId", "comment": "must distinguish the already-live deployment, since a live one is by definition already approved" },
+        {
+          "type": "not_regex",
+          "pattern": "^\\s*\\$?\\s*tvc\\s+deploy\\s+list\\b",
+          "flags": "m",
+          "comment": "Secondary guard: must not INVOKE the nonexistent command. Naming it to deny it exists is fine, which is why this matches command position rather than a substring."
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Set up tvc CLI auth for a CI job that has no interactive login.",
+      "expected_output": "Uses the TVC_ORG_ID, TVC_API_KEY_PUBLIC, TVC_API_KEY_PRIVATE env vars (all three), not TURNKEY_API_* and not a login prompt",
+      "files": ["skills/tvc-deployments/SKILL.md"],
+      "assertions": [
+        { "type": "contains", "value": "TVC_ORG_ID" },
+        { "type": "contains", "value": "TVC_API_KEY_PUBLIC" },
+        { "type": "contains", "value": "TVC_API_KEY_PRIVATE" },
+        { "type": "not_contains", "value": "TURNKEY_API_PUBLIC_KEY" }
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "My tvc command failed with {\"reason\":\"command_error\",\"code\":\"unauthorized\",\"httpStatus\":401,\"message\":\"...\"}. What should I do?",
+      "expected_output": "Identifies it as an auth/permission failure, points at verifying TVC_ORG_ID/TVC_API_KEY_* or the login profile and key permissions; branches on code not message",
+      "files": ["skills/tvc-deployments/references/error-reference.md"],
+      "gradeFullResponse": true,
+      "assertions": [
+        { "type": "regex", "value": "unauthorized|401|credential|permission" },
+        { "type": "regex", "value": "TVC_ORG_ID|TVC_API_KEY|login" }
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Create a new version of an existing TVC deployment and cut traffic over to it.",
+      "expected_output": "Uses deploy init --from-deployment to seed config, deploy create, deploy approve with --dangerous-skip-interactive, then app set-live-deploy to switch traffic",
+      "files": ["skills/tvc-deployments/references/deploy-lifecycle.md"],
+      "assertions": [
+        { "type": "regex", "value": "--from-deployment|deploy init" },
+        { "type": "regex", "value": "deploy[\"'\\s,]+create", "comment": "tolerates both shell form and argv arrays" },
+        { "type": "contains", "value": "set-live-deploy" }
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Tail the logs of my TVC deployment from an agent loop.",
+      "expected_output": "Uses tvc deploy debug-logs (requires debug-mode deploy), bounds the stream with --tail-lines or a timeout, notes --poll never self-terminates",
+      "files": ["skills/tvc-deployments/SKILL.md"],
+      "assertions": [
+        { "type": "contains", "value": "debug-logs" },
+        { "type": "regex", "value": "--tail-lines|--poll|timeout|bound" }
+      ]
+    }
+  ]
+}

--- a/tvc/skills/tvc-deployments/references/config-files.md
+++ b/tvc/skills/tvc-deployments/references/config-files.md
@@ -1,0 +1,108 @@
+# TVC config files (scaffold, then edit)
+
+`app create`, `deploy create`, and the local-quorum-key flow all read a JSON config file. The reliable pattern is **scaffold with `init`, then fill the sentinels**, rather than hand-authoring JSON. The `init` commands prefill real context (operator pubkey, last app ID, current QOS version) and drop `<FILL_IN_*>` sentinels where you must decide a value. `init` never overwrites an existing file.
+
+Always treat the scaffolded file as the source of truth for the current schema, fields evolve, and the CLI's scaffold is authoritative for the version you have installed.
+
+Scaffold-then-edit is a hard rule for `deploy.json`, not a preference: the parser has **no field defaults**. Eight of its eleven fields are required at parse time — `appId`, `qosVersion`, `pivotContainerImageUrl`, `pivotPath`, `expectedPivotDigest`, `healthCheckType`, `healthCheckPort`, `publicIngressPort` — and a hand-written file missing any of them fails with `command_error` ("missing field `...`"). Only `pivotArgs` (defaults `[]`), `dangerousDeployDebugMode` (defaults `false`), and `pivotContainerEncryptedPullSecret` (defaults absent) may be omitted. The 3000/HTTP defaults you see in scaffolded files live in `deploy init` and the flag-only path, not in the file parser.
+
+## App config
+
+```bash
+tvc app init --output app.json     # reason: app_config_created
+# open app.json, replace every <FILL_IN_*> sentinel (operator set / quorum params)
+tvc app create --config-file app.json --message-format json
+```
+
+- `--config-file` / `-c` is required for `app create` (env `TVC_APP_CONFIG`).
+- `--output` / `-o` is optional for `app init` (env `TVC_APP_CONFIG_OUT`); it defaults to `app.json`. Pass it explicitly in scripts so the path is deterministic.
+
+### Wiring the operator into `app.json`
+
+The scaffold prefills `manifestSetParams.newOperators[0].publicKey` with your profile's saved default operator when the profile resolves exactly one; otherwise it drops a `<FILL_IN_OPERATOR_PUBLIC_KEY>` sentinel. Branch on which you got:
+
+- **Prefilled with a real key:** the profile already has a usable operator. Keep the scaffolded key and do **not** run `tvc operator create` — a freshly created operator's key would not be the one in the scaffold, so the app's manifest set would not contain it and it could never approve this app's deployments.
+- **`<FILL_IN_OPERATOR_PUBLIC_KEY>` sentinel:** run `tvc operator create --message-format json` and paste the returned `compositePublicKey` (the `encryptPublicKey` and `signPublicKey` concatenated, emitted as one field) into `newOperators[0].publicKey`.
+
+Either way, the identities allowed to approve this app's deployments are the `manifestSetOperatorIds` returned by `app create` — save those and pass one of them to `deploy approve --operator-id`. The `operatorId` printed by `operator create` is only valid for approval if that operator's public key actually made it into the manifest set. Note that on the prefilled path the approver id is unknowable before `app create` returns: the scaffold shows only a public key, and no command lists operators — so if asked for the operator id up front, answer that it arrives with `app create`.
+
+## Deploy config
+
+```bash
+tvc deploy init --output deploy.json         # reason: deployment_config_created
+# open deploy.json, set the pivot image + digest, ports, and args
+tvc deploy create --config-file deploy.json --app-id <APP_ID> --message-format json
+```
+
+Almost every deploy field also has a CLI flag / env var; flags override the file. The one exception is `healthCheckType`, which can only be set in the config file. The knobs:
+
+| Flag | Env | Meaning |
+|---|---|---|
+| `--app-id` | `TVC_APP_ID` | The app this deployment belongs to |
+| `--pivot-image-url` | `TVC_PIVOT_IMAGE_URL` | OCI image URL for the enclave pivot |
+| `--expected-pivot-digest` | `TVC_EXPECTED_PIVOT_DIGEST` | Expected digest of the pivot binary (integrity pin) |
+| `--pivot-path` | `TVC_PIVOT_PATH` | Path to the pivot binary inside the image |
+| `--pivot-args` | `TVC_PIVOT_ARGS` | Args passed to the pivot (repeatable) |
+| `--qos-version` | `TVC_QOS_VERSION` | QOS version to run |
+| `--health-check-port` | `TVC_HEALTH_CHECK_PORT` | Port the health check probes |
+| *(none)* | *(none)* | `healthCheckType` is config-file only: `TVC_HEALTH_CHECK_TYPE_HTTP` (default) or `TVC_HEALTH_CHECK_TYPE_GRPC`. There is no flag and no env var, so it must be set in `deploy.json`. |
+| `--public-ingress-port` | `TVC_PUBLIC_INGRESS_PORT` | Public ingress port |
+| `--pivot-pull-secret` | `TVC_PIVOT_PULL_SECRET` | Pull secret for a private image |
+| `--dangerous-deploy-debug-mode` | `TVC_DANGEROUS_DEPLOY_DEBUG_MODE` | Debug-mode deploy (logs tailable; never for prod) |
+
+Seed a new deployment's config from an existing one:
+
+```bash
+tvc deploy init --output deploy.json --from-deployment <OLD_DEPLOY_ID>
+```
+
+## The two digests, which are different fields
+
+A deployment pins **two** separate sha256 values. Conflating them yields a config that looks correct and fails at deploy time.
+
+| Field | Hashes | Obtained from |
+|---|---|---|
+| the `@sha256:` in `pivotContainerImageUrl` | the **container image manifest** | the registry, after you push |
+| `expectedPivotDigest` | the **pivot binary** inside that image | extract the binary at `pivotPath`, then sha256 it |
+
+The CLI computes neither for you, so both are derived out of band. A wrong `expectedPivotDigest` is only caught at deploy time; nothing local validates it.
+
+### What the image has to satisfy
+
+These are requirements, not a toolchain recommendation:
+
+- A **`linux/amd64` OCI image** (the enclave runtime requires that architecture), in a registry TVC can pull from.
+- **Referenced by digest, not by tag alone.** Tags are mutable, and pinning is the point of a verifiable deployment.
+- **One digest to pin.** If your build publishes a multi-arch index, you must select the `linux/amd64` child manifest rather than the index digest. Builders often have flags to suppress the index and attestation layers so there is exactly one.
+- If the registry is private, supply a pull secret (`pivotContainerEncryptedPullSecret` / `--pivot-pull-secret`); if it is public, remove that placeholder from the scaffold entirely.
+
+### Getting the values
+
+Any OCI-compatible tooling works. Common choices, none required:
+
+- **Image digest:** `docker buildx imagetools inspect`, `crane digest`, `skopeo inspect`, or a plain registry API request.
+- **Pivot binary:** extract the file at `pivotPath` out of the image, then hash it. `docker create` + `docker cp`, `podman create` + `podman cp`, or `crane export` piped through `tar` all work. Hash with `sha256sum` or `shasum -a 256`.
+
+Whatever you use, the binary you hash must be the one inside the image you are pinning. Hashing a local build artifact that was not the one published produces a mismatch that only surfaces when the enclave refuses to start.
+
+## Quorum keys: Turnkey-hosted by default, local files only when self-provisioning
+
+**Prefer the Turnkey-hosted path.** It is the default, it runs no `tvc keys` commands, and it writes no key material to disk:
+
+- `tvc app init` scaffolds `app.json` with `quorumPublicKey` already prefilled — leave it as scaffolded.
+- The scaffold writes `"shareSetParams": null` and `"shareSetId": null` — keep both as scaffolded (do not delete the keys or fill them in). A null/absent share set selects Turnkey's default hosted share set at `app create` time.
+- The approver identity is the operator wired into `manifestSetParams` — see "Wiring the operator into `app.json`" above.
+
+Keep those scaffold defaults unless the app requires a quorum key you generate and hold yourself. Only then use the local flow below.
+
+### Alternative: local quorum key files (self-provisioned operator)
+
+```bash
+tvc keys init-local-quorum-key -o quorum_key.json       # -o / TVC_QUORUM_KEY_CONFIG_OUT, defaults to quorum_key.json
+# edit quorum_key.json
+tvc keys generate-local-quorum-key \
+  --config-file quorum_key.json \
+  --quorum-key-metadata-out quorum_key_metadata.json    # -c required; metadata-out defaults to quorum_key_metadata.json
+```
+
+`quorum_key_metadata.json` and any re-encrypted share files contain sensitive shares. Keep them out of source control and out of the working tree you might commit. Prefer writing them to a path outside the repo.

--- a/tvc/skills/tvc-deployments/references/deploy-lifecycle.md
+++ b/tvc/skills/tvc-deployments/references/deploy-lifecycle.md
@@ -1,0 +1,177 @@
+# TVC deploy lifecycle (command-by-command)
+
+The full path from an empty directory to a live deployment, using only commands that exist today. Every command below is real; flags marked required are required.
+
+Set auth once (all three, or use a `tvc login` profile):
+
+```bash
+export TVC_ORG_ID=<org-uuid>
+export TVC_API_KEY_PUBLIC=<hex>
+export TVC_API_KEY_PRIVATE=<hex>
+# export TVC_API_BASE_URL=https://api.turnkey.com   # optional; this is the default
+```
+
+Add `--message-format json` to every command (also forces non-interactive). Parse stdout as NDJSON.
+
+## 1. Scaffold the app config (and ensure an operator)
+
+An operator is the approver identity for deployments; you need at least one in the app's manifest set. Scaffold first — the scaffold tells you whether your profile already has one:
+
+```bash
+tvc app init --output app.json            # reason: app_config_created
+```
+
+Open `app.json` and branch on `manifestSetParams.newOperators[0].publicKey`:
+
+- **Prefilled with a real key** — your logged-in profile already has a default operator. Keep the key and do **not** run `operator create`: a fresh operator's key would not be in this scaffold, so the app's manifest set would not contain it and it could never approve this app's deployments.
+- **`<FILL_IN_OPERATOR_PUBLIC_KEY>` sentinel** — create a hosted operator and paste its `compositePublicKey` into `newOperators[0].publicKey`:
+
+  ```bash
+  tvc operator create --message-format json   # reason: operator_created
+  ```
+
+  Save the `operatorId`, there is no `operator list` to recover it later. Useful flags (all optional, with env fallbacks): `--name` (`TVC_OPERATOR_NAME`), `--wallet-name` (`TVC_OPERATOR_WALLET_NAME`), `--wallet-id` (`TVC_OPERATOR_WALLET_ID`), `--account-path` (`TVC_OPERATOR_ACCOUNT_PATH`).
+
+## 2. Create the app
+
+Fill the remaining `<FILL_IN_*>` sentinels (app name, manifest set name; leave the prefilled quorum fields as scaffolded — see [config-files.md](config-files.md)), then create:
+
+```bash
+tvc app create --config-file app.json --message-format json   # reason: app_created
+```
+
+`app create` output carries `appId`, `manifestSetId`, and `manifestSetOperatorIds`. Save the `appId` **and** the `manifestSetOperatorIds`: the latter are the operator ids allowed to approve this app's deployments, this output is the only place that returns them, and step 4 needs one.
+
+- `--config-file` / `-c` is **required** for `app create` (env `TVC_APP_CONFIG`).
+- `--no-operator-reuse` forces a fresh operator set instead of reusing an existing one.
+
+## 3. Create a deployment
+
+```bash
+tvc deploy init --output deploy.json      # reason: deployment_config_created
+# edit deploy.json — pivot image URL, expected pivot digest, ports, args
+tvc deploy create --config-file deploy.json --app-id <APP_ID> --message-format json   # reason: deployment_created
+```
+
+`deploy create` output carries `deploymentId`, `appId`, and `pinnedImageUrl`. Save the `deploymentId`.
+
+- Everything in the config file can also be passed as a flag / env var: `--qos-version`, `--pivot-image-url`, `--expected-pivot-digest`, `--pivot-path`, `--pivot-args`, `--health-check-port`, `--public-ingress-port`, `--app-id`. Flags override the file.
+- `tvc deploy init --from-deployment <OLD_DEPLOY_ID>` seeds `deploy.json` from an existing deployment (use when shipping a new version).
+- `--dangerous-deploy-debug-mode` produces a debug-mode deployment whose logs you can tail with `deploy debug-logs`. It only works if the **app** was created with `--dangerous-enable-debug-mode-deployments` — an app-level opt-in that is decided at `app create`, can never be changed afterward, and permanently marks the app's quorum key as insecure (debug deployments emit zeroed attestation PCRs, so remote attestation cannot succeed). Never use debug mode for production.
+
+## 4. Approve the manifest
+
+In JSON/non-interactive mode this **requires** `--dangerous-skip-interactive` (there is no machine-readable manifest review yet, so the approval is blind, only approve deployments whose inputs you control).
+
+```bash
+tvc deploy approve \
+  --deploy-id <DEPLOY_ID> \
+  --operator-id <OPERATOR_ID> \
+  --dangerous-skip-interactive \
+  --message-format json
+```
+
+- `--operator-id` must be one of the app's `manifestSetOperatorIds` from the `app create` output. The `operatorId` printed by `operator create` qualifies only if that operator's key was actually wired into the manifest set. Omitting the flag works when the CLI knows exactly one candidate operator; with several, non-interactive mode fails asking for `--operator-id`.
+- Success: `reason: manifest_approval_posted`. Read its `quorumReached` field, which is a **nullable boolean, so treat it as tri-state**:
+  - `true` — approval quorum is met; move on to polling `get-status`.
+  - `false` — the deployment still needs more operator approvals before it can proceed; collect them via further `deploy approve` calls.
+  - `null` / absent — quorum state is **unknown**, not "not reached": the CLI could not run its post-approval check (e.g. you approved via `--manifest` with no `--deploy-id`). Do not re-approve; proceed to polling `get-status`.
+- Re-approving with an operator that has already approved returns `reason: manifest_approval_already_posted` (carrying `operatorId` and `approvalId`). Nothing was posted; it is safe to treat as success.
+- If more approvals are still needed, a follow-up call classifies as `code: approval_required`, collect the remaining operator approvals.
+- You can approve by manifest file instead of deploy id: `--manifest <PATH>` (mutually exclusive with `--deploy-id`).
+- `--dry-run` validates without posting; `--approval-out <PATH>` / `-o` writes the approval artifact.
+
+## 5. Confirm live (set live only if switching versions)
+
+The **first** deployment of an app auto-targets once approval quorum is reached, there is no separate "go live" step for it. So check status first; only call `set-live-deploy` when you are switching traffic to a new deployment while an older one is already live.
+
+Poll status (there is no `--wait`):
+
+```bash
+tvc deploy get-status --deploy-id <DEPLOY_ID> --message-format json   # reason: deployment_runtime_status
+```
+
+Right after approval this may return `replicas: null`, a 404 `not_found` ("app status not found"), or a run of transient `api_error` HTTP 500s ("failed to fetch app status: … internal server error") — all mean "no state yet, not ready", keep polling (observed: ~25s of consecutive 500s before the first real status). Once it returns state, read `isTargeted`:
+
+- **`isTargeted == true`** → this deployment is receiving traffic. It is live once `replicas.ready == replicas.desired`. First deployments land here with no set-live call.
+- **`isTargeted == false`** → it is not receiving traffic (an older deployment is still live). Switch traffic to it:
+
+  ```bash
+  tvc app set-live-deploy --deploy-id <DEPLOY_ID> --message-format json   # reason: live_deployment_set
+  ```
+
+  then poll `get-status` again until `isTargeted == true` && `replicas.ready == replicas.desired`.
+
+Do **not** call `set-live-deploy` on a deployment that is already targeted, it fails with `api_error` (HTTP 400) "already set as the live deployment". Gating on `isTargeted == false` avoids that.
+
+A reasonable loop: poll every 5s, give up after a timeout (e.g. 5 min), report the last status. For the app-wide view use `tvc app status --app-id <APP_ID> --message-format json` (`reason: app_status`); its `targetedDeploymentId` should equal your deployment id. Note `tvc deploy status --deploy-id <ID>` (`reason: deployment_status`) returns config-level info (manifest id, QOS version, debug-mode, marked-for-deletion) but **not** replica readiness, use `get-status` for liveness.
+
+**If the timeout passes with `isTargeted: true` but `replicas.ready` pinned at 0, stop — this is not agent-recoverable.** The likely causes are all invisible to the CLI: a wrong `expectedPivotDigest`, a health-check port the app does not listen on, or a cluster-side problem — and a non-debug deployment can never produce logs to distinguish them. Do not keep polling indefinitely, do not delete and retry with the same config (a bad input fails identically), and do not invent diagnostics. Report the last `get-status` output, the exact config used, and escalate to a human. (Only if the *app* was created with debug-mode deployments enabled is there a self-serve next step: ship a new deployment with `--dangerous-deploy-debug-mode` and read its `debug-logs`.)
+
+One cosmetic mismatch not to chase: `deploy status` echoes the pivot image with a `:latest` tag inserted before the digest (`repo:latest@sha256:…`) even when you submitted a digest-only URL. The digest still pins the image; it is not a config drift.
+
+## 6. Verify the app is serving
+
+Once the deployment is live, ask the CLI for the app's hostname instead of assuming it:
+
+```bash
+tvc app list --message-format json
+```
+
+`app list` has no `--app-id` filter (its only filter is `-n/--name`, a substring match), and `app status` does **not** return the domain, so select your app out of the list by `id`. Each entry in the `apps_listed` line carries a `publicDomain` field:
+
+```json
+{
+  "reason": "apps_listed",
+  "apps": [
+    {
+      "id": "<APP_ID>",
+      "name": "Little App",
+      "quorumPublicKey": "04cdff...",
+      "liveDeploymentId": "<DEPLOY_ID>",
+      "egressEnabled": false,
+      "debugModeDeploymentsEnabled": false,
+      "publicDomain": "app-<APP_ID>.<environment-specific-domain>"
+    }
+  ]
+}
+```
+
+**Read `publicDomain`; do not construct it.** The key is omitted from the JSON whenever its value is the empty string, and empty is the only "absent" signal the API has (the wire type is a non-optional string, so there is no null and no way to tell unset from empty). Treat a missing key as "no domain available right now" rather than an error.
+
+What empty *means* is not firmly established: the CLI documents it as "the app has no public domain configured," but it has not been confirmed whether it can also be empty transiently while a new app's domain is still being provisioned. If you get an empty value on an app you expect to have a domain, poll `app list` again before concluding it has none. There is no constructible fallback: the hostname pattern is environment-specific (production orgs get `app-<APP_ID>.turnkey.cloud`, dev orgs something entirely different, e.g. `app-<APP_ID>.apps.tvc-dev.turnkey.engineering`), so a guessed hostname is a dead end — the returned `publicDomain` is the only reliable source. It is populated as early as `app create`, before any deployment exists; it just serves nothing until a deployment is live.
+
+If the app exposes an HTTP health endpoint, check it:
+
+```bash
+DOMAIN=$(tvc app list --message-format json \
+  | jq -r --arg id "<APP_ID>" '.apps[] | select(.id == $id) | .publicDomain // empty')
+curl "https://$DOMAIN/health"
+```
+
+**Do not assert on the response body.** TVC judges liveness by the HTTP status, so a `200` is what matters; the body is app-defined. Treat a non-200 as unhealthy and read the body only for human diagnosis.
+
+The probe is configured on the deployment:
+
+| Field | Values | Default | Also settable via |
+|---|---|---|---|
+| `healthCheckType` | `TVC_HEALTH_CHECK_TYPE_HTTP`, `TVC_HEALTH_CHECK_TYPE_GRPC` | `..._HTTP` | config file only, no flag or env var |
+| `healthCheckPort` | any `u16`, must be the port your app listens on | `3000` | `--health-check-port`, `TVC_HEALTH_CHECK_PORT` |
+
+There is no health-check *path* field, so `/health` is a platform convention rather than something you choose. A deployment whose `healthCheckPort` does not match the port the pivot actually binds will never pass its probe, which looks identical to an app that failed to start.
+
+## Provisioning variant (local/self-hosted operator key)
+
+The hosted path above lets Turnkey hold the operator quorum key. For the self-provisioned variant, these commands are the building blocks (not needed for the minimal hosted happy path):
+
+- `tvc keys init-local-quorum-key -o quorum_key.json` → edit → `tvc keys generate-local-quorum-key -c quorum_key.json --quorum-key-metadata-out meta.json`
+- `tvc deploy provisioning-details --deploy-id <ID> --provision-bundle-out bundle.json`
+- `tvc keys re-encrypt-local-share --quorum-key-metadata meta.json --provision-bundle bundle.json --re-encrypted-out share.json`
+- `tvc deploy post-share --re-encrypted-share share.json --share-operator-id <OPERATOR_ID>`
+- `tvc deploy provision --deploy-id <ID> --operator-id <OPERATOR_ID>`
+
+`quorum_key_metadata` and share files contain sensitive material, keep them out of source control.
+
+## Quick reference: outcome reasons you will see
+
+`operator_created`, `app_config_created`, `app_created`, `deployment_config_created`, `deployment_created`, `manifest_approval_posted` (carries nullable `quorumReached`) / `manifest_approval_generated` / `manifest_approval_dry_run` / `manifest_approval_already_posted`, `live_deployment_set`, `deployment_runtime_status`, `deployment_status`, `app_status`, `apps_listed`, `debug_logs_fetched` (+ streamed `debug_log_line`), `deployment_deleted`, `deployment_restored`, `app_deleted`, `version`.

--- a/tvc/skills/tvc-deployments/references/error-reference.md
+++ b/tvc/skills/tvc-deployments/references/error-reference.md
@@ -1,0 +1,42 @@
+# TVC CLI error reference
+
+Every runtime error in JSON mode is a single NDJSON line:
+
+```json
+{ "reason": "command_error", "code": "<code>", "httpStatus": 404, "message": "<full error chain>" }
+```
+
+- `reason` is `command_error` for all runtime errors (and `missing_required_input` for that one special case). It identifies the *shape*; it is not the classification. Reasons are snake_case, like every other outcome reason.
+- `code` is the stable classification, **branch on this**, never on `message` text.
+- `httpStatus` is present only when the failure came from an HTTP response.
+- `message` is the full error chain including the server's response body (not just the top layer). Show it to humans; do not parse it programmatically.
+
+Exit codes: `0` success, `1` runtime error, `2` usage error.
+
+## Code taxonomy
+
+| `code` | Trigger | Recovery |
+|---|---|---|
+| `missing_required_input` | A value that would have been prompted for interactively was absent in non-interactive mode. Only the prompting commands emit it (`deploy approve` without `--dangerous-skip-interactive`, `login` without `--org`); a missing clap-required flag is `usage_error` instead. `reason` is `missing_required_input`. | The message names the missing flag. Supply it or its `TVC_*` env var. |
+| `usage_error` | Bad flags/args or unknown subcommand (clap parse failure). Exit code 2. | Fix the command. Re-check subcommand and flag names against the skill; do not invent flags. |
+| `unauthorized` | HTTP 401/403 from the API. | Verify `TVC_ORG_ID` / `TVC_API_KEY_PUBLIC` / `TVC_API_KEY_PRIVATE` (or your `tvc login` profile), and that the key is permitted for the action. |
+| `not_found` | HTTP 404, or an OK response with an empty resource. | Confirm the `--app-id` / `--deploy-id`. Remember there is no `deploy list` to discover IDs; you must have saved them. |
+| `approval_required` | The activity needs more approvals (consensus) before it can proceed. | Collect additional operator approvals via `deploy approve`, then continue. |
+| `network_error` | Connect / timeout / DNS; the request never reached the server. | Check `TVC_API_BASE_URL` and connectivity. Safe to retry with backoff. |
+| `api_error` | Any other non-2xx HTTP status, or a failed/unexpected activity. | Read `message` for the server's explanation. Not automatically retryable. |
+| `client_version_too_old` | The backend rejected this `tvc` release as older than the minimum it supports (HTTP 400 with `turnkeyErrorCode: TVC_CLIENT_VERSION_TOO_OLD`). | Not a config problem and never retryable: upgrade the binary (`cargo install tvc`) and rerun. The server's remediation text is in `message`. |
+| `command_error` | Fallback for anything not classified above. | Read `message`. |
+| `invalid_input` | Defined in the taxonomy but **not currently emitted** by the classifier. | You will not see this today; do not branch on it expecting semantic-validation failures. |
+
+## Handling patterns
+
+- **Retryable:** `network_error` (backoff + retry). `api_error` may be transient (5xx) or permanent (4xx-ish), inspect before retrying.
+- **Not retryable without a change:** `usage_error`, `missing_required_input`, `unauthorized`, `not_found`, `invalid_input`, `client_version_too_old` (the change is upgrading the binary).
+- **Needs a human/side action:** `approval_required` (get more approvals).
+- **Never loop blindly on the same command.** If a retry would send the identical request, only retry `network_error`.
+
+## Gotchas
+
+- JSON mode forces non-interactive, so the few commands that would prompt instead fail with `missing_required_input`. Most missing values surface as `usage_error` (a clap-required flag was omitted), so provide every required value up front and treat both codes as "fix the invocation".
+- `deploy approve` in JSON mode fails fast (as `missing_required_input` on `--dangerous-skip-interactive`) unless that flag is passed.
+- A 404-style "not found" can also mean "exists but has no state yet" (e.g. `deploy get-status` before replicas appear returns `replicas: null` rather than erroring, but a truly unknown ID errors as `not_found`). Distinguish by whether you hold a valid ID.

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -314,6 +314,9 @@ impl Commands {
                     unreachable!("create-certs returned before loading the TVC configuration")
                 }
             },
+            Commands::Skills { command } => match command {
+                SkillsCommands::Save(args) => commands::skills::save::run(args),
+            },
             Commands::Version => commands::version::run(),
         }
     }
@@ -353,6 +356,11 @@ enum Commands {
         #[command(subcommand)]
         command: YubikeyCommands,
     },
+    /// Manage the agent skills bundled with the CLI.
+    Skills {
+        #[command(subcommand)]
+        command: SkillsCommands,
+    },
     /// Print the tvc CLI version.
     Version,
 }
@@ -371,6 +379,7 @@ impl Commands {
             Commands::App { command } => command.name(),
             Commands::Keys { command } => command.name(),
             Commands::Yubikey { command } => command.name(),
+            Commands::Skills { command } => command.name(),
             Commands::Version => "version",
         }
     }
@@ -469,6 +478,21 @@ enum KeysCommands {
     InitLocalQuorumKey(commands::keys::init_local_quorum_key::Args),
     /// Re-encrypt a local share for enclave provisioning.
     ReEncryptLocalShare(commands::keys::re_encrypt_local_share::Args),
+}
+
+#[derive(Debug, Subcommand)]
+enum SkillsCommands {
+    /// Save the bundled agent skills to a skills directory.
+    #[command(long_about = commands::skills::save::LONG_ABOUT)]
+    Save(commands::skills::save::Args),
+}
+
+impl SkillsCommands {
+    fn name(&self) -> &'static str {
+        match self {
+            SkillsCommands::Save(_) => "skills save",
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/tvc/src/commands.rs
+++ b/tvc/src/commands.rs
@@ -15,6 +15,7 @@ pub mod display;
 pub mod keys;
 pub mod login;
 pub mod operator;
+pub mod skills;
 pub mod version;
 pub mod yubikey;
 

--- a/tvc/src/commands/skills.rs
+++ b/tvc/src/commands/skills.rs
@@ -1,0 +1,3 @@
+//! Agent skill commands.
+
+pub mod save;

--- a/tvc/src/commands/skills/save.rs
+++ b/tvc/src/commands/skills/save.rs
@@ -1,0 +1,238 @@
+//! Skills save command - writes the agent skills bundled in the binary to a
+//! skills directory where AI coding tools discover them.
+
+use crate::outcome::Outcome;
+use anyhow::{Context, Result, bail};
+use clap::Args as ClapArgs;
+use serde::Serialize;
+use std::fmt::{self, Display, Formatter};
+use std::path::PathBuf;
+use tracing::instrument;
+
+pub(crate) const LONG_ABOUT: &str = r#"
+Write the agent skills bundled with this tvc release to a skills directory.
+
+Skills follow the open Agent Skills format (SKILL.md), which is read by Claude
+Code, Codex, Cursor, and other tools that scan a skills directory. The bundled
+skills document the tvc CLI at exactly the version of this binary, so re-run
+this command after upgrading tvc.
+
+By default the skills are written to ./.claude/skills (the project-level
+directory). Use --global for ~/.claude/skills, or --dir for any other skills
+root. Files you have modified locally are never overwritten unless --force is
+passed; unmodified and absent files are always safe to (re)write."#;
+
+/// The skill directories bundled into the binary, as
+/// `(path relative to the skills root, content)`.
+///
+/// Evals are deliberately not bundled: they are test fixtures for the skill's
+/// own CI, not something an agent consumes. The `embedded_manifest_matches_
+/// skills_dir` test keeps this list in sync with `tvc/skills/` on disk.
+const EMBEDDED_SKILL_FILES: [(&str, &str); 4] = [
+    (
+        "tvc-deployments/SKILL.md",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/tvc-deployments/SKILL.md"
+        )),
+    ),
+    (
+        "tvc-deployments/references/deploy-lifecycle.md",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/tvc-deployments/references/deploy-lifecycle.md"
+        )),
+    ),
+    (
+        "tvc-deployments/references/config-files.md",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/tvc-deployments/references/config-files.md"
+        )),
+    ),
+    (
+        "tvc-deployments/references/error-reference.md",
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/skills/tvc-deployments/references/error-reference.md"
+        )),
+    ),
+];
+
+/// The names of the bundled skills (the top-level directories under the
+/// skills root).
+const SKILL_NAMES: [&str; 1] = ["tvc-deployments"];
+
+/// Save the bundled agent skills to a skills directory.
+#[derive(Debug, ClapArgs)]
+#[command(about, long_about = None)]
+pub struct Args {
+    /// Skills root directory to write into (each skill becomes a
+    /// subdirectory of it). Defaults to ./.claude/skills.
+    #[arg(
+        long,
+        value_name = "DIR",
+        env = "TVC_SKILLS_DIR",
+        conflicts_with = "global"
+    )]
+    pub dir: Option<PathBuf>,
+
+    /// Write to the user-level skills directory (~/.claude/skills) instead of
+    /// the project-level default (./.claude/skills).
+    #[arg(long)]
+    pub global: bool,
+
+    /// Overwrite skill files whose content differs from this binary's bundled
+    /// version.
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Run the skills save command.
+#[instrument(skip_all)]
+pub fn run(args: Args) -> Result<Outcome> {
+    let dest = match (args.dir, args.global) {
+        (Some(dir), _) => dir,
+        (None, true) => {
+            let home = std::env::var("HOME").context("HOME environment variable not set")?;
+            PathBuf::from(home).join(".claude").join("skills")
+        }
+        (None, false) => PathBuf::from(".claude").join("skills"),
+    };
+
+    // Plan first, write second: a conflict must abort before anything is
+    // written, so a refused run never leaves a half-updated skill behind.
+    let mut to_write = Vec::new();
+    let mut unchanged = 0usize;
+    let mut conflicts = Vec::new();
+
+    for (relative_path, content) in EMBEDDED_SKILL_FILES {
+        let path = dest.join(relative_path);
+        if path.exists() {
+            let existing = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read existing file: {}", path.display()))?;
+            if existing == content {
+                unchanged += 1;
+                continue;
+            }
+            if !args.force {
+                conflicts.push(relative_path);
+                continue;
+            }
+        }
+        to_write.push((path, content));
+    }
+
+    if !conflicts.is_empty() {
+        bail!(
+            "refusing to overwrite locally modified skill files: {}. \
+             Pass --force to replace them with this binary's bundled version",
+            conflicts.join(", ")
+        );
+    }
+
+    for (path, content) in &to_write {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+        }
+        std::fs::write(path, content)
+            .with_context(|| format!("failed to write file: {}", path.display()))?;
+    }
+
+    Ok(Outcome::SkillsSaved(SkillsSaved {
+        command: "skills save",
+        path: dest.display().to_string(),
+        skills: SKILL_NAMES.to_vec(),
+        files_written: to_write.len(),
+        files_unchanged: unchanged,
+    }))
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillsSaved {
+    command: &'static str,
+    path: String,
+    skills: Vec<&'static str>,
+    files_written: usize,
+    files_unchanged: usize,
+}
+
+impl Display for SkillsSaved {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Saved agent skills to {} ({} written, {} unchanged):",
+            self.path, self.files_written, self.files_unchanged
+        )?;
+        for skill in &self.skills {
+            writeln!(f, "  - {skill}")?;
+        }
+        write!(
+            f,
+            r#"
+Tools that support the Agent Skills format (Claude Code, Codex, Cursor, ...)
+discover skills in this directory. The skills describe the tvc CLI at this
+binary's version; re-run `tvc skills save` after upgrading tvc."#
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Walk `tvc/skills/` on disk and collect every file that must be
+    /// embedded, as paths relative to the skills root. Eval fixtures are the
+    /// deliberate exception (see `EMBEDDED_SKILL_FILES`).
+    fn skill_files_on_disk(dir: &Path, root: &Path, files: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("skills directory must be readable") {
+            let path = entry.expect("directory entry must be readable").path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "evals") {
+                    continue;
+                }
+                skill_files_on_disk(&path, root, files);
+            } else {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("walked file must live under the skills root");
+                files.push(relative.to_string_lossy().replace('\\', "/"));
+            }
+        }
+    }
+
+    #[test]
+    fn embedded_manifest_matches_skills_dir() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills");
+        let mut on_disk = Vec::new();
+        skill_files_on_disk(&root, &root, &mut on_disk);
+        on_disk.sort();
+
+        let mut embedded: Vec<String> = EMBEDDED_SKILL_FILES
+            .iter()
+            .map(|(path, _)| (*path).to_string())
+            .collect();
+        embedded.sort();
+
+        assert_eq!(
+            embedded, on_disk,
+            "EMBEDDED_SKILL_FILES is out of sync with tvc/skills/ — register \
+             new skill files in the manifest (evals stay excluded)"
+        );
+    }
+
+    #[test]
+    fn every_skill_has_a_skill_md() {
+        for skill in SKILL_NAMES {
+            assert!(
+                EMBEDDED_SKILL_FILES
+                    .iter()
+                    .any(|(path, _)| *path == format!("{skill}/SKILL.md")),
+                "skill `{skill}` has no embedded SKILL.md"
+            );
+        }
+    }
+}

--- a/tvc/src/outcome.rs
+++ b/tvc/src/outcome.rs
@@ -17,7 +17,7 @@
 use crate::commands::deploy::approve::{
     ApprovalAlreadyPosted, ApprovalDryRun, ApprovalGenerated, ApprovalPosted,
 };
-use crate::commands::{app, deploy, keys, login, operator, version, yubikey};
+use crate::commands::{app, deploy, keys, login, operator, skills, version, yubikey};
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 
@@ -64,6 +64,7 @@ pub enum Outcome {
     QuorumKeyGenerated(keys::generate_local_quorum_key::QuorumKeyGenerated),
     QuorumKeyConfigCreated(keys::init_local_quorum_key::QuorumKeyConfigCreated),
     ReEncryptedShareGenerated(keys::re_encrypt_local_share::ReEncryptedShareGenerated),
+    SkillsSaved(skills::save::SkillsSaved),
     Version(version::CliVersion),
 }
 
@@ -104,6 +105,7 @@ impl Display for Outcome {
             Outcome::QuorumKeyGenerated(msg) => msg.fmt(f),
             Outcome::QuorumKeyConfigCreated(msg) => msg.fmt(f),
             Outcome::ReEncryptedShareGenerated(msg) => msg.fmt(f),
+            Outcome::SkillsSaved(msg) => msg.fmt(f),
             Outcome::Version(msg) => msg.fmt(f),
         }
     }

--- a/tvc/tests/skills_save.rs
+++ b/tvc/tests/skills_save.rs
@@ -1,0 +1,190 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn skills_cmd() -> (TempDir, assert_cmd::Command) {
+    let temp = TempDir::new().unwrap();
+    let mut cmd = cargo_bin_cmd!("tvc");
+    cmd.env_clear().env("HOME", temp.path()).arg("skills");
+    (temp, cmd)
+}
+
+fn parse_single_json_line(assert: &assert_cmd::assert::Assert) -> Value {
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected one JSON message, got {stdout:?}");
+    serde_json::from_str(lines[0]).unwrap()
+}
+
+#[test]
+fn save_writes_the_bundled_skill_to_an_explicit_dir() {
+    let (temp, mut cmd) = skills_cmd();
+    let dest = temp.path().join("my-skills");
+
+    let assert = cmd
+        .args(["save", "--dir"])
+        .arg(&dest)
+        .args(["--message-format", "json"])
+        .assert()
+        .success();
+
+    let message = parse_single_json_line(&assert);
+    assert_eq!(message["reason"], "skills_saved");
+    assert_eq!(message["command"], "skills save");
+    assert_eq!(message["skills"], serde_json::json!(["tvc-deployments"]));
+    assert_eq!(message["filesWritten"], 4);
+    assert_eq!(message["filesUnchanged"], 0);
+
+    let skill_md = dest.join("tvc-deployments/SKILL.md");
+    let content = std::fs::read_to_string(&skill_md).unwrap();
+    assert!(
+        content.starts_with("---"),
+        "SKILL.md must begin with YAML frontmatter"
+    );
+    assert!(
+        dest.join("tvc-deployments/references/deploy-lifecycle.md")
+            .exists()
+    );
+}
+
+#[test]
+fn save_is_idempotent() {
+    let (temp, mut first) = skills_cmd();
+    let dest = temp.path().join("skills");
+    first
+        .args(["save", "--dir"])
+        .arg(&dest)
+        .assert()
+        .success();
+
+    let mut second = cargo_bin_cmd!("tvc");
+    second.env_clear().env("HOME", temp.path());
+    let assert = second
+        .args(["skills", "save", "--dir"])
+        .arg(&dest)
+        .args(["--message-format", "json"])
+        .assert()
+        .success();
+
+    let message = parse_single_json_line(&assert);
+    assert_eq!(message["filesWritten"], 0);
+    assert_eq!(message["filesUnchanged"], 4);
+}
+
+#[test]
+fn save_refuses_to_overwrite_a_modified_file_without_force() {
+    let (temp, mut first) = skills_cmd();
+    let dest = temp.path().join("skills");
+    first
+        .args(["save", "--dir"])
+        .arg(&dest)
+        .assert()
+        .success();
+
+    let skill_md = dest.join("tvc-deployments/SKILL.md");
+    std::fs::write(&skill_md, "locally modified").unwrap();
+
+    let mut second = cargo_bin_cmd!("tvc");
+    second.env_clear().env("HOME", temp.path());
+    let assert = second
+        .args(["skills", "save", "--dir"])
+        .arg(&dest)
+        .args(["--message-format", "json"])
+        .assert()
+        .failure();
+
+    let message = parse_single_json_line(&assert);
+    assert_eq!(message["reason"], "command_error");
+    assert_eq!(message["code"], "command_error");
+    assert!(
+        message["message"]
+            .as_str()
+            .unwrap()
+            .contains("tvc-deployments/SKILL.md")
+    );
+
+    let content = std::fs::read_to_string(&skill_md).unwrap();
+    assert_eq!(content, "locally modified", "refusal must not clobber");
+}
+
+#[test]
+fn save_force_replaces_a_modified_file() {
+    let (temp, mut first) = skills_cmd();
+    let dest = temp.path().join("skills");
+    first
+        .args(["save", "--dir"])
+        .arg(&dest)
+        .assert()
+        .success();
+
+    let skill_md = dest.join("tvc-deployments/SKILL.md");
+    std::fs::write(&skill_md, "locally modified").unwrap();
+
+    let mut second = cargo_bin_cmd!("tvc");
+    second.env_clear().env("HOME", temp.path());
+    let assert = second
+        .args(["skills", "save", "--force", "--dir"])
+        .arg(&dest)
+        .args(["--message-format", "json"])
+        .assert()
+        .success();
+
+    let message = parse_single_json_line(&assert);
+    assert_eq!(message["filesWritten"], 1);
+    assert_eq!(message["filesUnchanged"], 3);
+
+    let content = std::fs::read_to_string(&skill_md).unwrap();
+    assert!(content.starts_with("---"), "file must be restored");
+}
+
+#[test]
+fn save_global_targets_the_home_skills_dir() {
+    let (temp, mut cmd) = skills_cmd();
+
+    cmd.args(["save", "--global"]).assert().success();
+
+    assert!(
+        temp.path()
+            .join(".claude/skills/tvc-deployments/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
+fn save_defaults_to_the_project_skills_dir() {
+    let (temp, mut cmd) = skills_cmd();
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    cmd.arg("save").current_dir(&project).assert().success();
+
+    assert!(
+        project
+            .join(".claude/skills/tvc-deployments/SKILL.md")
+            .exists()
+    );
+}
+
+#[test]
+fn save_dir_conflicts_with_global() {
+    let (_temp, mut cmd) = skills_cmd();
+
+    cmd.args(["save", "--dir", "somewhere", "--global"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn save_human_output_is_not_json() {
+    let (temp, mut cmd) = skills_cmd();
+    let dest = temp.path().join("skills");
+
+    cmd.args(["save", "--dir"])
+        .arg(&dest)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""reason""#).not())
+        .stdout(predicate::str::contains("tvc-deployments"));
+}

--- a/tvc/tests/skills_save.rs
+++ b/tvc/tests/skills_save.rs
@@ -52,11 +52,7 @@ fn save_writes_the_bundled_skill_to_an_explicit_dir() {
 fn save_is_idempotent() {
     let (temp, mut first) = skills_cmd();
     let dest = temp.path().join("skills");
-    first
-        .args(["save", "--dir"])
-        .arg(&dest)
-        .assert()
-        .success();
+    first.args(["save", "--dir"]).arg(&dest).assert().success();
 
     let mut second = cargo_bin_cmd!("tvc");
     second.env_clear().env("HOME", temp.path());
@@ -76,11 +72,7 @@ fn save_is_idempotent() {
 fn save_refuses_to_overwrite_a_modified_file_without_force() {
     let (temp, mut first) = skills_cmd();
     let dest = temp.path().join("skills");
-    first
-        .args(["save", "--dir"])
-        .arg(&dest)
-        .assert()
-        .success();
+    first.args(["save", "--dir"]).arg(&dest).assert().success();
 
     let skill_md = dest.join("tvc-deployments/SKILL.md");
     std::fs::write(&skill_md, "locally modified").unwrap();
@@ -112,11 +104,7 @@ fn save_refuses_to_overwrite_a_modified_file_without_force() {
 fn save_force_replaces_a_modified_file() {
     let (temp, mut first) = skills_cmd();
     let dest = temp.path().join("skills");
-    first
-        .args(["save", "--dir"])
-        .arg(&dest)
-        .assert()
-        .success();
+    first.args(["save", "--dir"]).arg(&dest).assert().success();
 
     let skill_md = dest.join("tvc-deployments/SKILL.md");
     std::fs::write(&skill_md, "locally modified").unwrap();


### PR DESCRIPTION
## What

- Adds the `tvc-deployments` agent skill (SKILL.md + references, open Agent Skills format) under `tvc/skills/`.
- New `tvc skills save` command: embeds the skill in the binary and writes it to `./.claude/skills` by default (`--global` for `~/.claude/skills`, `--dir` for a custom root, `--force` to overwrite locally modified files; reruns are idempotent).
- Adds an "Agent skills" section to `tvc/AGENTS.md`: install via `tvc skills save`, keep the skill in sync with CLI changes.

## Why

Bundling pins the skill to the installed CLI version, so agent docs can never drift from the binary. Works with any tool reading the Agent Skills format (Claude Code, Codex, Cursor). Implements the `tvc skills` command suggested on TVC-134.

## Testing

Clippy clean; full `cargo test -p tvc` green, including a manifest-parity guard test and 8 new integration tests for save/idempotency/force/conflict behavior.
Manual test run.