### PR TITLE
fix(tvc): one profile per organization, id-keyed key dirs, and eager config migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,6 +4010,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1.0.140", default-features = false, features = ["std"]
 serde_bytes = { version = "0.11", default-features = false }
 serde_cbor = { version = "0.11", default-features = false }
 serde_with = { version = "3.14.0", default-features = false, features = ["macros", "base64"] }
-indexmap = "2.9"
+indexmap = { version = "2.9", default-features = false, features = ["std", "serde"] }
 
 # Cryptography
 hpke = { version = "0.10", features = ["alloc", "p256", "serde_impls"], default-features = false }
@@ -80,7 +80,7 @@ x509-parser = { version = "0.14.0", default-features = false }
 
 # Serialization formats
 borsh = { version = "1.0", features = ["std", "derive"], default-features = false }
-toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+toml = { version = "0.8", default-features = false, features = ["parse", "display", "preserve_order"] }
 
 # Code generation and parsing
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ x509-parser = { version = "0.14.0", default-features = false }
 
 # Serialization formats
 borsh = { version = "1.0", features = ["std", "derive"], default-features = false }
-toml = { version = "0.8", default-features = false, features = ["parse", "display", "preserve_order"] }
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 
 # Code generation and parsing
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -50,6 +50,13 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 displaydoc = { workspace = true }
 
+# `tests/common.rs` is the fixture module the integration-test binaries pull
+# in via `mod common;`; registering it with `test = false` stops cargo from
+# also building it as an (empty) test binary of its own.
+[[test]]
+name = "common"
+test = false
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 hpke = { workspace = true }

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -41,7 +41,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
-toml = { workspace = true }
+# preserve_order keeps `tvc.config.toml` in document order across load/save;
+# it's a tvc requirement, so the feature is enabled here, not workspace-wide.
+toml = { workspace = true, features = ["preserve_order"] }
 tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
 uuid = { workspace = true }
 x509-cert = { workspace = true, features = ["builder", "hazmat"] }

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -214,30 +214,7 @@ impl Commands {
 
         let home = std::env::var("HOME").context("HOME environment variable not set")?;
         let path = PathBuf::from(home).join(CONFIG_DIR).join(CONFIG_FILE);
-        debug!(config_path = %path.display(), "loading tvc config");
-
-        let config = if !path.exists() {
-            debug!(config_path = %path.display(), "tvc config not found; using defaults");
-            let config = Config::default();
-            config.save().await?;
-            config
-        } else {
-            let content = tokio::fs::read_to_string(&path)
-                .await
-                .with_context(|| format!("failed to read config file: {}", path.display()))?;
-
-            let config = Config::from_toml(&content)
-                .with_context(|| format!("failed to parse config file: {}", path.display()))?;
-
-            debug!(
-                config_path = %path.display(),
-                active_org = ?config.active_org,
-                org_count = config.orgs.len(),
-                "loaded tvc config"
-            );
-
-            config
-        };
+        let config = Config::load_from_path(&path).await?;
 
         match command {
             Commands::Deploy { command } => match command {

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -13,6 +13,7 @@ use turnkey_client::{
         external::data::v1::{TvcApp, TvcDeployment},
     },
 };
+use uuid::Uuid;
 
 /// Number of *required* auth env vars: org_id, api_key_public, api_key_private.
 /// `TVC_API_BASE_URL` is optional and defaults to `DEFAULT_API_BASE_URL`.
@@ -28,7 +29,7 @@ pub struct AuthenticatedClient {
     /// The Turnkey API client.
     pub client: TurnkeyClient<TurnkeyP256ApiKey>,
     /// The organization ID for API calls.
-    pub org_id: String,
+    pub org_id: Uuid,
     /// The API base URL for the active org. Used for environment-specific behavior.
     pub api_base_url: String,
 }
@@ -60,7 +61,7 @@ pub async fn build_client(config: &Config) -> Result<AuthenticatedClient> {
             }
         };
 
-    build_authed_client(&org_id, &api_base_url, &api_key_public, &api_key_private)
+    build_authed_client(org_id, &api_base_url, &api_key_public, &api_key_private)
 }
 
 #[instrument(skip_all)]
@@ -68,7 +69,7 @@ pub async fn fetch_tvc_app(auth: &AuthenticatedClient, app_id: &str) -> Result<T
     let response = auth
         .client
         .get_tvc_app(GetTvcAppRequest {
-            organization_id: auth.org_id.clone(),
+            organization_id: auth.org_id.to_string(),
             tvc_app_id: app_id.to_string(),
         })
         .await
@@ -100,7 +101,7 @@ pub async fn fetch_tvc_deployment(
 }
 
 #[instrument(skip_all)]
-async fn load_credentials_from_config(config: &Config) -> Result<(String, String, String, String)> {
+async fn load_credentials_from_config(config: &Config) -> Result<(Uuid, String, String, String)> {
     let (alias, org_config) = config
         .active_org_config()
         .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?;
@@ -117,7 +118,7 @@ async fn load_credentials_from_config(config: &Config) -> Result<(String, String
         .ok_or_else(|| anyhow!("No API key found for org '{alias}'. Run `tvc login` first."))?;
 
     Ok((
-        org_config.id.to_string(),
+        org_config.id,
         org_config.api_base_url.clone(),
         api_key.public_key.clone(),
         api_key.private_key.clone(),
@@ -155,7 +156,7 @@ pub(crate) fn build_turnkey_client(
 
 #[instrument(skip_all)]
 fn build_authed_client(
-    org_id: &str,
+    org_id: Uuid,
     api_base_url: &str,
     api_key_public: &str,
     api_key_private: &str,
@@ -171,7 +172,7 @@ fn build_authed_client(
 
     Ok(AuthenticatedClient {
         client,
-        org_id: org_id.to_string(),
+        org_id,
         api_base_url: api_base_url.to_string(),
     })
 }
@@ -189,7 +190,7 @@ fn read_env_var(name: &str) -> Option<String> {
 ///   required vars set; `api_base_url` falls back to the default if unset.
 /// - `Err`: only some of the required vars are set; the error names which.
 #[instrument(skip_all)]
-fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, String)>> {
+fn load_credentials_from_env_vars() -> Result<Option<(Uuid, String, String, String)>> {
     let org_id = read_env_var(ENV_ORG_ID);
     let api_key_public = read_env_var(ENV_API_KEY_PUBLIC);
     let api_key_private = read_env_var(ENV_API_KEY_PRIVATE);
@@ -233,8 +234,13 @@ fn load_credentials_from_env_vars() -> Result<Option<(String, String, String, St
         );
     }
 
+    let org_id = org_id
+        .unwrap()
+        .parse()
+        .with_context(|| format!("{ENV_ORG_ID} must be a UUID"))?;
+
     Ok(Some((
-        org_id.unwrap(),
+        org_id,
         api_base_url,
         api_key_public.unwrap(),
         api_key_private.unwrap(),

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -102,12 +102,12 @@ pub async fn fetch_tvc_deployment(
 
 #[instrument(skip_all)]
 async fn load_credentials_from_config(config: &Config) -> Result<(Uuid, String, String, String)> {
-    let (alias, org_config) = config
-        .active_org_config()
+    let (resolved, org_config) = config
+        .resolve_active()
         .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?;
 
     debug!(
-        org_alias = %alias,
+        org = %resolved,
         api_base_url = %org_config.api_base_url,
         api_key_path = %org_config.api_key_path.display(),
         "resolved active organization config"
@@ -115,10 +115,10 @@ async fn load_credentials_from_config(config: &Config) -> Result<(Uuid, String, 
 
     let api_key = StoredApiKey::load(org_config)
         .await?
-        .ok_or_else(|| anyhow!("No API key found for org '{alias}'. Run `tvc login` first."))?;
+        .ok_or_else(|| anyhow!("No API key found for org '{resolved}'. Run `tvc login` first."))?;
 
     Ok((
-        org_config.id,
+        resolved.id(),
         org_config.api_base_url.clone(),
         api_key.public_key.clone(),
         api_key.private_key.clone(),

--- a/tvc/src/client.rs
+++ b/tvc/src/client.rs
@@ -117,7 +117,7 @@ async fn load_credentials_from_config(config: &Config) -> Result<(String, String
         .ok_or_else(|| anyhow!("No API key found for org '{alias}'. Run `tvc login` first."))?;
 
     Ok((
-        org_config.id.clone(),
+        org_config.id.to_string(),
         org_config.api_base_url.clone(),
         api_key.public_key.clone(),
         api_key.private_key.clone(),

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -262,7 +262,7 @@ async fn run_with_app_config(
 
     let result = auth
         .client
-        .create_tvc_app(auth.org_id, timestamp_ms, intent)
+        .create_tvc_app(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to create TVC app")?;
 

--- a/tvc/src/commands/app/create.rs
+++ b/tvc/src/commands/app/create.rs
@@ -4,6 +4,7 @@ use crate::{
     client::build_client,
     config::{
         app::{AppConfig, AppConfigValidationErrors, OperatorSetParams},
+        placeholder::{StringWithPlaceholder, text::FillInAppName},
         turnkey,
     },
     operator::OperatorCandidate,
@@ -19,9 +20,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     io,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use tracing::{debug, instrument};
 use turnkey_client::generated::{CreateTvcAppIntent, TvcOperatorParams, TvcOperatorSetParams};
+use uuid::Uuid;
 
 /// Create a new TVC application from a config file.
 #[derive(Debug, ClapArgs)]
@@ -266,11 +269,16 @@ async fn run_with_app_config(
         .await
         .context("failed to create TVC app")?;
 
-    let app_id = result.result.app_id;
-    let operator_ids = result.result.manifest_set_operator_ids;
+    let app_id = result.result.app_id.parse()?;
+    let operator_ids = result
+        .result
+        .manifest_set_operator_ids
+        .iter()
+        .map(|id| Uuid::from_str(id))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    config.set_last_app_id(&app_id)?;
-    config.set_last_operator_ids(&operator_ids)?;
+    config.set_last_app_id(app_id)?;
+    config.set_last_operator_ids(operator_ids.clone())?;
     config.save().await?;
 
     Ok(Outcome::AppCreated(AppCreated {
@@ -285,10 +293,10 @@ async fn run_with_app_config(
 #[derive(Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppCreated {
-    app_id: String,
-    name: String,
+    app_id: Uuid,
+    name: StringWithPlaceholder<FillInAppName>,
     manifest_set_id: String,
-    manifest_set_operator_ids: Vec<String>,
+    manifest_set_operator_ids: Vec<Uuid>,
     config_path: String,
 }
 
@@ -306,10 +314,16 @@ Manifest Set ID: {}"#,
         )?;
 
         if !self.manifest_set_operator_ids.is_empty() {
+            let operator_ids = self
+                .manifest_set_operator_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+
             write!(
                 f,
                 "\nManifest Set Operator IDs: {}",
-                self.manifest_set_operator_ids.join(", ")
+                operator_ids.join(", ")
             )?;
         }
 
@@ -328,7 +342,7 @@ fn build_create_tvc_app_intent(app_config: &AppConfig) -> CreateTvcAppIntent {
     let share_set_params = app_config.effective_share_set_params();
 
     CreateTvcAppIntent {
-        name: app_config.name.clone(),
+        name: app_config.name.to_string(),
         quorum_public_key: app_config.quorum_public_key.clone(),
         manifest_set_id: app_config.manifest_set_id.clone(),
         manifest_set_params: app_config
@@ -362,7 +376,11 @@ fn to_tvc_operator_set_params(params: &OperatorSetParams) -> TvcOperatorSetParam
                 public_key: o.public_key.clone(),
             })
             .collect(),
-        existing_operator_ids: params.existing_operator_ids.clone(),
+        existing_operator_ids: params
+            .existing_operator_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
     }
 }
 
@@ -376,7 +394,7 @@ mod tests {
 
     fn valid_config() -> AppConfig {
         AppConfig {
-            name: "test-app".to_string(),
+            name: "test-app".into(),
             quorum_public_key: KNOWN_QUORUM_KEY.to_string(),
             enable_egress: false,
             manifest_set_id: None,
@@ -426,7 +444,7 @@ mod tests {
                 name: "share-operator".to_string(),
                 public_key: "share-public-key".to_string(),
             }],
-            existing_operator_ids: vec!["existing-operator-id".to_string()],
+            existing_operator_ids: vec![Uuid::from_u128(9)],
         });
 
         let intent = build_create_tvc_app_intent(&config);
@@ -437,7 +455,7 @@ mod tests {
         assert_eq!(share_set_params.new_operators[0].name, "share-operator");
         assert_eq!(
             share_set_params.existing_operator_ids,
-            vec!["existing-operator-id".to_string()]
+            vec![Uuid::from_u128(9).to_string()]
         );
     }
 
@@ -554,25 +572,25 @@ mod tests {
         "07".repeat(130)
     }
 
-    fn candidate(id: &str) -> OperatorCandidate {
+    fn candidate(id: Uuid) -> OperatorCandidate {
         OperatorCandidate {
-            id: id.to_string(),
+            id,
             name: None,
             public_key: Some(operator_public_key().parse().unwrap()),
         }
     }
 
-    fn unmatched_candidate(id: &str) -> OperatorCandidate {
+    fn unmatched_candidate(id: Uuid) -> OperatorCandidate {
         OperatorCandidate {
-            id: id.to_string(),
+            id,
             name: None,
             public_key: Some("08".repeat(130).parse().unwrap()),
         }
     }
 
-    fn unknown_key_candidate(id: &str) -> OperatorCandidate {
+    fn unknown_key_candidate(id: Uuid) -> OperatorCandidate {
         OperatorCandidate {
-            id: id.to_string(),
+            id,
             name: None,
             public_key: None,
         }
@@ -583,7 +601,7 @@ mod tests {
     fn decide_reuse_keeps_config_when_flag_set() {
         let params = manifest_params_with_new_operator();
         assert_eq!(
-            decide_operator_reuse(true, Some(&params), &[candidate("op-1")]),
+            decide_operator_reuse(true, Some(&params), &[candidate(Uuid::from_u128(1))]),
             OperatorReuse::KeepConfig
         );
     }
@@ -607,8 +625,8 @@ mod tests {
                 false,
                 Some(&params),
                 &[
-                    unmatched_candidate("hosted"),
-                    unknown_key_candidate("saved")
+                    unmatched_candidate(Uuid::from_u128(0xB1)),
+                    unknown_key_candidate(Uuid::from_u128(0xB2))
                 ],
             ),
             OperatorReuse::KeepConfig
@@ -624,7 +642,7 @@ mod tests {
         });
 
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &[candidate("op-1")]),
+            decide_operator_reuse(false, Some(&params), &[candidate(Uuid::from_u128(1))]),
             OperatorReuse::KeepConfig
         );
     }
@@ -633,12 +651,12 @@ mod tests {
     #[test]
     fn decide_reuse_keeps_config_when_config_pins_existing_ids() {
         let mut params = manifest_params_with_new_operator();
-        params.existing_operator_ids = vec!["explicit-op".to_string()];
+        params.existing_operator_ids = vec![Uuid::from_u128(3)];
         assert_eq!(
             decide_operator_reuse(
                 false,
                 Some(&params),
-                &[candidate("op-1"), candidate("op-2")]
+                &[candidate(Uuid::from_u128(1)), candidate(Uuid::from_u128(2))]
             ),
             OperatorReuse::KeepConfig
         );
@@ -648,7 +666,7 @@ mod tests {
     #[test]
     fn decide_reuse_keeps_config_without_manifest_params() {
         assert_eq!(
-            decide_operator_reuse(false, None, &[candidate("op-1")]),
+            decide_operator_reuse(false, None, &[candidate(Uuid::from_u128(1))]),
             OperatorReuse::KeepConfig
         );
     }
@@ -658,8 +676,8 @@ mod tests {
     fn decide_reuse_reuses_the_sole_candidate() {
         let params = manifest_params_with_new_operator();
         assert_eq!(
-            decide_operator_reuse(false, Some(&params), &[candidate("op-1")]),
-            OperatorReuse::Reuse(candidate("op-1"))
+            decide_operator_reuse(false, Some(&params), &[candidate(Uuid::from_u128(1))]),
+            OperatorReuse::Reuse(candidate(Uuid::from_u128(1)))
         );
     }
 
@@ -668,14 +686,17 @@ mod tests {
     fn decide_reuse_returns_candidates_for_multiple_known_operators() {
         let params = manifest_params_with_new_operator();
         let candidates = [
-            candidate("op-1"),
-            unmatched_candidate("unrelated"),
-            candidate("op-2"),
-            unknown_key_candidate("saved"),
+            candidate(Uuid::from_u128(1)),
+            unmatched_candidate(Uuid::from_u128(0xB3)),
+            candidate(Uuid::from_u128(2)),
+            unknown_key_candidate(Uuid::from_u128(0xB2)),
         ];
         assert_eq!(
             decide_operator_reuse(false, Some(&params), &candidates),
-            OperatorReuse::MultipleCandidates(vec![candidate("op-1"), candidate("op-2")])
+            OperatorReuse::MultipleCandidates(vec![
+                candidate(Uuid::from_u128(1)),
+                candidate(Uuid::from_u128(2))
+            ])
         );
     }
 
@@ -684,10 +705,11 @@ mod tests {
     fn apply_operator_reuse_swaps_new_operators_for_existing_id() {
         let mut ctx = Ctx::new(EmptyShell::default(), true);
         let mut config = valid_config();
-        apply_operator_reuse(&mut ctx, &mut config, candidate("op-1")).unwrap();
+        let operator_id = Uuid::from_u128(1);
+        apply_operator_reuse(&mut ctx, &mut config, candidate(operator_id)).unwrap();
 
         let params = config.manifest_set_params.unwrap();
         assert!(params.new_operators.is_empty());
-        assert_eq!(params.existing_operator_ids, vec!["op-1".to_string()]);
+        assert_eq!(params.existing_operator_ids, vec![operator_id]);
     }
 }

--- a/tvc/src/commands/app/delete.rs
+++ b/tvc/src/commands/app/delete.rs
@@ -38,7 +38,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcom
 
     let result = auth
         .client
-        .delete_tvc_app_and_deployments(auth.org_id, timestamp_ms, intent)
+        .delete_tvc_app_and_deployments(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to delete TVC app and deployments")?;
 

--- a/tvc/src/commands/app/list.rs
+++ b/tvc/src/commands/app/list.rs
@@ -33,7 +33,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Resul
     let response = auth
         .client
         .get_tvc_apps(GetTvcAppsRequest {
-            organization_id: auth.org_id.clone(),
+            organization_id: auth.org_id.to_string(),
         })
         .await
         .context("failed to list TVC apps")?;

--- a/tvc/src/commands/app/set_live_deploy.rs
+++ b/tvc/src/commands/app/set_live_deploy.rs
@@ -40,7 +40,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcom
 
     let result = auth
         .client
-        .update_tvc_app_live_deployment(auth.org_id, timestamp_ms, intent)
+        .update_tvc_app_live_deployment(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to set TVC app live deployment")?;
 

--- a/tvc/src/commands/app/status.rs
+++ b/tvc/src/commands/app/status.rs
@@ -36,7 +36,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Resul
     let app_id = args.app_id.to_string();
 
     let request = GetAppStatusRequest {
-        organization_id: auth.org_id.clone(),
+        organization_id: auth.org_id.to_string(),
         app_id: app_id.clone(),
     };
 

--- a/tvc/src/commands/deploy.rs
+++ b/tvc/src/commands/deploy.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn port_summary_explains_shared_port() {
-        let config = DeployConfig::template(None);
+        let config = DeployConfig::template(Default::default());
 
         let summary = format_port_summary(&config);
 
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn port_summary_explains_split_ports() {
-        let mut config = DeployConfig::template(None);
+        let mut config = DeployConfig::template(Default::default());
         config.public_ingress_port = 8080;
         config.health_check_port = 9090;
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -263,7 +263,7 @@ impl Run for Args {
                         }
                         OperatorRecordKind::Hosted(hosted) => {
                             let hosted = ResolvedHostedOperator::from_registry(
-                                org.id.to_string(),
+                                org.id,
                                 &operator.name,
                                 hosted,
                             )?;
@@ -953,14 +953,14 @@ async fn post_approval_to_api(
 
     let result = auth
         .client
-        .create_tvc_manifest_approvals(auth.org_id.clone(), timestamp_ms, intent)
+        .create_tvc_manifest_approvals(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to post manifest approval")?;
 
     let quorum_reached = match plan.deploy_id {
         Some(deploy_id) => {
             let request = GetTvcDeploymentRequest {
-                organization_id: auth.org_id.clone(),
+                organization_id: auth.org_id.to_string(),
                 deployment_id: deploy_id.to_string(),
             };
 
@@ -1220,7 +1220,7 @@ async fn fetch_manifest_from_deploy(
     let auth = build_client(config).await?;
 
     let request = GetTvcDeploymentRequest {
-        organization_id: auth.org_id.clone(),
+        organization_id: auth.org_id.to_string(),
         deployment_id: deploy_id.to_string(),
     };
 

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -263,7 +263,7 @@ impl Run for Args {
                         }
                         OperatorRecordKind::Hosted(hosted) => {
                             let hosted = ResolvedHostedOperator::from_registry(
-                                org.id.clone(),
+                                org.id.to_string(),
                                 &operator.name,
                                 hosted,
                             )?;

--- a/tvc/src/commands/deploy/approve.rs
+++ b/tvc/src/commands/deploy/approve.rs
@@ -155,11 +155,11 @@ impl Run for Args {
         if !args.dry_run
             && let Some(OperatorSelector::Serial(serial)) = args.operator_selector.as_ref()
         {
-            let (alias, org) = config
+            let (org_id, org) = config
                 .active_org_config()
                 .context("--serial requires an active organization")?;
             org.select_yubikey_operator(Some(*serial))
-                .with_context(|| format!("org '{alias}'"))?;
+                .with_context(|| format!("org '{}'", config.display_name(org_id)))?;
         }
 
         let LoadedManifest {
@@ -232,7 +232,7 @@ impl Run for Args {
                     });
                 }
             } else {
-                let (_, org) = config.active_org_config().ok_or_else(|| {
+                let (org_id, org) = config.active_org_config().ok_or_else(|| {
                     anyhow::anyhow!(
                         "No active organization. Run `tvc login` first or provide \
                          --operator-seed or --operator-seed-path."
@@ -263,7 +263,7 @@ impl Run for Args {
                         }
                         OperatorRecordKind::Hosted(hosted) => {
                             let hosted = ResolvedHostedOperator::from_registry(
-                                org.id,
+                                org_id,
                                 &operator.name,
                                 hosted,
                             )?;

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -104,7 +104,7 @@ struct Overrides {
 
     /// Override the appId field.
     #[arg(long, env = "TVC_APP_ID")]
-    pub app_id: Option<String>,
+    pub app_id: Option<Uuid>,
 
     /// Override the qosVersion field.
     #[arg(long, env = "TVC_QOS_VERSION")]
@@ -179,15 +179,27 @@ async fn build_inputs_interactive(
         pivot_pull_secret,
         overrides,
     } = args;
-    let (mut deploy_config, file_loaded) = read_config_file_bytes(config_path.as_deref())
+    let file = read_config_file_bytes(config_path.as_deref())
         .await?
         .map(|(path, contents)| {
             serde_json::from_str(&contents)
                 .with_context(|| format!("failed to parse config file: {}", path.display()))
         })
-        .transpose()?
-        .map(|deploy_config| (deploy_config, true))
-        .unwrap_or_else(|| (flag_only_template(), false));
+        .transpose()?;
+
+    let (mut deploy_config, file_loaded) = match file {
+        Some(deploy_config) => (deploy_config, true),
+        None => {
+            // A blank template needs an app ID up front; the last created app
+            // is the natural default, and interactive mode can ask.
+            let app_id = match overrides.app_id.or_else(|| config.get_last_app_id()) {
+                Some(app_id) => app_id,
+                None => prompts::text("enter an app-id", None)?.parse()?,
+            };
+
+            (flag_only_template(app_id), false)
+        }
+    };
 
     apply_overrides(&mut deploy_config, &overrides);
 
@@ -200,8 +212,7 @@ async fn build_inputs_interactive(
             }
             _ => {
                 config_updated = true;
-                let saved_app_id = config.get_last_app_id();
-                deploy_config.fill_interactively(ctx, saved_app_id.as_deref())?;
+                deploy_config.fill_interactively(ctx)?;
             }
         }
     }
@@ -233,7 +244,13 @@ async fn build_inputs_non_interactive(args: Args) -> Result<ResolvedDeployInputs
     let mut config = match file {
         Some((path, bytes)) => serde_json::from_str(&bytes)
             .with_context(|| format!("failed to parse config file: {}", path.display()))?,
-        _ => flag_only_template(),
+        _ => {
+            let app_id = overrides
+                .app_id
+                .ok_or_else(|| anyhow!("--app-id is a required argument"))?;
+
+            flag_only_template(app_id)
+        }
     };
 
     apply_overrides(&mut config, &overrides);
@@ -280,8 +297,8 @@ async fn read_pivot_pull_secret(path: Option<&Path>) -> Result<Option<String>> {
     Ok(pull_secret.into())
 }
 
-fn flag_only_template() -> DeployConfig {
-    let mut template = DeployConfig::template(None);
+fn flag_only_template(app_id: Uuid) -> DeployConfig {
+    let mut template = DeployConfig::template(app_id);
     // Strip the template's "<REMOVE_ME...>" hint so flag-only mode doesn't ship
     // it to the API for public images.
     template.pivot_container_encrypted_pull_secret = None;
@@ -290,7 +307,7 @@ fn flag_only_template() -> DeployConfig {
 
 fn apply_overrides(config: &mut DeployConfig, overrides: &Overrides) {
     if let Some(v) = &overrides.app_id {
-        config.app_id = v.clone();
+        config.app_id = *v;
     }
     if let Some(v) = &overrides.qos_version {
         config.qos_version = v.clone();
@@ -368,7 +385,7 @@ fn build_create_intent(
     pivot_container_encrypted_pull_secret: Option<String>,
 ) -> CreateTvcDeploymentIntent {
     CreateTvcDeploymentIntent {
-        app_id: deploy_config.app_id.clone(),
+        app_id: deploy_config.app_id.to_string(),
         qos_version: deploy_config.qos_version.clone(),
         pivot_container_image_url,
         pivot_path: deploy_config.pivot_path.clone(),
@@ -410,7 +427,7 @@ async fn run_with_resolved_inputs(
     let auth = build_client(config).await?;
 
     // validate that the app exists
-    fetch_tvc_app(&auth, &deploy_config.app_id).await?;
+    fetch_tvc_app(&auth, &deploy_config.app_id.to_string()).await?;
 
     let pivot_container_encrypted_pull_secret = match inputs.pivot_pull_secret.as_ref() {
         Some(pull_secret) => Some(encrypt_pivot_pull_secret(pull_secret, &auth.api_base_url)?),
@@ -473,7 +490,7 @@ async fn run_with_resolved_inputs(
 #[serde(rename_all = "camelCase")]
 pub struct DeploymentCreated {
     deployment_id: String,
-    app_id: String,
+    app_id: Uuid,
     pinned_image_url: String,
     /// Present when the deployment was created from a config file.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -532,7 +549,7 @@ mod tests {
 
     fn all_required_flags() -> Args {
         let overrides = Overrides {
-            app_id: Some(FLAG_APP_ID.into()),
+            app_id: Some(FLAG_APP_ID.parse().unwrap()),
             qos_version: Some("flag-qos".into()),
             pivot_image_url: Some("flag-image".into()),
             expected_pivot_digest: Some("flag-digest".into()),
@@ -547,8 +564,7 @@ mod tests {
     }
 
     fn file_config() -> DeployConfig {
-        let mut c = DeployConfig::template(None);
-        c.app_id = FILE_APP_ID.into();
+        let mut c = DeployConfig::template(FILE_APP_ID.parse().unwrap());
         c.qos_version = "file-qos".into();
         c.pivot_container_image_url = "file-image".into();
         c.pivot_path = "file-path".into();
@@ -581,7 +597,7 @@ mod tests {
                     Some((path, bytes)) => serde_json::from_str(&bytes).with_context(|| {
                         format!("failed to parse config file: {}", path.display())
                     })?,
-                    None => flag_only_template(),
+                    None => flag_only_template(FILE_APP_ID.parse().unwrap()),
                 };
                 apply_overrides(&mut config, &args.overrides);
                 if let Err(errors) = config.validate() {
@@ -595,7 +611,7 @@ mod tests {
     fn flag_overrides_file_value() {
         let file = write_config(&file_config());
         let overrides = Overrides {
-            app_id: Some(FLAG_APP_ID.into()),
+            app_id: Some(FLAG_APP_ID.parse().unwrap()),
             ..Default::default()
         };
         let args = Args {
@@ -604,7 +620,7 @@ mod tests {
             ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, FLAG_APP_ID);
+        assert_eq!(resolved.app_id.to_string(), FLAG_APP_ID);
         // Untouched fields keep their file values.
         assert_eq!(resolved.qos_version, "file-qos");
         assert_eq!(resolved.health_check_port, 4000);
@@ -618,7 +634,7 @@ mod tests {
             ..Default::default()
         };
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, FILE_APP_ID);
+        assert_eq!(resolved.app_id.to_string(), FILE_APP_ID);
         assert_eq!(resolved.qos_version, "file-qos");
         assert_eq!(resolved.health_check_port, 4000);
     }
@@ -627,7 +643,7 @@ mod tests {
     fn no_file_uses_flag_only_with_template_defaults() {
         let resolved = run_resolve(&all_required_flags()).unwrap();
         // Required fields come from flags.
-        assert_eq!(resolved.app_id, FLAG_APP_ID);
+        assert_eq!(resolved.app_id.to_string(), FLAG_APP_ID);
         assert_eq!(resolved.qos_version, "flag-qos");
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");
@@ -645,7 +661,6 @@ mod tests {
     fn no_file_no_required_flags_bails_naming_each_field() {
         let err = run_resolve(&Default::default()).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("app_id"), "{msg}");
         assert!(msg.contains("pivot_container_image_url"), "{msg}");
         assert!(msg.contains("pivot_path"), "{msg}");
         assert!(msg.contains("expected_pivot_digest"), "{msg}");
@@ -864,7 +879,7 @@ mod tests {
         let args = TestCli::try_parse_from([
             "tvc-deploy-create",
             "--app-id",
-            "test-app",
+            FLAG_APP_ID,
             "--qos-version",
             "test-qos",
             "--pivot-image-url",
@@ -888,8 +903,9 @@ mod tests {
         .unwrap()
         .args;
 
-        let template = flag_only_template();
-        let mut resolved = flag_only_template();
+        let app_id = FILE_APP_ID.parse().unwrap();
+        let template = flag_only_template(app_id);
+        let mut resolved = flag_only_template(app_id);
         apply_overrides(&mut resolved, &args.overrides);
 
         // Each override moved off its template default ...
@@ -914,7 +930,7 @@ mod tests {
         );
 
         // ... to the value passed on the CLI.
-        assert_eq!(resolved.app_id, "test-app");
+        assert_eq!(resolved.app_id, FLAG_APP_ID.parse::<Uuid>().unwrap());
         assert_eq!(resolved.qos_version, "test-qos");
         assert_eq!(resolved.pivot_container_image_url, "test-image");
         assert_eq!(resolved.expected_pivot_digest, "sha256:test");
@@ -934,7 +950,7 @@ mod tests {
 
     #[test]
     fn non_interactive_overrides_can_complete_placeholder_file_without_prompting_to_save() {
-        let mut cfg = DeployConfig::template(None);
+        let mut cfg = DeployConfig::template(FLAG_APP_ID.parse().unwrap());
         cfg.pivot_container_encrypted_pull_secret = None;
         let file = write_config(&cfg);
         let args = Args {
@@ -943,7 +959,7 @@ mod tests {
         };
 
         let resolved = run_resolve(&args).unwrap();
-        assert_eq!(resolved.app_id, FLAG_APP_ID);
+        assert_eq!(resolved.app_id.to_string(), FLAG_APP_ID);
         assert_eq!(resolved.qos_version, "flag-qos");
         assert_eq!(resolved.pivot_container_image_url, "flag-image");
         assert_eq!(resolved.pivot_path, "flag-path");

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -18,6 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::try_join;
 use tracing::instrument;
 use turnkey_client::generated::{CreateTvcDeploymentIntent, ValidateTvcImageRequest};
+use uuid::Uuid;
 
 pub(crate) const LONG_ABOUT: &str = r#"
 Create a new TVC deployment.
@@ -350,7 +351,7 @@ fn offer_to_save_config(
 }
 
 fn build_validate_image_request(
-    organization_id: &str,
+    organization_id: Uuid,
     image_url: &str,
     pivot_container_encrypted_pull_secret: Option<String>,
 ) -> ValidateTvcImageRequest {
@@ -417,7 +418,7 @@ async fn run_with_resolved_inputs(
     };
 
     let validate_image_request = build_validate_image_request(
-        &auth.org_id,
+        auth.org_id,
         &deploy_config.pivot_container_image_url,
         pivot_container_encrypted_pull_secret.clone(),
     );
@@ -453,7 +454,7 @@ async fn run_with_resolved_inputs(
 
     let result = auth
         .client
-        .create_tvc_deployment(auth.org_id, timestamp_ms, intent)
+        .create_tvc_deployment(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to create TVC deployment")?;
 

--- a/tvc/src/commands/deploy/debug_logs.rs
+++ b/tvc/src/commands/deploy/debug_logs.rs
@@ -131,7 +131,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
     let auth = crate::client::build_client(&config).await?;
 
     let request = DebugLogQueryRequest {
-        organization_id: auth.org_id,
+        organization_id: auth.org_id.to_string(),
         deployment_id: args.deploy_id.to_string(),
         poll: args.poll,
         poll_interval_seconds: args.poll_interval_seconds,

--- a/tvc/src/commands/deploy/delete.rs
+++ b/tvc/src/commands/deploy/delete.rs
@@ -38,7 +38,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcom
 
     let result = auth
         .client
-        .delete_tvc_deployment(auth.org_id, timestamp_ms, intent)
+        .delete_tvc_deployment(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to delete TVC deployment")?;
 

--- a/tvc/src/commands/deploy/get_status.rs
+++ b/tvc/src/commands/deploy/get_status.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Resul
     // are resolved INSIDE the `build-client`. Instead, all the necessary data for the client
     // should be resolved, then passed into an infallible constructor
     let auth = crate::client::build_client(&config).await?;
-    let org_id = auth.org_id.clone();
+    let org_id = auth.org_id.to_string();
 
     let deployment = fetch_tvc_deployment(&auth, org_id.clone(), deployment_id.clone()).await?;
 

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -91,7 +91,7 @@ async fn execute(ctx: &mut StdCtx, args: Args, config: &turnkey::Config) -> Resu
             // TL;DR split fetching the data/resources separately
             // from building the client
             let auth = build_client(config).await?;
-            let org_id = auth.org_id.clone();
+            let org_id = auth.org_id.to_string();
             let deployment = fetch_tvc_deployment(&auth, org_id, deploy_id).await?;
             DeployConfig::try_from(deployment)?
         }

--- a/tvc/src/commands/deploy/init.rs
+++ b/tvc/src/commands/deploy/init.rs
@@ -10,11 +10,12 @@ use crate::{
 };
 use anyhow::{Context, Result, bail};
 use chrono::Local;
-use clap::Args as ClapArgs;
+use clap::{ArgGroup, Args as ClapArgs};
 use serde::Serialize;
 use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use tracing::instrument;
+use uuid::Uuid;
 
 pub(crate) const LONG_ABOUT: &str = r#"
 Generate a deployment config file to edit, then pass to `tvc deploy create`.
@@ -26,11 +27,23 @@ placeholder template is written."#;
 
 /// Generate a template deployment configuration file.
 #[derive(Debug, ClapArgs)]
-#[command(about, long_about = None)]
+#[command(
+    about,
+    long_about = None,
+    group(
+        ArgGroup::new("app_id_source")
+            .args(["app_id", "from_deployment"])
+            .multiple(false)
+    )
+)]
 pub struct Args {
     /// Output file path.
     #[arg(short, long, value_name = "PATH", env = "TVC_DEPLOY_CONFIG_OUT")]
     pub output: Option<PathBuf>,
+
+    /// App ID to prefill in the deployment config template.
+    #[arg(long, value_name = "APP_ID", env = "TVC_APP_ID")]
+    pub app_id: Option<Uuid>,
 
     /// Seed the config from an existing deployment instead of a blank template.
     ///
@@ -39,7 +52,7 @@ pub struct Args {
     /// is tied to the container image, so recompute it if you change the image. A
     /// pull secret, if the source used one, must be re-supplied.
     #[arg(long, value_name = "DEPLOY_ID", env = "TVC_FROM_DEPLOYMENT")]
-    pub from_deployment: Option<String>,
+    pub from_deployment: Option<Uuid>,
 
     /// Walk through prompts for each field and write a filled config instead
     /// of a placeholder template.
@@ -63,6 +76,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: turnkey::Config) -> Resul
 async fn execute(ctx: &mut StdCtx, args: Args, config: &turnkey::Config) -> Result<Outcome> {
     let Args {
         output,
+        app_id,
         from_deployment,
         interactive: is_interactive,
     } = args;
@@ -80,30 +94,30 @@ async fn execute(ctx: &mut StdCtx, args: Args, config: &turnkey::Config) -> Resu
 
     let is_from_deployment = from_deployment.is_some();
 
-    // The last created app ID prefills the blank template and the interactive
-    // prompt defaults.
-    let saved_app_id = config.get_last_app_id();
+    // The last created app ID prefills a blank template when neither ID flag
+    // was given.
+    let id = from_deployment
+        .or(app_id)
+        .or_else(|| config.get_last_app_id())
+        .unwrap_or_default();
 
     // Seed the config either from an existing deployment or a blank template.
-    let mut deploy_config = match from_deployment {
-        Some(deploy_id) => {
-            // TODO (TVC-154):
-            // TL;DR split fetching the data/resources separately
-            // from building the client
-            let auth = build_client(config).await?;
-            let org_id = auth.org_id.to_string();
-            let deployment = fetch_tvc_deployment(&auth, org_id, deploy_id).await?;
-            DeployConfig::try_from(deployment)?
-        }
-        None => DeployConfig::template(saved_app_id.as_deref()),
+    let mut deploy_config = if is_from_deployment {
+        // TODO (TVC-154):
+        // TL;DR split fetching the data/resources separately
+        // from building the client
+        let auth = build_client(config).await?;
+        let org_id = auth.org_id.to_string();
+        let deployment = fetch_tvc_deployment(&auth, org_id, id.to_string()).await?;
+        DeployConfig::try_from(deployment)?
+    } else {
+        DeployConfig::template(id)
     };
 
     // Optionally walk prompts to fill any remaining placeholders (e.g. the
     // expected pivot digest that `--from-deployment` deliberately leaves blank).
-    // In `--from-deployment` mode the app ID is already set, so the saved-app-id
-    // default is only consulted for a blank template.
     if is_interactive {
-        deploy_config.fill_interactively(ctx, saved_app_id.as_deref())?;
+        deploy_config.fill_interactively(ctx)?;
     }
 
     let needs_pull_secret = deploy_config.pull_secret_is_placeholder();

--- a/tvc/src/commands/deploy/post_share.rs
+++ b/tvc/src/commands/deploy/post_share.rs
@@ -47,7 +47,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Resul
 
     let result = auth
         .client
-        .post_tvc_quorum_key_share(auth.org_id, timestamp_ms, intent)
+        .post_tvc_quorum_key_share(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to post quorum key share")?;
 

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -247,11 +247,10 @@ mod tests {
         };
 
         Config {
-            active_org: Some("active".to_string()),
+            active_org: Some(Uuid::from_u128(0xA1)),
             orgs: IndexMap::from([(
-                "active".to_string(),
+                Uuid::from_u128(0xA1),
                 OrgConfig {
-                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Hosted,

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -182,9 +182,10 @@ mod tests {
     use crate::config::turnkey::{
         HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
     };
+    use indexmap::IndexMap;
     use qos_core::protocol::services::boot::VersionedManifestEnvelope;
     use serde::Deserialize;
-    use std::{collections::HashMap, path::PathBuf};
+    use std::path::PathBuf;
 
     const DEPLOYMENT_ID: &str = "33333333-3333-4333-8333-333333333333";
     const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
@@ -247,10 +248,10 @@ mod tests {
 
         Config {
             active_org: Some("active".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "active".to_string(),
                 OrgConfig {
-                    id: "org-id".to_string(),
+                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Hosted,

--- a/tvc/src/commands/deploy/provision.rs
+++ b/tvc/src/commands/deploy/provision.rs
@@ -78,11 +78,11 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome
 
     let operator = config.resolve_hosted_operator(&operator_id)?;
     let auth = build_client(&config).await?;
-    ensure_authenticated_org(&auth.org_id, operator.organization_id())?;
+    ensure_authenticated_org(auth.org_id, operator.organization_id())?;
 
     let details = fetch_provisioning_details(&auth, &deploy_id).await?;
     let deployment =
-        fetch_tvc_deployment(&auth, auth.org_id.clone(), deploy_id.to_string()).await?;
+        fetch_tvc_deployment(&auth, auth.org_id.to_string(), deploy_id.to_string()).await?;
     let TvcManifest {
         id: _,
         manifest: deployment_manifest,
@@ -104,7 +104,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome
     )?;
     let result = auth
         .client
-        .re_encrypt_tvc_quorum_key_share(auth.org_id, timestamp_ms()?, intent)
+        .re_encrypt_tvc_quorum_key_share(auth.org_id.to_string(), timestamp_ms()?, intent)
         .await
         .map_err(|error| hosted_activity_error("re-encrypt hosted TVC quorum-key share", error))?;
     let output = validate_result(result.result)?;

--- a/tvc/src/commands/deploy/restore.rs
+++ b/tvc/src/commands/deploy/restore.rs
@@ -39,7 +39,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Resul
 
     let result = auth
         .client
-        .restore_tvc_deployment(auth.org_id, timestamp_ms, intent)
+        .restore_tvc_deployment(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .context("failed to restore TVC deployment")?;
 

--- a/tvc/src/commands/deploy/status.rs
+++ b/tvc/src/commands/deploy/status.rs
@@ -37,7 +37,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> anyhow::Result
     let deploy_id = args.deploy_id.to_string();
 
     let request = GetTvcDeploymentRequest {
-        organization_id: auth.org_id.clone(),
+        organization_id: auth.org_id.to_string(),
         deployment_id: deploy_id.clone(),
     };
 

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -4,7 +4,7 @@
 use crate::{
     commands::{Run, login::resolve_org_query},
     config::turnkey::{
-        Config, QosOperatorPublicKey, SelectLocalOperatorError, StoredQosOperatorKey,
+        Config, OrgQuery, QosOperatorPublicKey, SelectLocalOperatorError, StoredQosOperatorKey,
     },
     outcome::Outcome,
     output::StdCtx,
@@ -16,6 +16,7 @@ use serde::Serialize;
 use std::{
     fmt::{self, Display, Formatter},
     path::PathBuf,
+    str::FromStr,
 };
 
 /// Back up a local operator key by copying its key file to a chosen
@@ -25,8 +26,8 @@ use std::{
 pub struct Args {
     /// Organization alias or ID whose operator key to back up.
     /// Defaults to the active organization.
-    #[arg(long, env = "TVC_ORG", value_name = "ORG")]
-    org: Option<String>,
+    #[arg(long, env = "TVC_ORG", value_name = "ORG", value_parser = OrgQuery::from_str)]
+    org: Option<OrgQuery>,
     /// Destination file for the backup copy.
     #[arg(short, long, value_name = "PATH", env = "TVC_OPERATOR_KEY_BACKUP_OUT")]
     output: Option<PathBuf>,
@@ -48,21 +49,16 @@ impl Run for Args {
             return Err(error_required_in_non_interactive("--output"));
         }
 
-        let (alias, org_config) = match &self.org {
-            Some(query) => {
-                let alias = resolve_org_query(ctx, &config, query)?;
-                let org_config = config
-                    .orgs
-                    .get(&alias)
-                    .expect("alias was resolved against this config");
-
-                (alias, org_config)
-            }
-            None => config
-                .active_org_config()
-                .map(|(alias, org_config)| (alias.clone(), org_config))
-                .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?,
-        };
+        let (alias, org_config) = self
+            .org
+            .as_ref()
+            .map(|query| resolve_org_query(ctx, &config, query))
+            .unwrap_or_else(|| {
+                config
+                    .active_org_config()
+                    .map(|(alias, org_config)| (alias.as_str(), org_config))
+                    .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))
+            })?;
 
         let (_, local) = org_config
             .select_local_operator()
@@ -112,7 +108,7 @@ impl Run for Args {
             }
             // No --output: the shared interactive flow. Declining the
             // overwrite cancels the command - backing up is all it does.
-            None => prompt_for_backup_destination(&alias)?
+            None => prompt_for_backup_destination(alias)?
                 .ok_or_else(|| anyhow!("operation cancelled by user: backup"))?,
         };
 

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -49,14 +49,13 @@ impl Run for Args {
             return Err(error_required_in_non_interactive("--output"));
         }
 
-        let (alias, org_config) = self
+        let (resolved, org_config) = self
             .org
             .as_ref()
-            .map(|query| resolve_org_query(ctx, &config, query))
+            .map(|query| resolve_org_query(&config, query))
             .unwrap_or_else(|| {
                 config
-                    .active_org_config()
-                    .map(|(alias, org_config)| (alias.as_str(), org_config))
+                    .resolve_active()
                     .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))
             })?;
 
@@ -68,13 +67,13 @@ impl Run for Args {
                 // missing-operator error.
                 SelectLocalOperatorError::NoLocalOperator => {
                     anyhow::Error::new(error).context(format!(
-                        "org '{alias}' has no local operator key file to back up; hosted \
+                        "org '{resolved}' has no local operator key file to back up; hosted \
                          operators' private keys are held by Turnkey, and YubiKey operators' \
                          private keys never leave the device — neither can be exported"
                     ))
                 }
                 SelectLocalOperatorError::MultipleLocalOperators => {
-                    anyhow::Error::new(error).context(format!("org '{alias}'"))
+                    anyhow::Error::new(error).context(format!("org '{resolved}'"))
                 }
             })?;
         let source = &local.key_path;
@@ -108,11 +107,11 @@ impl Run for Args {
             }
             // No --output: the shared interactive flow. Declining the
             // overwrite cancels the command - backing up is all it does.
-            None => prompt_for_backup_destination(alias)?
+            None => prompt_for_backup_destination(&resolved.to_string())?
                 .ok_or_else(|| anyhow!("operation cancelled by user: backup"))?,
         };
 
-        back_up(alias.to_string(), source.clone(), destination).await
+        back_up(resolved.to_string(), source.clone(), destination).await
     }
 }
 

--- a/tvc/src/commands/keys/backup_operator_key.rs
+++ b/tvc/src/commands/keys/backup_operator_key.rs
@@ -2,7 +2,7 @@
 //! user-chosen destination.
 
 use crate::{
-    commands::{Run, login::find_org},
+    commands::{Run, login::resolve_org_query},
     config::turnkey::{
         Config, QosOperatorPublicKey, SelectLocalOperatorError, StoredQosOperatorKey,
     },
@@ -49,14 +49,18 @@ impl Run for Args {
         }
 
         let (alias, org_config) = match &self.org {
-            Some(query) => find_org(&config, query).ok_or_else(|| {
-                anyhow!(
-                    "Login profile '{query}' not found. \
-                     Run `tvc login` to see configured profiles."
-                )
-            })?,
+            Some(query) => {
+                let alias = resolve_org_query(ctx, &config, query)?;
+                let org_config = config
+                    .orgs
+                    .get(&alias)
+                    .expect("alias was resolved against this config");
+
+                (alias, org_config)
+            }
             None => config
                 .active_org_config()
+                .map(|(alias, org_config)| (alias.clone(), org_config))
                 .ok_or_else(|| anyhow!("No active organization. Run `tvc login` first."))?,
         };
 
@@ -108,7 +112,7 @@ impl Run for Args {
             }
             // No --output: the shared interactive flow. Declining the
             // overwrite cancels the command - backing up is all it does.
-            None => prompt_for_backup_destination(alias)?
+            None => prompt_for_backup_destination(&alias)?
                 .ok_or_else(|| anyhow!("operation cancelled by user: backup"))?,
         };
 

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -127,7 +127,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcom
     let expected_share_count = intent.operator_encrypt_keys.len();
     let auth = build_client(&config).await?;
     if let Some(configured_org_id) = configured_org_id {
-        ensure_authenticated_org(&auth.org_id, &configured_org_id)?;
+        ensure_authenticated_org(auth.org_id, configured_org_id)?;
     }
     let timestamp_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -136,7 +136,7 @@ pub async fn run(_ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcom
 
     let result = auth
         .client
-        .create_tvc_quorum_key(auth.org_id, timestamp_ms, intent)
+        .create_tvc_quorum_key(auth.org_id.to_string(), timestamp_ms, intent)
         .await
         .map_err(|error| hosted_activity_error("create hosted TVC quorum key", error))?;
     let output = validate_result(result.result, expected_share_count)?;
@@ -151,7 +151,7 @@ fn parse_operator_id(value: &str) -> std::result::Result<Uuid, String> {
 fn resolve_operator_encrypt_keys(
     config: &Config,
     operator_source: OperatorSource,
-) -> Result<(Vec<OperatorPublicKey>, Option<String>)> {
+) -> Result<(Vec<OperatorPublicKey>, Option<Uuid>)> {
     match operator_source {
         OperatorSource::EncryptKeys(keys) => Ok((keys, None)),
         OperatorSource::OperatorIds(operator_ids) => {
@@ -164,7 +164,7 @@ fn resolve_operator_encrypt_keys(
 fn resolve_operator_ids(
     config: &Config,
     operator_ids: &[Uuid],
-) -> Result<(Vec<OperatorPublicKey>, Option<String>)> {
+) -> Result<(Vec<OperatorPublicKey>, Option<Uuid>)> {
     let (_, org) = config
         .active_org_config()
         .context("No active organization. Run `tvc login` first.")?;
@@ -178,7 +178,7 @@ fn resolve_operator_ids(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok((keys, Some(org.id.to_string())))
+    Ok((keys, Some(org.id)))
 }
 
 fn validate_operator_ids(operator_ids: &[Uuid]) -> Result<()> {

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -165,7 +165,7 @@ fn resolve_operator_ids(
     config: &Config,
     operator_ids: &[Uuid],
 ) -> Result<(Vec<OperatorPublicKey>, Option<Uuid>)> {
-    let (_, org) = config
+    let (configured_org_id, _) = config
         .active_org_config()
         .context("No active organization. Run `tvc login` first.")?;
 
@@ -178,7 +178,7 @@ fn resolve_operator_ids(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok((keys, Some(org.id)))
+    Ok((keys, Some(configured_org_id)))
 }
 
 fn validate_operator_ids(operator_ids: &[Uuid]) -> Result<()> {
@@ -307,11 +307,10 @@ mod tests {
 
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
         Config {
-            active_org: Some("active".to_string()),
+            active_org: Some(Uuid::from_u128(0xA1)),
             orgs: IndexMap::from([(
-                "active".to_string(),
+                Uuid::from_u128(0xA1),
                 OrgConfig {
-                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,

--- a/tvc/src/commands/keys/create_quorum_key.rs
+++ b/tvc/src/commands/keys/create_quorum_key.rs
@@ -178,7 +178,7 @@ fn resolve_operator_ids(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok((keys, Some(org.id.clone())))
+    Ok((keys, Some(org.id.to_string())))
 }
 
 fn validate_operator_ids(operator_ids: &[Uuid]) -> Result<()> {
@@ -265,9 +265,10 @@ mod tests {
     use crate::config::turnkey::{
         HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
     };
+    use indexmap::IndexMap;
     use qos_p256::P256Pair;
     use serde_json::Value;
-    use std::{collections::HashMap, path::PathBuf};
+    use std::path::PathBuf;
 
     const FIRST_OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
     const SECOND_OPERATOR_ID: &str = "22222222-2222-4222-8222-222222222222";
@@ -307,10 +308,10 @@ mod tests {
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
         Config {
             active_org: Some("active".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "active".to_string(),
                 OrgConfig {
-                    id: "org-id".to_string(),
+                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -69,6 +69,9 @@ enum OrgPlan {
     /// interactively, with the name to echo in output (aliases only appear
     /// in output when the user used one).
     Existing { id: Uuid, name: Option<String> },
+    /// A confirmed new name for an organization that is already configured;
+    /// login binds it and proceeds against the existing entry.
+    BindAlias { id: Uuid, alias: String },
     New {
         id: Uuid,
         alias: String,
@@ -488,7 +491,7 @@ fn build_login_plan_interactive(
     };
 
     let yubikey_serial = match &org {
-        OrgPlan::Existing { id, .. } => config
+        OrgPlan::Existing { id, .. } | OrgPlan::BindAlias { id, .. } => config
             .orgs
             .get(id)
             .filter(|org| org.default_operator_kind == OperatorKind::Yubikey)
@@ -587,6 +590,17 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                 plan.api_base_url_override.as_deref(),
             );
             (id, name, None)
+        }
+        OrgPlan::BindAlias { id, alias } => {
+            // The endpoint confirmed the binding (and any re-point); the save
+            // below persists it.
+            config.aliases.bind(alias.clone(), id);
+            update_api_base_url_from_override(
+                &mut config,
+                id,
+                plan.api_base_url_override.as_deref(),
+            );
+            (id, Some(alias), None)
         }
         OrgPlan::New {
             id,
@@ -828,28 +842,27 @@ fn prompt_for_new_org_inputs(
         .parse()
         .context("Organization ID must be a UUID")?;
 
-    // One entry per organization: the registry is keyed by ID, so a second
-    // login for the same organization is a reconfiguration, not an addition.
+    // The registry is keyed by ID, so a second login for the same
+    // organization binds another name to the existing entry — after an
+    // explicit confirmation — instead of reconfiguring it.
     if config.orgs.contains_key(&id) {
         let known = config.display_name(id);
-        bail!(
-            "Organization '{id}' is already configured as '{known}'. \
-             Run `tvc login --org {known}` to use it, \
-             or `tvc profile delete --org {known}` to remove it first."
-        );
+        shell_eprintln!(
+            ctx,
+            "Organization '{id}' is already configured as '{known}'."
+        )?;
+        prompts::confirm_or_bail(
+            &format!("Bind another alias to '{known}' and log in to it?"),
+            "alias binding",
+        )?;
+
+        let alias = prompt_for_alias_binding(ctx, config, id)?;
+
+        return Ok(OrgPlan::BindAlias { id, alias });
     }
 
-    let alias = prompts::text("Organization alias", Some("default"))?;
+    let alias = prompt_for_alias_binding(ctx, config, id)?;
     debug!(org_alias = %alias, "user entered new organization inputs");
-
-    if let Some(existing) = config.aliases.resolve(&alias) {
-        bail!(
-            "Alias '{alias}' already names organization '{}'. \
-             Choose a different alias, \
-             or run `tvc profile delete --org {alias}` to remove it first.",
-            existing.id()
-        );
-    }
 
     let operator = {
         enum OperatorKeyChoice {
@@ -905,6 +918,39 @@ fn prompt_for_new_org_inputs(
         alias,
         operator,
     })
+}
+
+/// Prompt for an alias to bind to `org_id`, enforcing the binding policy:
+/// UUID-shaped names are refused outright — org queries parse UUID-shaped
+/// input as an organization ID, so such a name could never be looked up —
+/// and re-pointing a name away from another organization requires an
+/// explicit confirmation.
+fn prompt_for_alias_binding(ctx: &mut StdCtx, config: &Config, org_id: Uuid) -> Result<String> {
+    let alias = prompts::text("Organization alias", Some("default"))?;
+
+    if Uuid::parse_str(&alias).is_ok() {
+        bail!(
+            "Alias '{alias}' is UUID-shaped, so it would always resolve as an \
+             organization ID instead of a name. Choose a non-UUID alias."
+        );
+    }
+
+    if let Some(existing) = config.aliases.resolve(&alias) {
+        // Already naming this organization is a no-op, not a re-point.
+        if existing.id() != org_id {
+            shell_eprintln!(
+                ctx,
+                "Alias '{alias}' currently names organization '{}'.",
+                existing.id()
+            )?;
+            prompts::confirm_or_bail(
+                &format!("Re-point alias '{alias}' to organization '{org_id}'?"),
+                "alias re-pointing",
+            )?;
+        }
+    }
+
+    Ok(alias)
 }
 
 enum OrgChoice {

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -59,6 +59,9 @@ pub struct DeleteArgs {
 }
 
 enum OrgPlan {
+    /// A resolved alias of a configured profile. The plan builders validate
+    /// the user's query (alias or organization ID) before constructing this,
+    /// so it is never a raw query.
     Existing(String),
     New {
         id: String,
@@ -103,7 +106,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome
     );
 
     let plan = if ctx.is_non_interactive() {
-        build_login_plan_non_interactive(args)?
+        build_login_plan_non_interactive(args, &config)?
     } else {
         build_login_plan_interactive(ctx, args, &config)?
     };
@@ -135,7 +138,7 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         }
     }
 
-    let alias = resolve_profile_alias(&config, args.org)?;
+    let alias = resolve_profile_alias(&config, args.org, is_non_interactive)?;
     let org_id = config
         .orgs
         .get(&alias)
@@ -296,17 +299,36 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
 }
 
 /// Resolve the alias of a configured profile to delete. Prompts interactively
-/// with a picker when no query is given; a query that matches nothing is handled
-/// by `find_org` returning `None`.
-fn resolve_profile_alias(config: &Config, org: Option<String>) -> Result<String> {
+/// with a picker when no query is given, or when an org-ID query matches
+/// several profiles; non-interactive runs must name a single profile.
+fn resolve_profile_alias(
+    config: &Config,
+    org: Option<String>,
+    is_non_interactive: bool,
+) -> Result<String> {
     match org {
-        Some(query) => match find_org(config, &query) {
-            Some((alias, _)) => Ok(alias.clone()),
-            None => bail!(
-                "Login profile '{query}' not found. \
-                 Run `tvc login` to see configured profiles."
-            ),
-        },
+        Some(query) => {
+            let aliases = find_org_aliases(config, &query);
+
+            match aliases.as_slice() {
+                [] => bail!(
+                    "Login profile '{query}' not found. \
+                     Run `tvc login` to see configured profiles."
+                ),
+                [alias] => Ok(alias.clone()),
+                _ if is_non_interactive => bail!(
+                    "Organization '{query}' is configured under multiple profiles: {}. \
+                     Re-run with --org <alias> to select which profile to delete.",
+                    aliases.join(", ")
+                ),
+                _ => Ok(prompts::select(
+                    "Select profile to delete",
+                    duplicate_alias_choices(config, &aliases),
+                )?
+                .alias
+                .to_string()),
+            }
+        }
         None => {
             // Reached only in interactive mode; a non-interactive run without
             // --org is rejected up front in `run_delete` before we get here.
@@ -342,6 +364,27 @@ impl Display for ProfileChoice<'_> {
     }
 }
 
+/// Selection choices for aliases that share one organization ID, marking the
+/// active profile the way the no-query delete picker does.
+fn duplicate_alias_choices<'a>(
+    config: &'a Config,
+    aliases: &'a [String],
+) -> Vec<ProfileChoice<'a>> {
+    aliases
+        .iter()
+        .map(|alias| ProfileChoice {
+            alias: alias.as_str(),
+            org_id: config
+                .orgs
+                .get(alias)
+                .expect("alias was resolved from this config")
+                .id
+                .as_str(),
+            is_active: config.active_org.as_deref() == Some(alias.as_str()),
+        })
+        .collect()
+}
+
 fn build_login_plan_interactive(
     ctx: &mut StdCtx,
     args: Args,
@@ -353,14 +396,34 @@ fn build_login_plan_interactive(
         serial,
     } = args;
     let org = match org {
-        Some(query) => OrgPlan::Existing(query),
+        Some(query) => {
+            let aliases = find_org_aliases(config, &query);
+
+            let alias = match aliases.as_slice() {
+                [] => bail!(
+                    "Organization '{query}' not found. \
+                     Run `tvc login` without --org to set up a new organization."
+                ),
+                [alias] => alias.clone(),
+                _ => prompts::select(
+                    &format!("Select profile for organization '{query}'"),
+                    duplicate_alias_choices(config, &aliases),
+                )?
+                .alias
+                .to_string(),
+            };
+
+            OrgPlan::Existing(alias)
+        }
         None => prompt_for_org_plan(ctx, config, api_base_url.as_deref(), serial)?,
     };
 
     let yubikey_serial = match &org {
-        OrgPlan::Existing(query) => find_org(config, query)
-            .filter(|(_, org)| org.default_operator_kind == OperatorKind::Yubikey)
-            .map(|(_, org)| -> Result<YubiKeySerial> {
+        OrgPlan::Existing(alias) => config
+            .orgs
+            .get(alias)
+            .filter(|org| org.default_operator_kind == OperatorKind::Yubikey)
+            .map(|org| -> Result<YubiKeySerial> {
                 if let Some(serial) = serial {
                     return Ok(org.select_yubikey_operator(Some(serial))?.1.serial);
                 }
@@ -400,13 +463,28 @@ fn build_login_plan_interactive(
     })
 }
 
-fn build_login_plan_non_interactive(args: Args) -> Result<LoginPlan> {
+fn build_login_plan_non_interactive(args: Args, config: &Config) -> Result<LoginPlan> {
     let Some(org_query) = args.org else {
         return Err(error_required_in_non_interactive("--org"));
     };
 
+    let aliases = find_org_aliases(config, &org_query);
+
+    let alias = match aliases.as_slice() {
+        [] => bail!(
+            "Organization '{org_query}' not found. \
+             Run `tvc login` without --org to set up a new organization."
+        ),
+        [alias] => alias.clone(),
+        _ => bail!(
+            "Organization '{org_query}' is configured under multiple profiles: {}. \
+             Re-run with --org <alias> to select one.",
+            aliases.join(", ")
+        ),
+    };
+
     Ok(LoginPlan {
-        org: OrgPlan::Existing(org_query),
+        org: OrgPlan::Existing(alias),
         api_base_url_override: args.api_base_url,
         api_key_policy: ApiKeyPolicy::RequireExisting,
         yubikey_serial: args.serial,
@@ -415,20 +493,18 @@ fn build_login_plan_non_interactive(args: Args) -> Result<LoginPlan> {
 
 async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<Outcome> {
     let (alias, org_config, yubikey) = match plan.org {
-        OrgPlan::Existing(query) => {
-            let alias = match find_org(&config, &query) {
-                Some((alias, _)) => alias.clone(),
-                None => bail!(
-                    "Organization '{query}' not found. \
-                     Run `tvc login` without --org to set up a new organization."
-                ),
-            };
+        OrgPlan::Existing(alias) => {
             update_api_base_url_from_override(
                 &mut config,
                 &alias,
                 plan.api_base_url_override.as_deref(),
             );
-            let org_config = config.orgs.get(&alias).unwrap().clone();
+
+            let org_config = config
+                .orgs
+                .get(&alias)
+                .cloned()
+                .expect("plan alias was resolved against this config");
             (alias, org_config, None)
         }
         OrgPlan::New {
@@ -742,6 +818,25 @@ pub(crate) fn find_org<'a>(config: &'a Config, org: &str) -> Option<(&'a String,
     }
 
     None
+}
+
+/// Every configured alias matching an org query, for callers to dispose of
+/// per their mode. An exact alias match is unambiguous and wins outright;
+/// otherwise all aliases registered for the query as an organization ID are
+/// returned, sorted for stable output.
+fn find_org_aliases(config: &Config, query: &str) -> Vec<String> {
+    if config.orgs.contains_key(query) {
+        return vec![query.to_string()];
+    }
+
+    let mut aliases = config
+        .orgs
+        .iter()
+        .filter(|(_, org)| org.id == query)
+        .map(|(alias, _)| alias.clone())
+        .collect::<Vec<_>>();
+    aliases.sort();
+    aliases
 }
 
 fn generate_org(
@@ -1307,6 +1402,55 @@ mod tests {
         update_api_base_url_from_override(&mut config, "default", Some(OVERRIDE_URL));
 
         assert_eq!(config.orgs["default"].api_base_url, OVERRIDE_URL);
+    }
+
+    #[test]
+    fn find_org_aliases_prefers_exact_alias_match() {
+        // The alias "org-x" collides with another profile's organization ID;
+        // the exact alias match must win outright.
+        let config = config_with_orgs(&[("org-x", "org-y"), ("a", "org-x")]);
+
+        assert_eq!(find_org_aliases(&config, "org-x"), ["org-x"]);
+    }
+
+    #[test]
+    fn find_org_aliases_returns_all_id_matches_sorted() {
+        let config = config_with_orgs(&[("c", "org-1"), ("a", "org-1"), ("b", "org-1")]);
+
+        assert_eq!(find_org_aliases(&config, "org-1"), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn find_org_aliases_returns_empty_for_unknown_query() {
+        let config = config_with_orgs(&[("a", "org-1")]);
+
+        assert!(find_org_aliases(&config, "org-unknown").is_empty());
+    }
+
+    fn config_with_orgs(entries: &[(&str, &str)]) -> Config {
+        Config {
+            active_org: None,
+            orgs: entries
+                .iter()
+                .map(|(alias, org_id)| {
+                    (
+                        alias.to_string(),
+                        OrgConfig {
+                            id: org_id.to_string(),
+                            api_key_path: PathBuf::from("api_key.json"),
+                            api_base_url: API_BASE_URL_PROD.to_string(),
+                            default_operator_kind: OperatorKind::Local,
+                            operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
+                            extra: toml::Table::new(),
+                        },
+                    )
+                })
+                .collect(),
+            yubikeys: Default::default(),
+            last_created_app_id: HashMap::new(),
+            last_operator_ids: HashMap::new(),
+            extra: toml::Table::new(),
+        }
     }
 
     fn config_with_org(api_base_url: &str) -> Config {

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -131,10 +131,13 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
     execute_login(ctx, config, plan).await
 }
 
-/// Move legacy alias-keyed key directories to the id-keyed layout and rewrite
-/// each organization's paths, saving after every organization so a crash
-/// strands at most one. A rename failure warns and skips: the legacy paths
-/// remain valid, and login must not die over a tidiness move.
+/// Migrate legacy alias-keyed key directories to the id-keyed layout: copy
+/// the files across (verifying every copy), rewrite the organization's
+/// paths, save, and only then delete the old directory. Every crash window
+/// therefore leaves the config pointing at files that exist — the legacy
+/// originals before the save, the verified copies after it. A failure warns
+/// and skips the organization: its legacy paths remain valid, and login must
+/// not die over a tidiness move.
 async fn migrate_legacy_key_directories(
     ctx: &mut StdCtx,
     config: &mut Config,
@@ -144,21 +147,88 @@ async fn migrate_legacy_key_directories(
         let source = legacy_org_dir(&alias)?;
         let target = default_org_dir(org_id)?;
 
-        match tokio::fs::rename(&source, &target).await {
-            Ok(()) => {}
-            // A crash between a previous run's rename and its save leaves the
-            // files already moved; treat the move as done and just rewrite.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound && target.is_dir() => {}
-            Err(error) => {
-                shell_eprintln!(
-                    ctx,
-                    "WARNING: could not move key directory {} -> {}: {error}. \
-                     The organization keeps its current paths.",
-                    source.display(),
+        let copied = async {
+            // A missing source with a populated target is an interrupted
+            // run's post-copy window (or an old rename-based move); there is
+            // nothing left to copy.
+            if !source.is_dir() {
+                ensure!(
+                    target.is_dir(),
+                    "the legacy directory is missing and nothing was copied to {}",
                     target.display()
-                )?;
-                continue;
+                );
+                return Ok(());
             }
+
+            // Only resume our own interrupted copy: every file already at
+            // the target must be an identical copy of a legacy file —
+            // anything else means the directory belongs to someone else.
+            if target.is_dir() {
+                let mut entries = tokio::fs::read_dir(&target).await?;
+
+                while let Some(entry) = entries.next_entry().await? {
+                    let name = entry.file_name();
+                    let source_file = source.join(&name);
+                    let matches = entry.file_type().await?.is_file()
+                        && tokio::fs::try_exists(&source_file).await?
+                        && tokio::fs::read(entry.path()).await?
+                            == tokio::fs::read(&source_file).await?;
+
+                    ensure!(
+                        matches,
+                        "{} already contains {}",
+                        target.display(),
+                        name.display()
+                    );
+                }
+            }
+
+            let mut names = Vec::new();
+            let mut entries = tokio::fs::read_dir(&source).await?;
+
+            while let Some(entry) = entries.next_entry().await? {
+                ensure!(
+                    entry.file_type().await?.is_file(),
+                    "{} is not a regular file",
+                    entry.path().display()
+                );
+                names.push(entry.file_name());
+            }
+
+            tokio::fs::create_dir_all(&target).await?;
+
+            for name in names {
+                let bytes = tokio::fs::read(source.join(&name)).await?;
+                let to = target.join(&name);
+
+                // Present files passed the identical-copy scan above.
+                if tokio::fs::try_exists(&to).await? {
+                    continue;
+                }
+
+                tokio::fs::write(&to, &bytes).await?;
+
+                // Verify the copy before the config ever points at it.
+                ensure!(
+                    tokio::fs::read(&to).await? == bytes,
+                    "verification failed for {}",
+                    to.display()
+                );
+            }
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = copied {
+            shell_eprintln!(
+                ctx,
+                "WARNING: could not move key directory {} -> {}: {error:#}. \
+                 The organization keeps its current paths.",
+                source.display(),
+                target.display()
+            )?;
+            continue;
         }
 
         if let Some(org) = config.orgs.get_mut(&org_id) {
@@ -180,6 +250,20 @@ async fn migrate_legacy_key_directories(
             source.display(),
             target.display()
         )?;
+
+        // The copies are saved and verified; the originals are redundant now.
+        match tokio::fs::remove_dir_all(&source).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                shell_eprintln!(
+                    ctx,
+                    "WARNING: could not remove the old key directory {}: {error}. \
+                     Remove it manually; the config no longer references it.",
+                    source.display()
+                )?;
+            }
+        }
     }
 
     Ok(())

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     config::turnkey::{
         API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
-        OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
+        OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey, Resolved,
         SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
         YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
         default_org_dir, legacy_org_dir,
@@ -65,10 +65,10 @@ pub struct DeleteArgs {
 }
 
 enum OrgPlan {
-    /// A resolved alias of a configured profile. The plan builders validate
-    /// the user's query (alias or organization ID) before constructing this,
-    /// so it is never a raw query.
-    Existing(String),
+    /// A configured organization resolved from the user's query or picked
+    /// interactively, with the name to echo in output (aliases only appear
+    /// in output when the user used one).
+    Existing { id: Uuid, name: Option<String> },
     New {
         id: Uuid,
         alias: String,
@@ -112,18 +112,10 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
     );
 
     let plan = if ctx.is_non_interactive() {
-        build_login_plan_non_interactive(ctx, args, &config)?
+        build_login_plan_non_interactive(args, &config)?
     } else {
-        // Consolidate before resolving the org query, so the builders never
-        // resolve against profiles that are about to be deleted.
-        let duplicates = config.duplicated_org_ids();
-
-        if !duplicates.is_empty() {
-            consolidate_duplicate_profiles(ctx, &mut config, duplicates).await?;
-        }
-
-        // Runs after consolidation: one profile per organization means the
-        // id-keyed target directories cannot collide.
+        // Move legacy alias-keyed key directories to the id-keyed layout
+        // before anything resolves paths against the config.
         let legacy_profiles = config.legacy_layout_profiles()?;
 
         if !legacy_profiles.is_empty() {
@@ -136,90 +128,9 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
     execute_login(ctx, config, plan).await
 }
 
-/// Fold duplicate profiles down to one per organization before login
-/// proceeds: prompt for the profile to keep per duplicated organization,
-/// confirm once, then delete the others with full profile-delete cleanup.
-/// Nothing is mutated before the confirmation, so declining leaves the config
-/// and disk untouched.
-async fn consolidate_duplicate_profiles(
-    ctx: &mut StdCtx,
-    config: &mut Config,
-    duplicates: Vec<(Uuid, Vec<String>)>,
-) -> Result<()> {
-    shell_eprintln!(
-        ctx,
-        "Multiple profiles are configured for the same organization. `{}` keeps \
-         one profile per organization, so the extra profiles must be deleted \
-         before login can continue.",
-        env!("CARGO_PKG_NAME")
-    )?;
-    shell_eprintln!(ctx, "")?;
-
-    let keepers = duplicates
-        .iter()
-        .map(|(org_id, _)| {
-            prompts::select(
-                &format!("Select the profile to keep for organization '{org_id}'"),
-                profile_choices(config, &config.matching_profiles(&OrgQuery::Id(*org_id))),
-            )
-            .map(|choice| choice.alias.to_string())
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let losers = duplicates
-        .iter()
-        .zip(&keepers)
-        .flat_map(|((_, aliases), keeper)| aliases.iter().filter(move |alias| *alias != keeper))
-        .cloned()
-        .collect::<Vec<_>>();
-
-    let listed = losers
-        .iter()
-        .map(|alias| format!("'{alias}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    shell_eprintln!(ctx, "")?;
-    shell_eprintln!(
-        ctx,
-        "This deletes the local config entries and key files for {listed}. It \
-         does NOT touch the Turnkey dashboard; revocation instructions follow \
-         each deletion."
-    )?;
-    prompts::confirm_or_bail(
-        &format!("Permanently delete {listed} and the key files on disk?"),
-        "profile consolidation",
-    )?;
-
-    // Repair the active profile onto its group's keeper before deleting, so
-    // every save below persists a config whose active_org still exists.
-    let active_keeper = duplicates
-        .iter()
-        .zip(&keepers)
-        .find_map(|((_, aliases), keeper)| {
-            config
-                .active_org
-                .as_ref()
-                .filter(|active| aliases.contains(active) && *active != keeper)
-                .map(|_| keeper.clone())
-        });
-
-    if let Some(keeper) = active_keeper {
-        config.set_active_org(&keeper)?;
-    }
-
-    for alias in losers {
-        let deleted = delete_profile(ctx, config, alias).await?;
-        shell_println!(ctx, "{deleted}")?;
-        shell_println!(ctx)?;
-    }
-
-    Ok(())
-}
-
 /// Move legacy alias-keyed key directories to the id-keyed layout and rewrite
-/// each profile's paths, saving after every profile so a crash strands at
-/// most one. A rename failure warns and skips that profile: its legacy paths
+/// each organization's paths, saving after every organization so a crash
+/// strands at most one. A rename failure warns and skips: the legacy paths
 /// remain valid, and login must not die over a tidiness move.
 async fn migrate_legacy_key_directories(
     ctx: &mut StdCtx,
@@ -239,7 +150,7 @@ async fn migrate_legacy_key_directories(
                 shell_eprintln!(
                     ctx,
                     "WARNING: could not move key directory {} -> {}: {error}. \
-                     The profile keeps its current paths.",
+                     The organization keeps its current paths.",
                     source.display(),
                     target.display()
                 )?;
@@ -247,7 +158,7 @@ async fn migrate_legacy_key_directories(
             }
         }
 
-        if let Some(org) = config.orgs.get_mut(&alias) {
+        if let Some(org) = config.orgs.get_mut(&org_id) {
             let operator_key_path = default_operator_key_path(org_id)?;
             org.api_key_path = default_api_key_path(org_id)?;
             org.operators
@@ -271,10 +182,10 @@ async fn migrate_legacy_key_directories(
     Ok(())
 }
 
-/// Permanently delete a saved login profile: its config entry and its API and
-/// any local operator key files on disk. YubiKey operator references vanish
-/// with the profile, but the devices and their shared registry entries are
-/// never touched.
+/// Permanently delete a saved organization login: its config entry, every
+/// alias bound to it, and its API and any local operator key files on disk.
+/// YubiKey operator references vanish with the login, but the devices and
+/// their shared registry entries are never touched.
 pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) -> Result<Outcome> {
     let is_non_interactive = ctx.is_non_interactive();
     debug!(
@@ -285,7 +196,7 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
     );
 
     // Validate inputs before any business logic: non-interactive mode cannot
-    // prompt, so it requires --org (which profile) and --yes (confirmation).
+    // prompt, so it requires --org (which organization) and --yes (confirmation).
     if is_non_interactive {
         if args.org.is_none() {
             return Err(error_required_in_non_interactive("--org"));
@@ -295,13 +206,34 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         }
     }
 
-    let (alias, org_id, dashboard_url) = {
-        let (alias, org) = resolve_profile_alias(&config, args.org, is_non_interactive)?;
-        (
-            alias.to_string(),
-            org.id,
-            dashboard_base_url(&org.api_base_url),
-        )
+    let (org_id, org_display, dashboard_url) = match args.org {
+        Some(query) => {
+            let (resolved, org) = resolve_org_query(&config, &query)?;
+            (
+                resolved.id(),
+                resolved.to_string(),
+                dashboard_base_url(&org.api_base_url),
+            )
+        }
+        None => {
+            // Reached only in interactive mode; a non-interactive run without
+            // --org is rejected up front before we get here.
+            if config.orgs.is_empty() {
+                bail!("No organization logins to delete.");
+            }
+
+            let row = prompts::select("Select organization to delete", org_rows(&config))?;
+            let dashboard_url = config
+                .orgs
+                .get(&row.id)
+                .map(|org| dashboard_base_url(&org.api_base_url))
+                .unwrap_or(dashboard_base_url(API_BASE_URL_PROD));
+            (
+                row.id,
+                row.name.unwrap_or_else(|| row.id.to_string()),
+                dashboard_url,
+            )
+        }
     };
 
     // Interactive confirmation. A non-interactive run without --yes was rejected
@@ -310,11 +242,11 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         shell_eprintln!(ctx, "")?;
         shell_eprintln!(
             ctx,
-            "WARNING: This permanently deletes login profile '{alias}' ({org_id})."
+            "WARNING: This permanently deletes the login for organization '{org_display}' ({org_id})."
         )?;
         shell_eprintln!(
             ctx,
-            "  - Removes the local config entry and deletes the API and any local"
+            "  - Removes the config entry, its aliases, and deletes the API and any local"
         )?;
         shell_eprintln!(
             ctx,
@@ -332,13 +264,13 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
 
         let references_yubikeys = config
             .orgs
-            .get(&alias)
+            .get(&org_id)
             .is_some_and(|org| org.yubikey_operators().next().is_some());
 
         if references_yubikeys {
             shell_eprintln!(
                 ctx,
-                "  - YubiKey operator references are removed from this profile only: the"
+                "  - YubiKey operator references are removed from this login only: the"
             )?;
             shell_eprintln!(
                 ctx,
@@ -346,7 +278,7 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
             )?;
             shell_eprintln!(
                 ctx,
-                "    (other profiles may share them). After removing every profile reference,"
+                "    (other organizations may share them). After removing every reference,"
             )?;
             shell_eprintln!(
                 ctx,
@@ -360,29 +292,38 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
 
         shell_eprintln!(ctx, "")?;
         prompts::confirm_or_bail(
-            &format!("Permanently delete profile '{alias}' ({org_id}) and its key files?"),
+            &format!("Permanently delete '{org_display}' ({org_id}) and its key files?"),
             "deletion",
         )?;
     }
 
-    let deleted = delete_profile(ctx, &mut config, alias).await?;
+    let deleted = delete_org_login(ctx, &mut config, org_id).await?;
 
     Ok(Outcome::ProfileDeleted(deleted))
 }
 
-/// Permanently delete profile `alias`: remove it from the config registry,
-/// delete its key files when they use the default per-org directory layout
-/// (custom key paths are left on disk with a warning), then save the config.
-/// The save comes last so that dying between the file cleanup and the save
-/// leaves the profile listed and the deletion retryable; the file deletion
-/// tolerates an already-missing directory for exactly that retry.
-async fn delete_profile(
+/// Permanently delete the login for `org_id`: remove it from the config
+/// (with every alias bound to it), delete its key files when they use a
+/// default per-org directory layout (custom key paths are left on disk with
+/// a warning), then save the config. The save comes last so that dying
+/// between the file cleanup and the save leaves the login listed and the
+/// deletion retryable; the file deletion tolerates an already-missing
+/// directory for exactly that retry.
+async fn delete_org_login(
     ctx: &mut StdCtx,
     config: &mut Config,
-    alias: String,
+    org_id: Uuid,
 ) -> Result<ProfileDeleted> {
-    let Some(removed) = config.remove_org(&alias) else {
-        bail!("Login profile '{alias}' not found.");
+    // Legacy directory candidates are named by the aliases, so collect them
+    // before the removal unbinds the names.
+    let legacy_dirs = config
+        .aliases
+        .names_of(org_id)
+        .map(legacy_org_dir)
+        .collect::<Result<Vec<_>>>()?;
+
+    let Some((removed, unbound_aliases)) = config.remove_org(org_id) else {
+        bail!("Organization '{org_id}' is not configured.");
     };
 
     // Read the API key's public key before deleting its file, so the
@@ -395,17 +336,17 @@ async fn delete_profile(
         .map(|key| key.public_key);
 
     // The default layout stores both key files in one per-org directory —
-    // id-keyed today, alias-keyed for profiles created before TVC-55 — so a
-    // default profile is removed by deleting that directory. Custom
-    // (hand-edited) key paths are left untouched with a warning, since the
-    // user placed them deliberately and they may live outside our config tree.
-    let owned_dir = [default_org_dir(removed.id)?, legacy_org_dir(&alias)?]
-        .into_iter()
+    // id-keyed today, alias-keyed before TVC-55 — so a default-layout login
+    // is removed by deleting that directory. Custom (hand-edited) key paths
+    // are left untouched with a warning, since the user placed them
+    // deliberately and they may live outside our config tree.
+    let owned_dir = std::iter::once(default_org_dir(org_id)?)
+        .chain(legacy_dirs)
         .find(|dir| removed.has_default_layout_at(dir));
 
     let removed_dir = match owned_dir {
         Some(dir) => {
-            // A hand-edited config can point several profiles into one
+            // A hand-edited config can point several organizations into one
             // directory; deleting it would take the survivors' keys with it.
             let still_used = config.orgs.values().any(|org| {
                 org.api_key_path.starts_with(&dir)
@@ -418,7 +359,7 @@ async fn delete_profile(
             if still_used {
                 shell_eprintln!(
                     ctx,
-                    "WARNING: key directory {} is still used by another profile and was NOT deleted.",
+                    "WARNING: key directory {} is still used by another organization and was NOT deleted.",
                     dir.display()
                 )?;
                 None
@@ -476,8 +417,8 @@ async fn delete_profile(
         .collect::<Vec<_>>();
 
     Ok(ProfileDeleted {
-        alias,
-        organization_id: removed.id,
+        aliases: unbound_aliases,
+        organization_id: org_id,
         removed_key_directory: removed_dir.map(|dir| dir.display().to_string()),
         retained_yubikey_serials,
         dashboard_url: dashboard_base_url(&removed.api_base_url).to_string(),
@@ -485,90 +426,42 @@ async fn delete_profile(
     })
 }
 
-/// Resolve the profile to delete. Prompts interactively with a picker when no
-/// query is given, or when an org-ID query matches several profiles;
-/// non-interactive runs must name a single profile.
-fn resolve_profile_alias(
-    config: &Config,
-    org: Option<OrgQuery>,
-    is_non_interactive: bool,
-) -> Result<(&str, &OrgConfig)> {
-    match org {
-        Some(query) => {
-            let profiles = config.matching_profiles(&query);
-
-            match profiles.as_slice() {
-                [] => bail!(
-                    "Login profile '{query}' not found. \
-                     Run `tvc login` to see configured profiles."
-                ),
-                [profile] => Ok(*profile),
-                _ if is_non_interactive => bail!(
-                    "Organization '{query}' is configured under multiple profiles: {}. \
-                     Re-run with --org <alias> to select which profile to delete.",
-                    profiles
-                        .iter()
-                        .map(|(alias, _)| *alias)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
-                _ => {
-                    let choice = prompts::select(
-                        "Select profile to delete",
-                        profile_choices(config, &profiles),
-                    )?;
-                    Ok((choice.alias, choice.org))
-                }
-            }
-        }
-        None => {
-            // Reached only in interactive mode; a non-interactive run without
-            // --org is rejected up front in `run_delete` before we get here.
-            if config.orgs.is_empty() {
-                bail!("No login profiles to delete.");
-            }
-
-            let all = config
-                .orgs
-                .iter()
-                .map(|(alias, org)| (alias.as_str(), org))
-                .collect::<Vec<_>>();
-            let choice =
-                prompts::select("Select profile to delete", profile_choices(config, &all))?;
-            Ok((choice.alias, choice.org))
-        }
-    }
+/// One picker row for an organization: its aliases (or bare ID) plus the
+/// active marker. `name` carries the first alias for output echoing.
+struct OrgRow {
+    id: Uuid,
+    name: Option<String>,
+    display: String,
 }
 
-struct ProfileChoice<'a> {
-    alias: &'a str,
-    org: &'a OrgConfig,
-    is_active: bool,
-}
-
-impl Display for ProfileChoice<'_> {
+impl Display for OrgRow {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({})", self.alias, self.org.id)?;
-
-        if self.is_active {
-            write!(f, " (active)")?;
-        }
-
-        Ok(())
+        self.display.fmt(f)
     }
 }
 
-/// Picker choices for the given profiles, marking the active one.
-fn profile_choices<'a>(
-    config: &Config,
-    profiles: &[(&'a str, &'a OrgConfig)],
-) -> Vec<ProfileChoice<'a>> {
-    profiles
-        .iter()
-        .map(|(alias, org)| ProfileChoice {
-            alias,
-            org,
-            is_active: config.active_org.as_deref() == Some(*alias),
+fn org_rows(config: &Config) -> Vec<OrgRow> {
+    config
+        .orgs
+        .keys()
+        .map(|id| {
+            let names = config.aliases.names_of(*id).collect::<Vec<_>>();
+            let active = if config.active_org == Some(*id) {
+                " (active)"
+            } else {
+                ""
+            };
+            let display = if names.is_empty() {
+                format!("{id}{active}")
+            } else {
+                format!("{} ({id}){active}", names.join(", "))
+            };
+
+            OrgRow {
+                id: *id,
+                name: names.first().map(|name| name.to_string()),
+                display,
+            }
         })
         .collect()
 }
@@ -585,16 +478,19 @@ fn build_login_plan_interactive(
     } = args;
     let org = match org {
         Some(query) => {
-            let (alias, _) = resolve_org_query(ctx, config, &query)?;
-            OrgPlan::Existing(alias.to_string())
+            let (resolved, _) = resolve_org_query(config, &query)?;
+            OrgPlan::Existing {
+                id: resolved.id(),
+                name: resolved.name().map(str::to_string),
+            }
         }
         None => prompt_for_org_plan(ctx, config, api_base_url.as_deref(), serial)?,
     };
 
     let yubikey_serial = match &org {
-        OrgPlan::Existing(alias) => config
+        OrgPlan::Existing { id, .. } => config
             .orgs
-            .get(alias)
+            .get(id)
             .filter(|org| org.default_operator_kind == OperatorKind::Yubikey)
             .map(|org| -> Result<YubiKeySerial> {
                 if let Some(serial) = serial {
@@ -636,19 +532,18 @@ fn build_login_plan_interactive(
     })
 }
 
-fn build_login_plan_non_interactive(
-    ctx: &mut StdCtx,
-    args: Args,
-    config: &Config,
-) -> Result<LoginPlan> {
+fn build_login_plan_non_interactive(args: Args, config: &Config) -> Result<LoginPlan> {
     let Some(query) = args.org else {
         return Err(error_required_in_non_interactive("--org"));
     };
 
-    let (alias, _) = resolve_org_query(ctx, config, &query)?;
+    let (resolved, _) = resolve_org_query(config, &query)?;
 
     Ok(LoginPlan {
-        org: OrgPlan::Existing(alias.to_string()),
+        org: OrgPlan::Existing {
+            id: resolved.id(),
+            name: resolved.name().map(str::to_string),
+        },
         api_base_url_override: args.api_base_url,
         api_key_policy: ApiKeyPolicy::RequireExisting,
         yubikey_serial: args.serial,
@@ -665,63 +560,33 @@ enum ResolveError {
          Run `tvc login` without --org to set up a new organization."
     )]
     NotFound { query: OrgQuery },
-    #[error(
-        "Organization '{query}' is configured under multiple profiles: {listed}. \
-         Re-run with --org <alias> to select one."
-    )]
-    MultipleProfiles { query: OrgQuery, listed: String },
 }
 
-/// Resolve an org query (profile alias or organization ID) to a single
-/// configured profile.
-///
-/// An explicitly named alias is an unambiguous choice and wins outright. An
-/// org-ID query matching several profiles prompts for one interactively;
-/// non-interactively it fails with instructions. Read-only consumers (login,
-/// key backup) share these rules; destructive commands resolve via
-/// `resolve_profile_alias` instead, which never guesses among duplicates.
+/// Resolve an org query (alias or organization ID) to a configured
+/// organization. A query names at most one organization by construction, so
+/// resolution never prompts and never guesses; every org-selecting command
+/// shares it.
 pub(crate) fn resolve_org_query<'c>(
-    ctx: &mut StdCtx,
     config: &'c Config,
     query: &OrgQuery,
-) -> Result<(&'c str, &'c OrgConfig)> {
-    let matches = config.matching_profiles(query);
-
-    match matches.as_slice() {
-        [] => bail!(ResolveError::NotFound {
-            query: query.clone()
-        }),
-        [profile] => Ok(*profile),
-        _ if ctx.is_non_interactive() => bail!(ResolveError::MultipleProfiles {
+) -> Result<(Resolved<'c>, &'c OrgConfig)> {
+    config.resolve(query).ok_or_else(|| {
+        ResolveError::NotFound {
             query: query.clone(),
-            listed: matches
-                .iter()
-                .map(|(alias, _)| *alias)
-                .collect::<Vec<_>>()
-                .join(", "),
-        }),
-        // Unreachable from login while it consolidates duplicates up front;
-        // kept so --org-by-ID resolution stays deterministic for read-only
-        // consumers that do not consolidate.
-        _ => {
-            let choice = prompts::select(
-                &format!("Select profile for organization '{query}'"),
-                profile_choices(config, &matches),
-            )?;
-            Ok((choice.alias, choice.org))
         }
-    }
+        .into()
+    })
 }
 
 async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<Outcome> {
-    let (alias, yubikey) = match plan.org {
-        OrgPlan::Existing(alias) => {
+    let (org_id, org_name, yubikey) = match plan.org {
+        OrgPlan::Existing { id, name } => {
             update_api_base_url_from_override(
                 &mut config,
-                &alias,
+                id,
                 plan.api_base_url_override.as_deref(),
             );
-            (alias, None)
+            (id, name, None)
         }
         OrgPlan::New {
             id,
@@ -750,28 +615,35 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                 }
             };
 
-            debug!(org_alias = %alias, "adding organization");
+            debug!(org_id = %id, org_alias = %alias, "adding organization");
             config.add_org(
-                &alias,
                 id,
                 new_org_api_base_url(plan.api_base_url_override.as_deref()),
                 operator,
             )?;
-            (alias, yubikey)
+            config.aliases.bind(alias.clone(), id);
+            (id, Some(alias), yubikey)
         }
     };
 
-    config.set_active_org(&alias)?;
+    config.set_active_org(org_id)?;
 
     config.save().await?;
 
-    // All mutation is done, so the rest of the flow can borrow the profile;
+    // All mutation is done, so the rest of the flow can borrow the entry;
     // the plan was resolved against (or inserted into) this same config.
-    let Some(org_config) = config.orgs.get(&alias) else {
-        bail!("login profile '{alias}' disappeared from the config");
+    let Some(org_config) = config.orgs.get(&org_id) else {
+        bail!("organization '{org_id}' disappeared from the config");
     };
 
-    shell_println!(ctx, "Selected org: {} ({})", alias, org_config.id)?;
+    // Echo the reference the user gave us: their alias when they used one,
+    // the bare ID otherwise.
+    match &org_name {
+        Some(name) => shell_println!(ctx, "Selected org: {name} ({org_id})")?,
+        None => shell_println!(ctx, "Selected org: {org_id}")?,
+    }
+
+    let org_display = org_name.clone().unwrap_or_else(|| org_id.to_string());
 
     if let Some(yubikey) = &yubikey {
         shell_println!(ctx)?;
@@ -800,9 +672,8 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                 api_key
             }
             ApiKeyPolicy::RequireExisting => bail!(
-                "API key is required in non-interactive mode for org '{}'. \
-                 Run `tvc login` interactively to generate and register one first.",
-                org_config.id
+                "API key is required in non-interactive mode for org '{org_display}'. \
+                 Run `tvc login` interactively to generate and register one first."
             ),
         },
     };
@@ -810,7 +681,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     shell_println!(ctx)?;
     shell_println!(ctx, "Verifying credentials...")?;
 
-    let whoami = verify_credentials(&api_key, org_config.id, &org_config.api_base_url).await?;
+    let whoami = verify_credentials(&api_key, org_id, &org_config.api_base_url).await?;
 
     // Login ensures the org's default backend is usable, and never crosses
     // over: a local default finds or generates the registered key file; a
@@ -821,8 +692,8 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         OperatorKind::Local => {
             let (_, local) = org_config
                 .select_local_operator()
-                .with_context(|| format!("org '{alias}'"))?;
-            let operator_key = find_or_generate_operator_key(ctx, &alias, local).await?;
+                .with_context(|| format!("org '{org_display}'"))?;
+            let operator_key = find_or_generate_operator_key(ctx, &org_display, local).await?;
 
             LoggedInOperator::Local {
                 operator_public_key: operator_key.public_key,
@@ -832,7 +703,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         OperatorKind::Hosted => {
             let (name, hosted) = org_config
                 .select_hosted_operator()
-                .with_context(|| format!("org '{alias}'"))?;
+                .with_context(|| format!("org '{org_display}'"))?;
             shell_println!(
                 ctx,
                 "Using hosted operator '{}' ({}).",
@@ -857,9 +728,9 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                 {
                     return Err(anyhow::Error::new(error)
                         .context(MissingRequiredInput::new("--serial"))
-                        .context(format!("org '{alias}'")));
+                        .context(format!("org '{org_display}'")));
                 }
-                selected => selected.with_context(|| format!("org '{alias}'"))?,
+                selected => selected.with_context(|| format!("org '{org_display}'"))?,
             };
             let entry = config.yubikeys.get(yubikey.serial).ok_or_else(|| {
                 anyhow!(
@@ -890,7 +761,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         organization_id: whoami.organization_id,
         username: whoami.username,
         user_id: whoami.user_id,
-        alias,
+        alias: org_name,
         api_public_key: api_key.public_key.clone(),
         config_file_path: crate::config::turnkey::config_file_path()?
             .display()
@@ -918,25 +789,17 @@ fn prompt_for_org_plan(
         return prompt_for_new_org_inputs(ctx, config, api_base_url_override, serial);
     }
 
-    let mut options: Vec<OrgChoice> = config
-        .orgs
-        .iter()
-        .map(|(alias, org)| {
-            let suffix = if config.active_org.as_ref() == Some(alias) {
-                " (active)"
-            } else {
-                ""
-            };
-            OrgChoice::Existing {
-                display: format!("{alias} ({}){suffix}", org.id),
-                alias: alias.clone(),
-            }
-        })
-        .collect();
+    let mut options = org_rows(config)
+        .into_iter()
+        .map(OrgChoice::Existing)
+        .collect::<Vec<_>>();
     options.push(OrgChoice::New);
 
     match prompts::select("Select organization", options)? {
-        OrgChoice::Existing { alias, .. } => Ok(OrgPlan::Existing(alias)),
+        OrgChoice::Existing(row) => Ok(OrgPlan::Existing {
+            id: row.id,
+            name: row.name,
+        }),
         OrgChoice::New => prompt_for_new_org_inputs(ctx, config, api_base_url_override, serial),
     }
 }
@@ -965,26 +828,26 @@ fn prompt_for_new_org_inputs(
         .parse()
         .context("Organization ID must be a UUID")?;
 
-    // One profile per organization: a second alias for the same ID would make
-    // resolution ambiguous again (TVC-159). Consolidation already folded any
-    // legacy duplicates before this prompt, so at most one profile matches.
-    if let Some((alias, _)) = config.matching_profiles(&OrgQuery::Id(id)).first() {
+    // One entry per organization: the registry is keyed by ID, so a second
+    // login for the same organization is a reconfiguration, not an addition.
+    if config.orgs.contains_key(&id) {
+        let known = config.display_name(id);
         bail!(
-            "Organization '{id}' is already configured as profile '{alias}'. \
-             Run `tvc login --org {alias}` to use it, \
-             or `tvc profile delete --org {alias}` to remove it first."
+            "Organization '{id}' is already configured as '{known}'. \
+             Run `tvc login --org {known}` to use it, \
+             or `tvc profile delete --org {known}` to remove it first."
         );
     }
 
     let alias = prompts::text("Organization alias", Some("default"))?;
     debug!(org_alias = %alias, "user entered new organization inputs");
 
-    if let Some(existing) = config.orgs.get(&alias) {
+    if let Some(existing) = config.aliases.resolve(&alias) {
         bail!(
-            "Profile alias '{alias}' is already in use for organization '{}'. \
+            "Alias '{alias}' already names organization '{}'. \
              Choose a different alias, \
              or run `tvc profile delete --org {alias}` to remove it first.",
-            existing.id
+            existing.id()
         );
     }
 
@@ -1045,14 +908,14 @@ fn prompt_for_new_org_inputs(
 }
 
 enum OrgChoice {
-    Existing { display: String, alias: String },
+    Existing(OrgRow),
     New,
 }
 
 impl Display for OrgChoice {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            OrgChoice::Existing { display, .. } => write!(f, "{display}"),
+            OrgChoice::Existing(row) => row.fmt(f),
             OrgChoice::New => write!(f, "[new] Add a new organization"),
         }
     }
@@ -1066,12 +929,12 @@ fn new_org_api_base_url(api_base_url_override: Option<&str>) -> String {
 
 fn update_api_base_url_from_override(
     config: &mut Config,
-    alias: &str,
+    org_id: Uuid,
     api_base_url_override: Option<&str>,
 ) {
     if let Some(api_base_url) = api_base_url_override {
-        debug!(org_alias = alias, %api_base_url, "updating organization API base URL from override");
-        if let Some(org_config) = config.orgs.get_mut(alias) {
+        debug!(%org_id, %api_base_url, "updating organization API base URL from override");
+        if let Some(org_config) = config.orgs.get_mut(&org_id) {
             org_config.api_base_url = api_base_url.to_string();
         }
     }
@@ -1267,7 +1130,8 @@ pub struct LoggedIn {
     organization_id: String,
     username: String,
     user_id: String,
-    alias: String,
+    /// The alias the user logged in with, when they used one.
+    alias: Option<String>,
     api_public_key: String,
     config_file_path: String,
     api_key_path: String,
@@ -1315,7 +1179,7 @@ impl Default for LoggedInOperator {
 #[derive(Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileDeleted {
-    alias: String,
+    aliases: Vec<String>,
     organization_id: Uuid,
     removed_key_directory: Option<String>,
     /// Serials of the YubiKey operators the profile referenced. The devices
@@ -1328,9 +1192,14 @@ pub struct ProfileDeleted {
 
 impl Display for ProfileDeleted {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let names = if self.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(" ('{}')", self.aliases.join("', '"))
+        };
         let mut lines = vec![format!(
-            "Deleted login profile '{}' ({}).",
-            self.alias, self.organization_id
+            "Deleted the login for organization {}{names}.",
+            self.organization_id
         )];
 
         if let Some(directory) = &self.removed_key_directory {
@@ -1366,7 +1235,7 @@ impl Display for ProfileDeleted {
                 lines.push("  2. Delete the API key with public key:".to_string());
                 lines.push(format!("       {public_key}"));
             }
-            None => lines.push("  2. Delete the API key associated with this profile".to_string()),
+            None => lines.push("  2. Delete the API key associated with this login".to_string()),
         }
 
         f.write_str(&lines.join("\n"))
@@ -1390,7 +1259,7 @@ Credentials
             self.organization_id,
             self.username,
             self.user_id,
-            self.alias,
+            self.alias.as_deref().unwrap_or(&self.organization_id),
             self.api_public_key,
         )?;
 
@@ -1450,8 +1319,6 @@ mod tests {
         API_BASE_URL_DEV, API_BASE_URL_PREPROD, DASHBOARD_URL_DEV, DASHBOARD_URL_PREPROD,
         DASHBOARD_URL_PROD, OperatorKind, OperatorRecord,
     };
-    use indexmap::IndexMap;
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     const OVERRIDE_URL: &str = "http://127.0.0.1:8081";
@@ -1462,7 +1329,7 @@ mod tests {
             organization_id: "org-1".to_string(),
             username: "user".to_string(),
             user_id: "user-1".to_string(),
-            alias: "prod".to_string(),
+            alias: Some("prod".to_string()),
             api_public_key: "api-key".to_string(),
             config_file_path: "/config/tvc.config.toml".to_string(),
             api_key_path: "/keys/api_key.json".to_string(),
@@ -1590,10 +1457,10 @@ mod tests {
     fn absent_override_preserves_existing_org_api_base_url() {
         let mut config = config_with_org("http://existing.example");
 
-        update_api_base_url_from_override(&mut config, "default", None);
+        update_api_base_url_from_override(&mut config, Uuid::from_u128(1), None);
 
         assert_eq!(
-            config.orgs["default"].api_base_url,
+            config.orgs[&Uuid::from_u128(1)].api_base_url,
             "http://existing.example"
         );
     }
@@ -1602,29 +1469,27 @@ mod tests {
     fn explicit_override_updates_existing_org_api_base_url() {
         let mut config = config_with_org(API_BASE_URL_PROD);
 
-        update_api_base_url_from_override(&mut config, "default", Some(OVERRIDE_URL));
+        update_api_base_url_from_override(&mut config, Uuid::from_u128(1), Some(OVERRIDE_URL));
 
-        assert_eq!(config.orgs["default"].api_base_url, OVERRIDE_URL);
+        assert_eq!(config.orgs[&Uuid::from_u128(1)].api_base_url, OVERRIDE_URL);
     }
 
     fn config_with_org(api_base_url: &str) -> Config {
-        Config {
-            active_org: Some("default".to_string()),
-            orgs: IndexMap::from([(
-                "default".to_string(),
-                OrgConfig {
-                    id: Uuid::from_u128(1),
-                    api_key_path: PathBuf::from("api_key.json"),
-                    api_base_url: api_base_url.to_string(),
-                    default_operator_kind: OperatorKind::Local,
-                    operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
-                    extra: toml::Table::new(),
-                },
-            )]),
-            yubikeys: Default::default(),
-            last_created_app_id: HashMap::new(),
-            last_operator_ids: HashMap::new(),
-            extra: toml::Table::new(),
-        }
+        let mut config = Config::default();
+        config.orgs.insert(
+            Uuid::from_u128(1),
+            OrgConfig {
+                api_key_path: PathBuf::from("api_key.json"),
+                api_base_url: api_base_url.to_string(),
+                default_operator_kind: OperatorKind::Local,
+                operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
+                extra: toml::Table::new(),
+            },
+        );
+        config
+            .aliases
+            .bind("default".to_string(), Uuid::from_u128(1));
+        config.set_active_org(Uuid::from_u128(1)).unwrap();
+        config
     }
 }

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -1,28 +1,32 @@
 //! Login command for authenticating with Turnkey.
 
-use crate::client::build_turnkey_client;
-use crate::commands::keys::backup_operator_key::{
-    OperatorKeyBackedUp, back_up, prompt_for_backup_destination,
+use crate::{
+    client::build_turnkey_client,
+    commands::keys::backup_operator_key::{
+        OperatorKeyBackedUp, back_up, prompt_for_backup_destination,
+    },
+    config::turnkey::{
+        API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
+        OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
+        SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
+        YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
+        default_org_dir, legacy_org_dir,
+    },
+    outcome::Outcome,
+    output::{MissingRequiredInput, StdCtx},
+    prompts::{self, error_required_in_non_interactive},
+    shell_eprintln, shell_print, shell_println,
 };
-use crate::config::turnkey::{
-    API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
-    OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
-    SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
-    YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
-    default_org_dir, legacy_org_dir,
-};
-use crate::outcome::Outcome;
-use crate::output::{MissingRequiredInput, StdCtx};
-use crate::prompts::{self, error_required_in_non_interactive};
-use crate::{shell_eprintln, shell_print, shell_println};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use clap::Args as ClapArgs;
 use qos_p256::P256Pair;
 use serde::Serialize;
-use std::collections::BTreeSet;
-use std::fmt::{self, Display, Formatter};
-use std::io::BufRead;
-use std::str::FromStr;
+use std::{
+    collections::BTreeSet,
+    fmt::{self, Display, Formatter},
+    io::BufRead,
+    str::FromStr,
+};
 use thiserror::Error;
 use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -733,8 +733,34 @@ fn prompt_for_new_org_inputs(
         bail!("Organization ID is required");
     }
 
+    // One profile per organization: a second alias for the same ID would make
+    // resolution ambiguous again (TVC-159).
+    let already_configured = config
+        .orgs
+        .iter()
+        .filter(|(_, org)| org.id == id)
+        .map(|(alias, _)| alias)
+        .min();
+
+    if let Some(alias) = already_configured {
+        bail!(
+            "Organization '{id}' is already configured as profile '{alias}'. \
+             Run `tvc login --org {alias}` to use it, \
+             or `tvc profile delete --org {alias}` to remove it first."
+        );
+    }
+
     let alias = prompts::text("Organization alias", Some("default"))?;
     debug!(org_alias = %alias, "user entered new organization inputs");
+
+    if let Some(existing) = config.orgs.get(&alias) {
+        bail!(
+            "Profile alias '{alias}' is already in use for organization '{}'. \
+             Choose a different alias, \
+             or run `tvc profile delete --org {alias}` to remove it first.",
+            existing.id
+        );
+    }
 
     let operator = {
         enum OperatorKeyChoice {

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -97,7 +97,7 @@ struct LoginPlan {
 }
 
 #[instrument(skip_all)]
-pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome> {
+pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Outcome> {
     debug!(
         non_interactive = ctx.is_non_interactive(),
         org_arg_present = args.org.is_some(),
@@ -108,10 +108,97 @@ pub async fn run(ctx: &mut StdCtx, args: Args, config: Config) -> Result<Outcome
     let plan = if ctx.is_non_interactive() {
         build_login_plan_non_interactive(args, &config)?
     } else {
+        // Consolidate before resolving the org query, so the builders never
+        // resolve against profiles that are about to be deleted.
+        let duplicates = config.duplicated_org_ids();
+        consolidate_duplicate_profiles(ctx, &mut config, duplicates).await?;
         build_login_plan_interactive(ctx, args, &config)?
     };
 
     execute_login(ctx, config, plan).await
+}
+
+/// Fold duplicate profiles down to one per organization before login
+/// proceeds: prompt for the profile to keep per duplicated organization,
+/// confirm once, then delete the others with full profile-delete cleanup.
+/// Nothing is mutated before the confirmation, so declining leaves the config
+/// and disk untouched.
+async fn consolidate_duplicate_profiles(
+    ctx: &mut StdCtx,
+    config: &mut Config,
+    duplicates: Vec<(String, Vec<String>)>,
+) -> Result<()> {
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+
+    shell_eprintln!(
+        ctx,
+        "Multiple profiles are configured for the same organization. tvc keeps \
+         one profile per organization, so the extra profiles must be deleted \
+         before login can continue."
+    )?;
+    shell_eprintln!(ctx, "")?;
+
+    let mut losers: Vec<String> = Vec::new();
+    let mut active_repair: Option<String> = None;
+
+    for (org_id, aliases) in &duplicates {
+        let keeper = prompts::select(
+            &format!("Select the profile to keep for organization '{org_id}'"),
+            duplicate_alias_choices(config, aliases),
+        )?
+        .alias
+        .to_string();
+
+        if let Some(active) = &config.active_org
+            && aliases.contains(active)
+            && *active != keeper
+        {
+            active_repair = Some(keeper.clone());
+        }
+
+        losers.extend(aliases.iter().filter(|alias| **alias != keeper).cloned());
+    }
+
+    let listed = losers
+        .iter()
+        .map(|alias| format!("'{alias}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let noun = if losers.len() == 1 {
+        "profile"
+    } else {
+        "profiles"
+    };
+
+    shell_eprintln!(ctx, "")?;
+    shell_eprintln!(
+        ctx,
+        "This deletes the local config entries and key files for {listed}. It \
+         does NOT touch the Turnkey dashboard; revocation instructions follow \
+         each deletion."
+    )?;
+    prompts::confirm_or_bail(
+        &format!("Permanently delete {noun} {listed} and the key files on disk?"),
+        "profile consolidation",
+    )?;
+
+    for alias in &losers {
+        let deleted = delete_profile(ctx, config, alias).await?;
+        shell_println!(ctx, "{deleted}")?;
+        shell_println!(ctx)?;
+    }
+
+    // `remove_org` cleared `active_org` if the active profile was among the
+    // losers; its group's keeper inherits it.
+    if let Some(keeper) = active_repair {
+        config.set_active_org(&keeper)?;
+    }
+
+    config.save().await?;
+
+    Ok(())
 }
 
 /// Permanently delete a saved login profile: its config entry and its API and
@@ -211,8 +298,28 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         )?;
     }
 
+    let deleted = delete_profile(ctx, &mut config, &alias).await?;
+
+    // Save last: persist the config removal only after the on-disk cleanup
+    // succeeds, so a failure leaves the profile listed and the delete retryable.
+    config.save().await?;
+
+    Ok(Outcome::ProfileDeleted(deleted))
+}
+
+/// Remove profile `alias` from the config registry and delete its key files
+/// when they use the default per-org directory layout; custom key paths are
+/// left on disk with a warning. Does not save the config: callers batch one
+/// or more removals and persist afterwards, preserving the save-last
+/// invariant that a failed file cleanup leaves the profile listed and the
+/// deletion retryable.
+async fn delete_profile(
+    ctx: &mut StdCtx,
+    config: &mut Config,
+    alias: &str,
+) -> Result<ProfileDeleted> {
     let removed = config
-        .remove_org(&alias)
+        .remove_org(alias)
         .expect("alias was resolved from config");
 
     // Read the API key's public key before deleting its file, so the
@@ -228,8 +335,8 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
     // default profile is removed by deleting that whole directory. Custom
     // (hand-edited) key paths are left untouched with a warning, since the user
     // placed them deliberately and they may live outside our config tree.
-    let default_api_key = default_api_key_path(&alias)?;
-    let default_operator_key = default_operator_key_path(&alias)?;
+    let default_api_key = default_api_key_path(alias)?;
+    let default_operator_key = default_operator_key_path(alias)?;
     let local_key_paths: Vec<_> = removed
         .operators
         .iter()
@@ -244,7 +351,7 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
             .all(|path| *path == &default_operator_key);
 
     let removed_dir = if uses_default_layout {
-        let dir = default_org_dir(&alias)?;
+        let dir = default_org_dir(alias)?;
         match tokio::fs::remove_dir_all(&dir).await {
             Ok(()) => Some(dir),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -276,26 +383,22 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         None
     };
 
-    // Save last: persist the config removal only after the on-disk cleanup above
-    // succeeds, so a failure leaves the profile listed and the delete retryable.
-    config.save().await?;
-
     // A local delete does not touch the dashboard-registered API key, and we
     // can't tell whether it is still there, so hedge with "may" and give steps.
     let dashboard_url = dashboard_base_url(&removed.api_base_url);
-    let retained_yubikey_serials: Vec<YubiKeySerial> = removed
+    let retained_yubikey_serials = removed
         .yubikey_operators()
         .map(|(_, yubikey)| yubikey.serial)
-        .collect();
+        .collect::<Vec<_>>();
 
-    Ok(Outcome::ProfileDeleted(ProfileDeleted {
-        alias,
+    Ok(ProfileDeleted {
+        alias: alias.to_string(),
         organization_id: removed.id,
         removed_key_directory: removed_dir.map(|dir| dir.display().to_string()),
         retained_yubikey_serials,
         dashboard_url: dashboard_url.to_string(),
         api_public_key,
-    }))
+    })
 }
 
 /// Resolve the alias of a configured profile to delete. Prompts interactively
@@ -405,6 +508,9 @@ fn build_login_plan_interactive(
                      Run `tvc login` without --org to set up a new organization."
                 ),
                 [alias] => alias.clone(),
+                // Unreachable while login consolidates duplicates up front;
+                // kept so --org-by-ID resolution stays deterministic if the
+                // consolidation gate ever moves.
                 _ => prompts::select(
                     &format!("Select profile for organization '{query}'"),
                     duplicate_alias_choices(config, &aliases),

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -106,7 +106,7 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
     );
 
     let plan = if ctx.is_non_interactive() {
-        build_login_plan_non_interactive(args, &config)?
+        build_login_plan_non_interactive(ctx, args, &config)?
     } else {
         // Consolidate before resolving the org query, so the builders never
         // resolve against profiles that are about to be deleted.
@@ -499,28 +499,7 @@ fn build_login_plan_interactive(
         serial,
     } = args;
     let org = match org {
-        Some(query) => {
-            let aliases = find_org_aliases(config, &query);
-
-            let alias = match aliases.as_slice() {
-                [] => bail!(
-                    "Organization '{query}' not found. \
-                     Run `tvc login` without --org to set up a new organization."
-                ),
-                [alias] => alias.clone(),
-                // Unreachable while login consolidates duplicates up front;
-                // kept so --org-by-ID resolution stays deterministic if the
-                // consolidation gate ever moves.
-                _ => prompts::select(
-                    &format!("Select profile for organization '{query}'"),
-                    duplicate_alias_choices(config, &aliases),
-                )?
-                .alias
-                .to_string(),
-            };
-
-            OrgPlan::Existing(alias)
-        }
+        Some(query) => OrgPlan::Existing(resolve_org_query(ctx, config, &query)?),
         None => prompt_for_org_plan(ctx, config, api_base_url.as_deref(), serial)?,
     };
 
@@ -569,25 +548,16 @@ fn build_login_plan_interactive(
     })
 }
 
-fn build_login_plan_non_interactive(args: Args, config: &Config) -> Result<LoginPlan> {
+fn build_login_plan_non_interactive(
+    ctx: &mut StdCtx,
+    args: Args,
+    config: &Config,
+) -> Result<LoginPlan> {
     let Some(org_query) = args.org else {
         return Err(error_required_in_non_interactive("--org"));
     };
 
-    let aliases = find_org_aliases(config, &org_query);
-
-    let alias = match aliases.as_slice() {
-        [] => bail!(
-            "Organization '{org_query}' not found. \
-             Run `tvc login` without --org to set up a new organization."
-        ),
-        [alias] => alias.clone(),
-        _ => bail!(
-            "Organization '{org_query}' is configured under multiple profiles: {}. \
-             Re-run with --org <alias> to select one.",
-            aliases.join(", ")
-        ),
-    };
+    let alias = resolve_org_query(ctx, config, &org_query)?;
 
     Ok(LoginPlan {
         org: OrgPlan::Existing(alias),
@@ -595,6 +565,40 @@ fn build_login_plan_non_interactive(args: Args, config: &Config) -> Result<Login
         api_key_policy: ApiKeyPolicy::RequireExisting,
         yubikey_serial: args.serial,
     })
+}
+
+/// Resolve an org query (profile alias or organization ID) to a single
+/// configured profile alias.
+///
+/// An explicitly named alias is an unambiguous choice and wins outright. An
+/// org-ID query matching several profiles prompts for one interactively;
+/// non-interactively it fails with instructions. Read-only consumers (login,
+/// key backup) share these rules; destructive commands resolve via
+/// `resolve_profile_alias` instead, which never guesses among duplicates.
+pub(crate) fn resolve_org_query(ctx: &mut StdCtx, config: &Config, query: &str) -> Result<String> {
+    let aliases = find_org_aliases(config, query);
+
+    match aliases.as_slice() {
+        [] => bail!(
+            "Organization '{query}' not found. \
+             Run `tvc login` without --org to set up a new organization."
+        ),
+        [alias] => Ok(alias.clone()),
+        _ if ctx.is_non_interactive() => bail!(
+            "Organization '{query}' is configured under multiple profiles: {}. \
+             Re-run with --org <alias> to select one.",
+            aliases.join(", ")
+        ),
+        // Unreachable from login while it consolidates duplicates up front;
+        // kept so --org-by-ID resolution stays deterministic for read-only
+        // consumers that do not consolidate.
+        _ => Ok(prompts::select(
+            &format!("Select profile for organization '{query}'"),
+            duplicate_alias_choices(config, &aliases),
+        )?
+        .alias
+        .to_string()),
+    }
 }
 
 async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<Outcome> {
@@ -936,20 +940,6 @@ impl Display for OrgChoice {
             OrgChoice::New => write!(f, "[new] Add a new organization"),
         }
     }
-}
-
-pub(crate) fn find_org<'a>(config: &'a Config, org: &str) -> Option<(&'a String, &'a OrgConfig)> {
-    if let Some((alias, org_config)) = config.orgs.get_key_value(org) {
-        return Some((alias, org_config));
-    }
-
-    for (alias, org_config) in &config.orgs {
-        if org_config.id == org {
-            return Some((alias, org_config));
-        }
-    }
-
-    None
 }
 
 /// Every configured alias matching an org query, for callers to dispose of

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -8,7 +8,8 @@ use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
     OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
     SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
-    YubiKeySerial, dashboard_base_url, default_org_dir, legacy_org_dir,
+    YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
+    default_org_dir, legacy_org_dir,
 };
 use crate::outcome::Outcome;
 use crate::output::{MissingRequiredInput, StdCtx};
@@ -117,6 +118,14 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
             consolidate_duplicate_profiles(ctx, &mut config, duplicates).await?;
         }
 
+        // Runs after consolidation: one profile per organization means the
+        // id-keyed target directories cannot collide.
+        let legacy_profiles = config.legacy_layout_profiles()?;
+
+        if !legacy_profiles.is_empty() {
+            migrate_legacy_key_directories(ctx, &mut config, legacy_profiles).await?;
+        }
+
         build_login_plan_interactive(ctx, args, &config)?
     };
 
@@ -199,6 +208,60 @@ async fn consolidate_duplicate_profiles(
         let deleted = delete_profile(ctx, config, alias).await?;
         shell_println!(ctx, "{deleted}")?;
         shell_println!(ctx)?;
+    }
+
+    Ok(())
+}
+
+/// Move legacy alias-keyed key directories to the id-keyed layout and rewrite
+/// each profile's paths, saving after every profile so a crash strands at
+/// most one. A rename failure warns and skips that profile: its legacy paths
+/// remain valid, and login must not die over a tidiness move.
+async fn migrate_legacy_key_directories(
+    ctx: &mut StdCtx,
+    config: &mut Config,
+    profiles: Vec<(String, Uuid)>,
+) -> Result<()> {
+    for (alias, org_id) in profiles {
+        let source = legacy_org_dir(&alias)?;
+        let target = default_org_dir(org_id)?;
+
+        match tokio::fs::rename(&source, &target).await {
+            Ok(()) => {}
+            // A crash between a previous run's rename and its save leaves the
+            // files already moved; treat the move as done and just rewrite.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && target.is_dir() => {}
+            Err(error) => {
+                shell_eprintln!(
+                    ctx,
+                    "WARNING: could not move key directory {} -> {}: {error}. \
+                     The profile keeps its current paths.",
+                    source.display(),
+                    target.display()
+                )?;
+                continue;
+            }
+        }
+
+        if let Some(org) = config.orgs.get_mut(&alias) {
+            let operator_key_path = default_operator_key_path(org_id)?;
+            org.api_key_path = default_api_key_path(org_id)?;
+            org.operators
+                .iter_mut()
+                .filter_map(|operator| match &mut operator.kind {
+                    OperatorRecordKind::Local(local) => Some(local),
+                    _ => None,
+                })
+                .for_each(|local| local.key_path = operator_key_path.clone());
+        }
+
+        config.save().await?;
+        shell_println!(
+            ctx,
+            "Moved key directory: {} -> {}",
+            source.display(),
+            target.display()
+        )?;
     }
 
     Ok(())

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -6,7 +6,7 @@ use crate::commands::keys::backup_operator_key::{
 };
 use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
-    OperatorRecord, OperatorRecordKind, OrgConfig, QosOperatorPublicKey,
+    OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
     SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
     YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
     default_org_dir,
@@ -22,6 +22,8 @@ use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 use std::io::BufRead;
+use std::str::FromStr;
+use thiserror::Error;
 use tracing::{debug, instrument};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::GetWhoamiRequest;
@@ -33,8 +35,8 @@ use uuid::Uuid;
 pub struct Args {
     /// Organization alias or ID to log in with.
     /// If not provided, will prompt interactively.
-    #[arg(long, env = "TVC_ORG")]
-    pub org: Option<String>,
+    #[arg(long, env = "TVC_ORG", value_parser = OrgQuery::from_str)]
+    pub org: Option<OrgQuery>,
     /// Turnkey API base URL. Defaults to production for newly configured orgs.
     #[arg(long, env = "TVC_API_BASE_URL", value_name = "URL")]
     pub api_base_url: Option<String>,
@@ -51,8 +53,8 @@ pub struct Args {
 pub struct DeleteArgs {
     /// Organization alias or ID of the profile to delete.
     /// If not provided, will prompt interactively.
-    #[arg(short, long, value_name = "ORG")]
-    pub org: Option<String>,
+    #[arg(short, long, value_name = "ORG", value_parser = OrgQuery::from_str)]
+    pub org: Option<OrgQuery>,
     /// Skip the confirmation prompt (required to delete in non-interactive mode).
     #[arg(short, long)]
     pub yes: bool,
@@ -64,7 +66,7 @@ enum OrgPlan {
     /// so it is never a raw query.
     Existing(String),
     New {
-        id: String,
+        id: Uuid,
         alias: String,
         operator: NewOrgOperatorPlan,
     },
@@ -111,7 +113,11 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
         // Consolidate before resolving the org query, so the builders never
         // resolve against profiles that are about to be deleted.
         let duplicates = config.duplicated_org_ids();
-        consolidate_duplicate_profiles(ctx, &mut config, duplicates).await?;
+
+        if !duplicates.is_empty() {
+            consolidate_duplicate_profiles(ctx, &mut config, duplicates).await?;
+        }
+
         build_login_plan_interactive(ctx, args, &config)?
     };
 
@@ -126,51 +132,40 @@ pub async fn run(ctx: &mut StdCtx, args: Args, mut config: Config) -> Result<Out
 async fn consolidate_duplicate_profiles(
     ctx: &mut StdCtx,
     config: &mut Config,
-    duplicates: Vec<(String, Vec<String>)>,
+    duplicates: Vec<(Uuid, Vec<String>)>,
 ) -> Result<()> {
-    if duplicates.is_empty() {
-        return Ok(());
-    }
-
     shell_eprintln!(
         ctx,
-        "Multiple profiles are configured for the same organization. tvc keeps \
+        "Multiple profiles are configured for the same organization. `{}` keeps \
          one profile per organization, so the extra profiles must be deleted \
-         before login can continue."
+         before login can continue.",
+        env!("CARGO_PKG_NAME")
     )?;
     shell_eprintln!(ctx, "")?;
 
-    let mut losers: Vec<String> = Vec::new();
-    let mut active_repair: Option<String> = None;
+    let keepers = duplicates
+        .iter()
+        .map(|(org_id, _)| {
+            prompts::select(
+                &format!("Select the profile to keep for organization '{org_id}'"),
+                profile_choices(config, &config.matching_profiles(&OrgQuery::Id(*org_id))),
+            )
+            .map(|choice| choice.alias.to_string())
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-    for (org_id, aliases) in &duplicates {
-        let keeper = prompts::select(
-            &format!("Select the profile to keep for organization '{org_id}'"),
-            duplicate_alias_choices(config, aliases),
-        )?
-        .alias
-        .to_string();
-
-        if let Some(active) = &config.active_org
-            && aliases.contains(active)
-            && *active != keeper
-        {
-            active_repair = Some(keeper.clone());
-        }
-
-        losers.extend(aliases.iter().filter(|alias| **alias != keeper).cloned());
-    }
+    let losers = duplicates
+        .iter()
+        .zip(&keepers)
+        .flat_map(|((_, aliases), keeper)| aliases.iter().filter(move |alias| *alias != keeper))
+        .cloned()
+        .collect::<Vec<_>>();
 
     let listed = losers
         .iter()
         .map(|alias| format!("'{alias}'"))
         .collect::<Vec<_>>()
         .join(", ");
-    let noun = if losers.len() == 1 {
-        "profile"
-    } else {
-        "profiles"
-    };
 
     shell_eprintln!(ctx, "")?;
     shell_eprintln!(
@@ -180,23 +175,32 @@ async fn consolidate_duplicate_profiles(
          each deletion."
     )?;
     prompts::confirm_or_bail(
-        &format!("Permanently delete {noun} {listed} and the key files on disk?"),
+        &format!("Permanently delete {listed} and the key files on disk?"),
         "profile consolidation",
     )?;
 
-    for alias in &losers {
+    // Repair the active profile onto its group's keeper before deleting, so
+    // every save below persists a config whose active_org still exists.
+    let active_keeper = duplicates
+        .iter()
+        .zip(&keepers)
+        .find_map(|((_, aliases), keeper)| {
+            config
+                .active_org
+                .as_ref()
+                .filter(|active| aliases.contains(active) && *active != keeper)
+                .map(|_| keeper.clone())
+        });
+
+    if let Some(keeper) = active_keeper {
+        config.set_active_org(&keeper)?;
+    }
+
+    for alias in losers {
         let deleted = delete_profile(ctx, config, alias).await?;
         shell_println!(ctx, "{deleted}")?;
         shell_println!(ctx)?;
     }
-
-    // `remove_org` cleared `active_org` if the active profile was among the
-    // losers; its group's keeper inherits it.
-    if let Some(keeper) = active_repair {
-        config.set_active_org(&keeper)?;
-    }
-
-    config.save().await?;
 
     Ok(())
 }
@@ -225,21 +229,18 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         }
     }
 
-    let alias = resolve_profile_alias(&config, args.org, is_non_interactive)?;
-    let org_id = config
-        .orgs
-        .get(&alias)
-        .map(|org| org.id.clone())
-        .unwrap_or_default();
+    let (alias, org_id, dashboard_url) = {
+        let (alias, org) = resolve_profile_alias(&config, args.org, is_non_interactive)?;
+        (
+            alias.to_string(),
+            org.id,
+            dashboard_base_url(&org.api_base_url),
+        )
+    };
 
     // Interactive confirmation. A non-interactive run without --yes was rejected
     // up front, so reaching here with !args.yes means we can prompt.
     if !args.yes {
-        let dashboard_url = config
-            .orgs
-            .get(&alias)
-            .map(|org| dashboard_base_url(&org.api_base_url))
-            .unwrap_or_default();
         shell_eprintln!(ctx, "")?;
         shell_eprintln!(
             ctx,
@@ -298,29 +299,25 @@ pub async fn run_delete(ctx: &mut StdCtx, args: DeleteArgs, mut config: Config) 
         )?;
     }
 
-    let deleted = delete_profile(ctx, &mut config, &alias).await?;
-
-    // Save last: persist the config removal only after the on-disk cleanup
-    // succeeds, so a failure leaves the profile listed and the delete retryable.
-    config.save().await?;
+    let deleted = delete_profile(ctx, &mut config, alias).await?;
 
     Ok(Outcome::ProfileDeleted(deleted))
 }
 
-/// Remove profile `alias` from the config registry and delete its key files
-/// when they use the default per-org directory layout; custom key paths are
-/// left on disk with a warning. Does not save the config: callers batch one
-/// or more removals and persist afterwards, preserving the save-last
-/// invariant that a failed file cleanup leaves the profile listed and the
-/// deletion retryable.
+/// Permanently delete profile `alias`: remove it from the config registry,
+/// delete its key files when they use the default per-org directory layout
+/// (custom key paths are left on disk with a warning), then save the config.
+/// The save comes last so that dying between the file cleanup and the save
+/// leaves the profile listed and the deletion retryable; the file deletion
+/// tolerates an already-missing directory for exactly that retry.
 async fn delete_profile(
     ctx: &mut StdCtx,
     config: &mut Config,
-    alias: &str,
+    alias: String,
 ) -> Result<ProfileDeleted> {
-    let removed = config
-        .remove_org(alias)
-        .expect("alias was resolved from config");
+    let Some(removed) = config.remove_org(&alias) else {
+        bail!("Login profile '{alias}' not found.");
+    };
 
     // Read the API key's public key before deleting its file, so the
     // dashboard-revocation reminder below can name exactly which key to remove.
@@ -335,8 +332,8 @@ async fn delete_profile(
     // default profile is removed by deleting that whole directory. Custom
     // (hand-edited) key paths are left untouched with a warning, since the user
     // placed them deliberately and they may live outside our config tree.
-    let default_api_key = default_api_key_path(alias)?;
-    let default_operator_key = default_operator_key_path(alias)?;
+    let default_api_key = default_api_key_path(&alias)?;
+    let default_operator_key = default_operator_key_path(&alias)?;
     let local_key_paths: Vec<_> = removed
         .operators
         .iter()
@@ -351,7 +348,7 @@ async fn delete_profile(
             .all(|path| *path == &default_operator_key);
 
     let removed_dir = if uses_default_layout {
-        let dir = default_org_dir(alias)?;
+        let dir = default_org_dir(&alias)?;
         match tokio::fs::remove_dir_all(&dir).await {
             Ok(()) => Some(dir),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -383,53 +380,59 @@ async fn delete_profile(
         None
     };
 
+    config.save().await?;
+
     // A local delete does not touch the dashboard-registered API key, and we
     // can't tell whether it is still there, so hedge with "may" and give steps.
-    let dashboard_url = dashboard_base_url(&removed.api_base_url);
     let retained_yubikey_serials = removed
         .yubikey_operators()
         .map(|(_, yubikey)| yubikey.serial)
         .collect::<Vec<_>>();
 
     Ok(ProfileDeleted {
-        alias: alias.to_string(),
+        alias,
         organization_id: removed.id,
         removed_key_directory: removed_dir.map(|dir| dir.display().to_string()),
         retained_yubikey_serials,
-        dashboard_url: dashboard_url.to_string(),
+        dashboard_url: dashboard_base_url(&removed.api_base_url).to_string(),
         api_public_key,
     })
 }
 
-/// Resolve the alias of a configured profile to delete. Prompts interactively
-/// with a picker when no query is given, or when an org-ID query matches
-/// several profiles; non-interactive runs must name a single profile.
+/// Resolve the profile to delete. Prompts interactively with a picker when no
+/// query is given, or when an org-ID query matches several profiles;
+/// non-interactive runs must name a single profile.
 fn resolve_profile_alias(
     config: &Config,
-    org: Option<String>,
+    org: Option<OrgQuery>,
     is_non_interactive: bool,
-) -> Result<String> {
+) -> Result<(&str, &OrgConfig)> {
     match org {
         Some(query) => {
-            let aliases = find_org_aliases(config, &query);
+            let profiles = config.matching_profiles(&query);
 
-            match aliases.as_slice() {
+            match profiles.as_slice() {
                 [] => bail!(
                     "Login profile '{query}' not found. \
                      Run `tvc login` to see configured profiles."
                 ),
-                [alias] => Ok(alias.clone()),
+                [profile] => Ok(*profile),
                 _ if is_non_interactive => bail!(
                     "Organization '{query}' is configured under multiple profiles: {}. \
                      Re-run with --org <alias> to select which profile to delete.",
-                    aliases.join(", ")
+                    profiles
+                        .iter()
+                        .map(|(alias, _)| *alias)
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 ),
-                _ => Ok(prompts::select(
-                    "Select profile to delete",
-                    duplicate_alias_choices(config, &aliases),
-                )?
-                .alias
-                .to_string()),
+                _ => {
+                    let choice = prompts::select(
+                        "Select profile to delete",
+                        profile_choices(config, &profiles),
+                    )?;
+                    Ok((choice.alias, choice.org))
+                }
             }
         }
         None => {
@@ -438,52 +441,48 @@ fn resolve_profile_alias(
             if config.orgs.is_empty() {
                 bail!("No login profiles to delete.");
             }
-            let choices: Vec<_> = config
+
+            let all = config
                 .orgs
                 .iter()
-                .map(|(alias, org)| ProfileChoice {
-                    alias: alias.as_str(),
-                    org_id: org.id.as_str(),
-                    is_active: config.active_org.as_deref() == Some(alias.as_str()),
-                })
-                .collect();
-            Ok(prompts::select("Select profile to delete", choices)?
-                .alias
-                .to_string())
+                .map(|(alias, org)| (alias.as_str(), org))
+                .collect::<Vec<_>>();
+            let choice =
+                prompts::select("Select profile to delete", profile_choices(config, &all))?;
+            Ok((choice.alias, choice.org))
         }
     }
 }
 
 struct ProfileChoice<'a> {
     alias: &'a str,
-    org_id: &'a str,
+    org: &'a OrgConfig,
     is_active: bool,
 }
 
 impl Display for ProfileChoice<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let suffix = if self.is_active { " (active)" } else { "" };
-        write!(f, "{} ({}){suffix}", self.alias, self.org_id)
+        write!(f, "{} ({})", self.alias, self.org.id)?;
+
+        if self.is_active {
+            write!(f, " (active)")?;
+        }
+
+        Ok(())
     }
 }
 
-/// Selection choices for aliases that share one organization ID, marking the
-/// active profile the way the no-query delete picker does.
-fn duplicate_alias_choices<'a>(
-    config: &'a Config,
-    aliases: &'a [String],
+/// Picker choices for the given profiles, marking the active one.
+fn profile_choices<'a>(
+    config: &Config,
+    profiles: &[(&'a str, &'a OrgConfig)],
 ) -> Vec<ProfileChoice<'a>> {
-    aliases
+    profiles
         .iter()
-        .map(|alias| ProfileChoice {
-            alias: alias.as_str(),
-            org_id: config
-                .orgs
-                .get(alias)
-                .expect("alias was resolved from this config")
-                .id
-                .as_str(),
-            is_active: config.active_org.as_deref() == Some(alias.as_str()),
+        .map(|(alias, org)| ProfileChoice {
+            alias,
+            org,
+            is_active: config.active_org.as_deref() == Some(*alias),
         })
         .collect()
 }
@@ -499,7 +498,10 @@ fn build_login_plan_interactive(
         serial,
     } = args;
     let org = match org {
-        Some(query) => OrgPlan::Existing(resolve_org_query(ctx, config, &query)?),
+        Some(query) => {
+            let (alias, _) = resolve_org_query(ctx, config, &query)?;
+            OrgPlan::Existing(alias.to_string())
+        }
         None => prompt_for_org_plan(ctx, config, api_base_url.as_deref(), serial)?,
     };
 
@@ -553,77 +555,93 @@ fn build_login_plan_non_interactive(
     args: Args,
     config: &Config,
 ) -> Result<LoginPlan> {
-    let Some(org_query) = args.org else {
+    let Some(query) = args.org else {
         return Err(error_required_in_non_interactive("--org"));
     };
 
-    let alias = resolve_org_query(ctx, config, &org_query)?;
+    let (alias, _) = resolve_org_query(ctx, config, &query)?;
 
     Ok(LoginPlan {
-        org: OrgPlan::Existing(alias),
+        org: OrgPlan::Existing(alias.to_string()),
         api_base_url_override: args.api_base_url,
         api_key_policy: ApiKeyPolicy::RequireExisting,
         yubikey_serial: args.serial,
     })
 }
 
+/// Refusals from resolving an org query against the configured profiles.
+/// Typed so the remediation text lives in one place and the error keeps its
+/// shape through the `anyhow` chain.
+#[derive(Debug, Error)]
+enum ResolveError {
+    #[error(
+        "Organization '{query}' not found. \
+         Run `tvc login` without --org to set up a new organization."
+    )]
+    NotFound { query: OrgQuery },
+    #[error(
+        "Organization '{query}' is configured under multiple profiles: {listed}. \
+         Re-run with --org <alias> to select one."
+    )]
+    MultipleProfiles { query: OrgQuery, listed: String },
+}
+
 /// Resolve an org query (profile alias or organization ID) to a single
-/// configured profile alias.
+/// configured profile.
 ///
 /// An explicitly named alias is an unambiguous choice and wins outright. An
 /// org-ID query matching several profiles prompts for one interactively;
 /// non-interactively it fails with instructions. Read-only consumers (login,
 /// key backup) share these rules; destructive commands resolve via
 /// `resolve_profile_alias` instead, which never guesses among duplicates.
-pub(crate) fn resolve_org_query(ctx: &mut StdCtx, config: &Config, query: &str) -> Result<String> {
-    let aliases = find_org_aliases(config, query);
+pub(crate) fn resolve_org_query<'c>(
+    ctx: &mut StdCtx,
+    config: &'c Config,
+    query: &OrgQuery,
+) -> Result<(&'c str, &'c OrgConfig)> {
+    let matches = config.matching_profiles(query);
 
-    match aliases.as_slice() {
-        [] => bail!(
-            "Organization '{query}' not found. \
-             Run `tvc login` without --org to set up a new organization."
-        ),
-        [alias] => Ok(alias.clone()),
-        _ if ctx.is_non_interactive() => bail!(
-            "Organization '{query}' is configured under multiple profiles: {}. \
-             Re-run with --org <alias> to select one.",
-            aliases.join(", ")
-        ),
+    match matches.as_slice() {
+        [] => bail!(ResolveError::NotFound {
+            query: query.clone()
+        }),
+        [profile] => Ok(*profile),
+        _ if ctx.is_non_interactive() => bail!(ResolveError::MultipleProfiles {
+            query: query.clone(),
+            listed: matches
+                .iter()
+                .map(|(alias, _)| *alias)
+                .collect::<Vec<_>>()
+                .join(", "),
+        }),
         // Unreachable from login while it consolidates duplicates up front;
         // kept so --org-by-ID resolution stays deterministic for read-only
         // consumers that do not consolidate.
-        _ => Ok(prompts::select(
-            &format!("Select profile for organization '{query}'"),
-            duplicate_alias_choices(config, &aliases),
-        )?
-        .alias
-        .to_string()),
+        _ => {
+            let choice = prompts::select(
+                &format!("Select profile for organization '{query}'"),
+                profile_choices(config, &matches),
+            )?;
+            Ok((choice.alias, choice.org))
+        }
     }
 }
 
 async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) -> Result<Outcome> {
-    let (alias, org_config, yubikey) = match plan.org {
+    let (alias, yubikey) = match plan.org {
         OrgPlan::Existing(alias) => {
             update_api_base_url_from_override(
                 &mut config,
                 &alias,
                 plan.api_base_url_override.as_deref(),
             );
-
-            let org_config = config
-                .orgs
-                .get(&alias)
-                .cloned()
-                .expect("plan alias was resolved against this config");
-            (alias, org_config, None)
+            (alias, None)
         }
         OrgPlan::New {
             id,
             alias,
             operator,
         } => {
-            let api_base_url = new_org_api_base_url(plan.api_base_url_override.as_deref());
-
             // The registry entry already exists; the save below persists only
             // the new organization and its serial reference.
             let (operator, yubikey) = match operator {
@@ -646,16 +664,28 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
                 }
             };
 
-            let (alias, org_config) = generate_org(&mut config, id, alias, api_base_url, operator)?;
-            (alias, org_config, yubikey)
+            debug!(org_alias = %alias, "adding organization");
+            config.add_org(
+                &alias,
+                id,
+                new_org_api_base_url(plan.api_base_url_override.as_deref()),
+                operator,
+            )?;
+            (alias, yubikey)
         }
     };
-
-    shell_println!(ctx, "Selected org: {} ({})", alias, org_config.id)?;
 
     config.set_active_org(&alias)?;
 
     config.save().await?;
+
+    // All mutation is done, so the rest of the flow can borrow the profile;
+    // the plan was resolved against (or inserted into) this same config.
+    let Some(org_config) = config.orgs.get(&alias) else {
+        bail!("login profile '{alias}' disappeared from the config");
+    };
+
+    shell_println!(ctx, "Selected org: {} ({})", alias, org_config.id)?;
 
     if let Some(yubikey) = &yubikey {
         shell_println!(ctx)?;
@@ -671,7 +701,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         )?;
     }
 
-    let api_key = match StoredApiKey::load(&org_config).await? {
+    let api_key = match StoredApiKey::load(org_config).await? {
         Some(api_key) => {
             debug!("using existing API key");
             shell_println!(ctx, "Using existing API key.")?;
@@ -679,7 +709,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
         }
         None => match plan.api_key_policy {
             ApiKeyPolicy::AllowGenerate => {
-                let api_key = generate_api_key(ctx, &org_config).await?;
+                let api_key = generate_api_key(ctx, org_config).await?;
                 wait_for_dashboard_registration(ctx)?;
                 api_key
             }
@@ -694,7 +724,7 @@ async fn execute_login(ctx: &mut StdCtx, mut config: Config, plan: LoginPlan) ->
     shell_println!(ctx)?;
     shell_println!(ctx, "Verifying credentials...")?;
 
-    let whoami = verify_credentials(&api_key, &org_config.id, &org_config.api_base_url).await?;
+    let whoami = verify_credentials(&api_key, org_config.id, &org_config.api_base_url).await?;
 
     // Login ensures the org's default backend is usable, and never crosses
     // over: a local default finds or generates the registered key file; a
@@ -839,20 +869,20 @@ fn prompt_for_new_org_inputs(
     shell_println!(ctx)?;
 
     let id = prompts::text("Organization ID", None)?;
+
     if id.is_empty() {
         bail!("Organization ID is required");
     }
 
-    // One profile per organization: a second alias for the same ID would make
-    // resolution ambiguous again (TVC-159).
-    let already_configured = config
-        .orgs
-        .iter()
-        .filter(|(_, org)| org.id == id)
-        .map(|(alias, _)| alias)
-        .min();
+    let id: Uuid = id
+        .trim()
+        .parse()
+        .context("Organization ID must be a UUID")?;
 
-    if let Some(alias) = already_configured {
+    // One profile per organization: a second alias for the same ID would make
+    // resolution ambiguous again (TVC-159). Consolidation already folded any
+    // legacy duplicates before this prompt, so at most one profile matches.
+    if let Some((alias, _)) = config.matching_profiles(&OrgQuery::Id(id)).first() {
         bail!(
             "Organization '{id}' is already configured as profile '{alias}'. \
              Run `tvc login --org {alias}` to use it, \
@@ -940,42 +970,6 @@ impl Display for OrgChoice {
             OrgChoice::New => write!(f, "[new] Add a new organization"),
         }
     }
-}
-
-/// Every configured alias matching an org query, for callers to dispose of
-/// per their mode. An exact alias match is unambiguous and wins outright;
-/// otherwise all aliases registered for the query as an organization ID are
-/// returned, sorted for stable output.
-fn find_org_aliases(config: &Config, query: &str) -> Vec<String> {
-    if config.orgs.contains_key(query) {
-        return vec![query.to_string()];
-    }
-
-    let mut aliases = config
-        .orgs
-        .iter()
-        .filter(|(_, org)| org.id == query)
-        .map(|(alias, _)| alias.clone())
-        .collect::<Vec<_>>();
-    aliases.sort();
-    aliases
-}
-
-fn generate_org(
-    config: &mut Config,
-    id: String,
-    alias: String,
-    api_base_url: String,
-    operator: NewOrgOperator,
-) -> Result<(String, OrgConfig)> {
-    debug!(org_alias = %alias, %api_base_url, "adding organization");
-    config.add_org(&alias, id, api_base_url, operator)?;
-    let org_config = config
-        .orgs
-        .get(&alias)
-        .with_context(|| format!("organization '{alias}' disappeared from config"))?
-        .clone();
-    Ok((alias, org_config))
 }
 
 fn new_org_api_base_url(api_base_url_override: Option<&str>) -> String {
@@ -1151,7 +1145,7 @@ pub struct WhoamiResult {
 
 async fn verify_credentials(
     api_key: &StoredApiKey,
-    org_id: &str,
+    org_id: Uuid,
     api_base_url: &str,
 ) -> Result<WhoamiResult> {
     debug!(%api_base_url, "verifying credentials with whoami");
@@ -1236,7 +1230,7 @@ impl Default for LoggedInOperator {
 #[serde(rename_all = "camelCase")]
 pub struct ProfileDeleted {
     alias: String,
-    organization_id: String,
+    organization_id: Uuid,
     removed_key_directory: Option<String>,
     /// Serials of the YubiKey operators the profile referenced. The devices
     /// and their registry entries are kept; other profiles may share them.
@@ -1370,6 +1364,7 @@ mod tests {
         API_BASE_URL_DEV, API_BASE_URL_PREPROD, DASHBOARD_URL_DEV, DASHBOARD_URL_PREPROD,
         DASHBOARD_URL_PROD, OperatorKind, OperatorRecord,
     };
+    use indexmap::IndexMap;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -1526,62 +1521,13 @@ mod tests {
         assert_eq!(config.orgs["default"].api_base_url, OVERRIDE_URL);
     }
 
-    #[test]
-    fn find_org_aliases_prefers_exact_alias_match() {
-        // The alias "org-x" collides with another profile's organization ID;
-        // the exact alias match must win outright.
-        let config = config_with_orgs(&[("org-x", "org-y"), ("a", "org-x")]);
-
-        assert_eq!(find_org_aliases(&config, "org-x"), ["org-x"]);
-    }
-
-    #[test]
-    fn find_org_aliases_returns_all_id_matches_sorted() {
-        let config = config_with_orgs(&[("c", "org-1"), ("a", "org-1"), ("b", "org-1")]);
-
-        assert_eq!(find_org_aliases(&config, "org-1"), ["a", "b", "c"]);
-    }
-
-    #[test]
-    fn find_org_aliases_returns_empty_for_unknown_query() {
-        let config = config_with_orgs(&[("a", "org-1")]);
-
-        assert!(find_org_aliases(&config, "org-unknown").is_empty());
-    }
-
-    fn config_with_orgs(entries: &[(&str, &str)]) -> Config {
-        Config {
-            active_org: None,
-            orgs: entries
-                .iter()
-                .map(|(alias, org_id)| {
-                    (
-                        alias.to_string(),
-                        OrgConfig {
-                            id: org_id.to_string(),
-                            api_key_path: PathBuf::from("api_key.json"),
-                            api_base_url: API_BASE_URL_PROD.to_string(),
-                            default_operator_kind: OperatorKind::Local,
-                            operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
-                            extra: toml::Table::new(),
-                        },
-                    )
-                })
-                .collect(),
-            yubikeys: Default::default(),
-            last_created_app_id: HashMap::new(),
-            last_operator_ids: HashMap::new(),
-            extra: toml::Table::new(),
-        }
-    }
-
     fn config_with_org(api_base_url: &str) -> Config {
         Config {
             active_org: Some("default".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "default".to_string(),
                 OrgConfig {
-                    id: "org-test".to_string(),
+                    id: Uuid::from_u128(1),
                     api_key_path: PathBuf::from("api_key.json"),
                     api_base_url: api_base_url.to_string(),
                     default_operator_kind: OperatorKind::Local,

--- a/tvc/src/commands/login.rs
+++ b/tvc/src/commands/login.rs
@@ -8,8 +8,7 @@ use crate::config::turnkey::{
     API_BASE_URL_PROD, Config, KeyCurve, LocalOperatorRecord, NewOrgOperator, OperatorKind,
     OperatorRecord, OperatorRecordKind, OrgConfig, OrgQuery, QosOperatorPublicKey,
     SelectYubiKeyOperatorError, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
-    YubiKeySerial, dashboard_base_url, default_api_key_path, default_operator_key_path,
-    default_org_dir,
+    YubiKeySerial, dashboard_base_url, default_org_dir, legacy_org_dir,
 };
 use crate::outcome::Outcome;
 use crate::output::{MissingRequiredInput, StdCtx};
@@ -328,56 +327,76 @@ async fn delete_profile(
         .flatten()
         .map(|key| key.public_key);
 
-    // The default layout stores both key files in the per-org directory, so a
-    // default profile is removed by deleting that whole directory. Custom
-    // (hand-edited) key paths are left untouched with a warning, since the user
-    // placed them deliberately and they may live outside our config tree.
-    let default_api_key = default_api_key_path(&alias)?;
-    let default_operator_key = default_operator_key_path(&alias)?;
-    let local_key_paths: Vec<_> = removed
-        .operators
-        .iter()
-        .filter_map(|operator| match &operator.kind {
-            OperatorRecordKind::Local(local) => Some(&local.key_path),
-            _ => None,
-        })
-        .collect();
-    let uses_default_layout = removed.api_key_path == default_api_key
-        && local_key_paths
-            .iter()
-            .all(|path| *path == &default_operator_key);
+    // The default layout stores both key files in one per-org directory —
+    // id-keyed today, alias-keyed for profiles created before TVC-55 — so a
+    // default profile is removed by deleting that directory. Custom
+    // (hand-edited) key paths are left untouched with a warning, since the
+    // user placed them deliberately and they may live outside our config tree.
+    let owned_dir = [default_org_dir(removed.id)?, legacy_org_dir(&alias)?]
+        .into_iter()
+        .find(|dir| removed.has_default_layout_at(dir));
 
-    let removed_dir = if uses_default_layout {
-        let dir = default_org_dir(&alias)?;
-        match tokio::fs::remove_dir_all(&dir).await {
-            Ok(()) => Some(dir),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+    let removed_dir = match owned_dir {
+        Some(dir) => {
+            // A hand-edited config can point several profiles into one
+            // directory; deleting it would take the survivors' keys with it.
+            let still_used = config.orgs.values().any(|org| {
+                org.api_key_path.starts_with(&dir)
+                    || org.operators.iter().any(|operator| {
+                        matches!(&operator.kind, OperatorRecordKind::Local(local)
+                            if local.key_path.starts_with(&dir))
+                    })
+            });
+
+            if still_used {
                 shell_eprintln!(
                     ctx,
-                    "WARNING: key directory was not on disk: {}",
+                    "WARNING: key directory {} is still used by another profile and was NOT deleted.",
                     dir.display()
                 )?;
                 None
-            }
-            Err(e) => {
-                return Err(e)
-                    .with_context(|| format!("failed to delete key directory: {}", dir.display()));
+            } else {
+                match tokio::fs::remove_dir_all(&dir).await {
+                    Ok(()) => Some(dir),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        shell_eprintln!(
+                            ctx,
+                            "WARNING: key directory was not on disk: {}",
+                            dir.display()
+                        )?;
+                        None
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("failed to delete key directory: {}", dir.display())
+                        });
+                    }
+                }
             }
         }
-    } else {
-        shell_eprintln!(
-            ctx,
-            "WARNING: custom key paths are configured and were NOT deleted."
-        )?;
-        shell_eprintln!(ctx, "Remove them manually if no longer needed:")?;
-        let custom_paths = local_key_paths
-            .into_iter()
-            .chain(Some(&removed.api_key_path))
-            .collect::<BTreeSet<_>>();
-        for path in custom_paths {
-            shell_eprintln!(ctx, "  {}", path.display())?;
+        None => {
+            shell_eprintln!(
+                ctx,
+                "WARNING: custom key paths are configured and were NOT deleted."
+            )?;
+            shell_eprintln!(ctx, "Remove them manually if no longer needed:")?;
+
+            let custom_paths = removed
+                .operators
+                .iter()
+                .filter_map(|operator| match &operator.kind {
+                    OperatorRecordKind::Local(local) => Some(&local.key_path),
+                    _ => None,
+                })
+                .chain(Some(&removed.api_key_path))
+                .collect::<BTreeSet<_>>();
+
+            for path in custom_paths {
+                shell_eprintln!(ctx, "  {}", path.display())?;
+            }
+
+            None
         }
-        None
     };
 
     config.save().await?;

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -192,7 +192,7 @@ impl Run for Args {
                     .context("No active organization. Run `tvc login` first.")?;
 
                 let auth = build_client(&config).await?;
-                ensure_authenticated_org(&auth.org_id, &configured_org_id.to_string())?;
+                ensure_authenticated_org(auth.org_id, configured_org_id)?;
 
                 let HostedOperatorSpec { name, wallet, path } = spec;
 
@@ -210,7 +210,7 @@ impl Run for Args {
 
                 let result = auth
                     .client
-                    .create_tvc_operator(auth.org_id.clone(), timestamp_ms()?, intent)
+                    .create_tvc_operator(auth.org_id.to_string(), timestamp_ms()?, intent)
                     .await
                     .map_err(|error| hosted_activity_error("create hosted TVC operator", error))?;
 

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -186,13 +186,13 @@ impl Run for Args {
     async fn run(self, ctx: &mut StdCtx, mut config: Config) -> Result<CreateOutcome> {
         match CreatePlan::try_from(self)? {
             CreatePlan::Hosted { spec, make_default } => {
-                let (alias, configured_org_id) = config
+                let (org_id, _) = config
                     .active_org_config()
-                    .map(|(alias, org)| (alias.clone(), org.id))
                     .context("No active organization. Run `tvc login` first.")?;
+                let org_display = config.display_name(org_id);
 
                 let auth = build_client(&config).await?;
-                ensure_authenticated_org(auth.org_id, configured_org_id)?;
+                ensure_authenticated_org(auth.org_id, org_id)?;
 
                 let HostedOperatorSpec { name, wallet, path } = spec;
 
@@ -222,8 +222,8 @@ impl Run for Args {
 
                 let record = OperatorRecord::try_from(result)?;
 
-                let org = config.orgs.get_mut(&alias).with_context(|| {
-                    format!("active organization '{alias}' disappeared from config")
+                let org = config.orgs.get_mut(&org_id).with_context(|| {
+                    format!("active organization '{org_display}' disappeared from config")
                 })?;
                 org.operators.push(record.clone());
 
@@ -239,14 +239,14 @@ impl Run for Args {
                 if let Err(save_error) = config.save().await {
                     let record = config
                         .orgs
-                        .get(&alias)
+                        .get(&org_id)
                         .and_then(|org| org.operators.last())
                         .with_context(|| {
                             format!(
-                                "hosted operator disappeared from active organization '{alias}'"
+                                "hosted operator disappeared from active organization '{org_display}'"
                             )
                         })?;
-                    let recovery = recovery_toml(&alias, record)?;
+                    let recovery = recovery_toml(org_id, record)?;
                     let default_note = if make_default {
                         "\n\nAlso set default_operator_kind = \"hosted\" in the organization's table."
                     } else {
@@ -286,10 +286,10 @@ Do not retry creation blindly; doing so would create another remote operator. Re
                     return Err(prompts::error_required_in_non_interactive("--serial"));
                 }
 
-                let (org_alias, org) = config
+                let (org_id, org) = config
                     .active_org_config()
                     .context("No active organization. Run `tvc login` first.")?;
-                let org_alias = org_alias.clone();
+                let org_alias = config.display_name(org_id);
 
                 let serial = match serial {
                     Some(serial) => {
@@ -328,6 +328,7 @@ Do not retry creation blindly; doing so would create another remote operator. Re
                     record,
                     serial,
                     make_default,
+                    org_id,
                     org_alias,
                 };
                 let added = create.execute(&mut config)?;
@@ -335,7 +336,7 @@ Do not retry creation blindly; doing so would create another remote operator. Re
                 // Nothing is persisted yet; re-running is safe because a
                 // duplicate serial is refused before another record is added.
                 let record_recovery = recovery_toml(
-                    &added.org_alias,
+                    org_id,
                     &OperatorRecord {
                         name: added.name.clone(),
                         kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
@@ -369,6 +370,8 @@ struct YubikeyCreate {
     record: OperatorRecord,
     serial: YubiKeySerial,
     make_default: bool,
+    org_id: Uuid,
+    /// Display name for the organization in messages.
     org_alias: String,
 }
 
@@ -386,7 +389,7 @@ impl YubikeyCreate {
         })?;
         let operator_public_key = entry.public_key;
 
-        let org = config.orgs.get_mut(&self.org_alias).with_context(|| {
+        let org = config.orgs.get_mut(&self.org_id).with_context(|| {
             format!(
                 "active organization '{}' disappeared from config",
                 self.org_alias
@@ -405,7 +408,6 @@ impl YubikeyCreate {
             serial: self.serial,
             operator_public_key,
             made_default: self.make_default,
-            org_alias: self.org_alias,
         })
     }
 }
@@ -454,8 +456,6 @@ pub struct YubikeyOperatorAdded {
     /// The composite `encrypt_public ‖ sign_public` operator key.
     operator_public_key: QosOperatorPublicKey,
     made_default: bool,
-    #[serde(skip)]
-    org_alias: String,
 }
 
 impl From<YubikeyOperatorAdded> for Outcome {
@@ -501,13 +501,11 @@ enum HostedOperatorWallet {
     Existing(Uuid),
 }
 
-fn recovery_toml(alias: &str, record: &OperatorRecord) -> Result<String> {
-    let quoted_alias = serde_json::to_string(alias)
-        .context("failed to quote organization alias for recovery record")?;
+fn recovery_toml(org_id: Uuid, record: &OperatorRecord) -> Result<String> {
     let record =
         toml::to_string_pretty(record).context("failed to serialize operator recovery record")?;
     Ok(format!(
-        r#"[[orgs.{quoted_alias}.operators]]
+        r#"[[orgs."{org_id}".operators]]
 {}"#,
         record.trim()
     ))
@@ -549,9 +547,12 @@ mod tests {
 
         let expected = hosted_record();
         let recovery: Recovery =
-            toml::from_str(&recovery_toml("default", &expected).unwrap()).unwrap();
+            toml::from_str(&recovery_toml(Uuid::from_u128(0x123), &expected).unwrap()).unwrap();
 
-        assert_eq!(recovery.orgs["default"].operators, vec![expected]);
+        assert_eq!(
+            recovery.orgs[&Uuid::from_u128(0x123).to_string()].operators,
+            vec![expected]
+        );
     }
 
     fn args(kind: CreateKind) -> Args {
@@ -616,11 +617,10 @@ mod tests {
 
     fn config_with_active_org() -> Config {
         Config {
-            active_org: Some("default".to_string()),
+            active_org: Some(Uuid::from_u128(0x123)),
             orgs: IndexMap::from([(
-                "default".to_string(),
+                Uuid::from_u128(0x123),
                 OrgConfig {
-                    id: Uuid::from_u128(0x123),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -638,7 +638,7 @@ mod tests {
         name: Option<String>,
         make_default: bool,
     ) -> YubikeyCreate {
-        let record = config.orgs["default"]
+        let record = config.orgs[&Uuid::from_u128(0x123)]
             .new_yubikey_operator(serial, name)
             .unwrap();
 
@@ -646,6 +646,7 @@ mod tests {
             record,
             serial,
             make_default,
+            org_id: Uuid::from_u128(0x123),
             org_alias: "default".to_string(),
         }
     }
@@ -665,7 +666,7 @@ mod tests {
         assert_eq!(added.serial, test_support::serial());
         assert_eq!(added.operator_public_key, composite);
 
-        let org = &config.orgs["default"];
+        let org = &config.orgs[&Uuid::from_u128(0x123)];
         assert_eq!(org.default_operator_kind, OperatorKind::Local);
         assert_eq!(
             org.operators,
@@ -678,12 +679,12 @@ mod tests {
         let mut config = config_with_active_org();
         config
             .orgs
-            .get_mut("default")
+            .get_mut(&Uuid::from_u128(0x123))
             .unwrap()
             .operators
             .push(OperatorRecord::yubikey(test_support::serial()));
 
-        let error = config.orgs["default"]
+        let error = config.orgs[&Uuid::from_u128(0x123)]
             .new_yubikey_operator(test_support::serial(), None)
             .unwrap_err();
 

--- a/tvc/src/commands/operator/create.rs
+++ b/tvc/src/commands/operator/create.rs
@@ -188,11 +188,11 @@ impl Run for Args {
             CreatePlan::Hosted { spec, make_default } => {
                 let (alias, configured_org_id) = config
                     .active_org_config()
-                    .map(|(alias, org)| (alias.clone(), org.id.as_str()))
+                    .map(|(alias, org)| (alias.clone(), org.id))
                     .context("No active organization. Run `tvc login` first.")?;
 
                 let auth = build_client(&config).await?;
-                ensure_authenticated_org(&auth.org_id, configured_org_id)?;
+                ensure_authenticated_org(&auth.org_id, &configured_org_id.to_string())?;
 
                 let HostedOperatorSpec { name, wallet, path } = spec;
 
@@ -519,7 +519,7 @@ mod tests {
     use crate::config::turnkey::{HostedOperatorRecord, OrgConfig};
     use crate::yubikey::SlotStatus;
     use crate::yubikey::test_support::{self, FakeDevice};
-    use std::collections::HashMap;
+    use indexmap::IndexMap;
     use std::path::PathBuf;
 
     fn hosted_record() -> OperatorRecord {
@@ -617,10 +617,10 @@ mod tests {
     fn config_with_active_org() -> Config {
         Config {
             active_org: Some("default".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "default".to_string(),
                 OrgConfig {
-                    id: "org-123".to_string(),
+                    id: Uuid::from_u128(0x123),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,

--- a/tvc/src/commands/yubikey/unregister.rs
+++ b/tvc/src/commands/yubikey/unregister.rs
@@ -57,7 +57,7 @@ impl Run for Args {
         };
 
         let referencing_orgs = {
-            let mut aliases = config
+            let mut names = config
                 .orgs
                 .iter()
                 .filter(|(_, org)| {
@@ -68,10 +68,10 @@ impl Run for Args {
                         )
                     })
                 })
-                .map(|(alias, _)| alias.as_str())
+                .map(|(org_id, _)| config.display_name(*org_id))
                 .collect::<Vec<_>>();
-            aliases.sort_unstable();
-            aliases
+            names.sort_unstable();
+            names
         };
 
         if !referencing_orgs.is_empty() {

--- a/tvc/src/config.rs
+++ b/tvc/src/config.rs
@@ -5,8 +5,10 @@
 //! - `app` - App creation config files
 //! - `deploy` - Deployment config files
 //! - `quorum_key` - Quorum key generation config files
+//! - `placeholder` - Typed `<FILL_IN_...>` template values
 
 pub mod app;
 pub mod deploy;
+pub mod placeholder;
 pub mod quorum_key;
 pub mod turnkey;

--- a/tvc/src/config/app.rs
+++ b/tvc/src/config/app.rs
@@ -1,10 +1,15 @@
 //! App configuration file format for `tvc app create`.
 
-use crate::prompts;
+use super::placeholder::StringWithPlaceholder;
+use crate::{
+    config::placeholder::{PlaceholderText, text::FillInAppName},
+    prompts,
+};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use thiserror::Error;
+use uuid::Uuid;
 
 pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
 
@@ -12,7 +17,7 @@ pub const MIN_SHARE_SET_THRESHOLD: u32 = 2;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppConfig {
-    pub name: String,
+    pub name: StringWithPlaceholder<FillInAppName>,
     pub quorum_public_key: String,
     #[serde(default)]
     pub enable_egress: bool,
@@ -39,7 +44,7 @@ pub struct OperatorSetParams {
     #[serde(default)]
     pub new_operators: Vec<OperatorParams>,
     #[serde(default)]
-    pub existing_operator_ids: Vec<String>,
+    pub existing_operator_ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,7 +74,7 @@ impl AppConfig {
     /// Generate a default template config with placeholders.
     pub fn template(operator_public_key: Option<&str>) -> Self {
         Self {
-            name: "<FILL_IN_APP_NAME>".to_string(),
+            name: StringWithPlaceholder::placeholder(),
             quorum_public_key: KNOWN_QUORUM_KEY.to_string(),
             enable_egress: false,
             manifest_set_id: None,
@@ -112,8 +117,8 @@ impl AppConfig {
     /// `saved_operator_public_key` is offered as the default when prompting
     /// for a `<FILL_IN>` operator public key.
     pub fn fill_interactively(&mut self, saved_operator_public_key: Option<&str>) -> Result<()> {
-        if self.name.starts_with("<FILL_IN") {
-            self.name = prompts::required_text("App name", None)?;
+        if matches!(self.name, StringWithPlaceholder::Placeholder(_)) {
+            self.name = prompts::required_text("App name", None)?.into();
         }
         if let Some(set_params) = self.manifest_set_params.as_mut() {
             if set_params.name.starts_with("<FILL_IN") {
@@ -142,7 +147,7 @@ impl AppConfig {
 
     /// Check if config contains placeholder values.
     pub fn has_placeholders(&self) -> bool {
-        self.name.starts_with("<FILL_IN")
+        matches!(self.name, StringWithPlaceholder::Placeholder(_))
             || self.manifest_set_params.as_ref().is_some_and(|p| {
                 p.name.starts_with("<FILL_IN")
                     || p.new_operators
@@ -160,10 +165,14 @@ impl AppConfig {
     pub fn validate(&self) -> Result<(), AppConfigValidationErrors> {
         let mut errors = Vec::new();
 
-        if self.name.starts_with("<FILL_IN") {
+        if matches!(
+            self.name,
+            StringWithPlaceholder::<FillInAppName>::Placeholder(_)
+        ) {
             errors.push(AppConfigValidationError::Placeholder {
                 field: "name",
-                placeholder: self.name.clone(),
+                // TODO: replace with &'static str when placeholder Strings are removed
+                placeholder: FillInAppName::TEXT.into(),
             });
         }
 
@@ -255,6 +264,7 @@ pub enum AppConfigValidationError {
     #[error("{field} contains placeholder value {placeholder}")]
     Placeholder {
         field: &'static str,
+        // TODO: fix me when all the strings are replaced with types
         placeholder: String,
     },
     #[error("{set}.newOperators[{index}].publicKey contains placeholder value {placeholder}")]

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -1,8 +1,6 @@
 //! Deployment configuration file format for `tvc deploy create`.
 
-use crate::output::Ctx;
-use crate::prompts;
-use crate::shell_println;
+use crate::{output::Ctx, prompts, shell_println};
 use anyhow::{Context, Result, anyhow};
 use qos_core::protocol::services::boot::VersionedManifest;
 use serde::{Deserialize, Serialize};
@@ -27,8 +25,12 @@ pub const DEFAULT_QOS_VERSION: &str = "0.12.1";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeployConfig {
-    pub app_id: String,
+    pub app_id: Uuid,
     pub qos_version: String,
+    /// Number of deployment replicas to request. Omitted (`None`) leaves the
+    /// choice to the backend default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replicas: Option<u32>,
     pub pivot_container_image_url: String,
     pub pivot_path: String,
     #[serde(default)]
@@ -44,10 +46,6 @@ pub struct DeployConfig {
     pub health_check_type: TvcHealthCheckType,
     pub health_check_port: u16,
     pub public_ingress_port: u16,
-    /// Number of deployment replicas to request. Omitted (`None`) leaves the
-    /// choice to the backend default.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub replicas: Option<u32>,
 }
 
 /// Build a config seeded from an existing deployment, for use as a template.
@@ -79,6 +77,8 @@ impl TryFrom<TvcDeployment> for DeployConfig {
             ..
         } = deployment;
 
+        let app_id = app_id.parse()?;
+
         let tvc_manifest =
             manifest.ok_or_else(|| anyhow!("deployment {id} has no manifest to seed from"))?;
         let manifest = VersionedManifest::try_from_slice_compat(&tvc_manifest.manifest)
@@ -103,6 +103,7 @@ impl TryFrom<TvcDeployment> for DeployConfig {
         Ok(Self {
             app_id,
             qos_version,
+            replicas: None,
             pivot_container_image_url: container_url,
             pivot_path: path,
             pivot_args: args,
@@ -113,7 +114,6 @@ impl TryFrom<TvcDeployment> for DeployConfig {
             health_check_type,
             health_check_port,
             public_ingress_port,
-            replicas: None,
         })
     }
 }
@@ -121,10 +121,11 @@ impl TryFrom<TvcDeployment> for DeployConfig {
 impl DeployConfig {
     /// Generate a default template config with placeholders.
     // Future: Could auto-fill appId if there's only one app in the org
-    pub fn template(app_id: Option<&str>) -> Self {
+    pub fn template(app_id: Uuid) -> Self {
         Self {
-            app_id: app_id.unwrap_or("<FILL_IN_APP_ID>").to_string(),
+            app_id,
             qos_version: DEFAULT_QOS_VERSION.to_string(),
+            replicas: None,
             pivot_container_image_url: "<FILL_IN_PIVOT_CONTAINER_IMAGE_URL>".to_string(),
             pivot_path: "<FILL_IN_PIVOT_PATH>".to_string(),
             pivot_args: vec![],
@@ -134,7 +135,6 @@ impl DeployConfig {
             health_check_type: TvcHealthCheckType::Http,
             health_check_port: 3000,
             public_ingress_port: 3000,
-            replicas: None,
         }
     }
 
@@ -142,14 +142,7 @@ impl DeployConfig {
     /// Non-placeholder fields are preserved unchanged so partial edits work.
     ///
     /// `saved_app_id` is offered as the default for the App ID prompt when set.
-    pub fn fill_interactively<W: Write, W2: Write>(
-        &mut self,
-        ctx: &mut Ctx<W, W2>,
-        saved_app_id: Option<&str>,
-    ) -> Result<()> {
-        if self.app_id.starts_with("<FILL_IN") {
-            self.app_id = prompts::required_text("App ID", saved_app_id)?;
-        }
+    pub fn fill_interactively<W: Write, W2: Write>(&mut self, ctx: &mut Ctx<W, W2>) -> Result<()> {
         if self.qos_version.starts_with("<FILL_IN") {
             self.qos_version = prompts::required_text("QOS version", None)?;
         }
@@ -180,8 +173,7 @@ impl DeployConfig {
 
     /// Check if config contains placeholder values.
     pub fn has_placeholders(&self) -> bool {
-        self.app_id.starts_with("<FILL_IN")
-            || self.qos_version.starts_with("<FILL_IN")
+        self.qos_version.starts_with("<FILL_IN")
             || self.pivot_container_image_url.starts_with("<FILL_IN")
             || self.pivot_path.starts_with("<FILL_IN")
             || self.expected_pivot_digest.starts_with("<FILL_IN")
@@ -193,9 +185,6 @@ impl DeployConfig {
     /// `<FILL_IN...>` placeholders, in struct order. Empty if complete.
     pub fn missing_required_fields(&self) -> Vec<&'static str> {
         let mut missing = Vec::new();
-        if self.app_id.starts_with("<FILL_IN") {
-            missing.push("--app-id");
-        }
         if self.qos_version.starts_with("<FILL_IN") {
             missing.push("--qos-version");
         }
@@ -217,16 +206,6 @@ impl DeployConfig {
 
     pub fn validate(&self) -> Result<(), DeployConfigValidationErrors> {
         let mut errors = Vec::new();
-        if self.app_id.starts_with("<FILL_IN") {
-            errors.push(DeployConfigValidationError::Placeholder {
-                field: "app_id",
-                placeholder: self.app_id.clone(),
-            });
-        } else if Uuid::try_parse(&self.app_id).is_err() {
-            errors.push(DeployConfigValidationError::InvalidAppId {
-                value: self.app_id.clone(),
-            });
-        }
         if self.qos_version.starts_with("<FILL_IN") {
             errors.push(DeployConfigValidationError::Placeholder {
                 field: "qos_version",
@@ -349,7 +328,7 @@ mod tests {
         TvcDeployment {
             id: "deploy-123".into(),
             organization_id: "org-1".into(),
-            app_id: "app-1".into(),
+            app_id: Uuid::from_u128(645).to_string(),
             manifest_set: None,
             share_set: None,
             manifest: Some(manifest(false)),
@@ -374,7 +353,6 @@ mod tests {
     #[test]
     fn from_deployment_copies_recoverable_fields() {
         let config = DeployConfig::try_from(sample_deployment(false)).unwrap();
-        assert_eq!(config.app_id, "app-1");
         assert_eq!(config.qos_version, "0.6.1");
         assert_eq!(config.pivot_container_image_url, "ghcr.io/x/y@sha256:img");
         assert_eq!(config.pivot_path, "/bin/pivot");
@@ -392,16 +370,6 @@ mod tests {
         assert!(!config.dangerous_deploy_debug_mode);
         // A seeded config therefore has no remaining placeholder fields.
         assert!(config.missing_required_fields().is_empty());
-    }
-
-    /// The API deployment type carries no configured (desired) replica count —
-    /// only runtime `DeploymentStatus` exposes ready/desired replicas — so a
-    /// seeded config leaves `replicas` unset and the backend default applies on
-    /// the next deploy.
-    #[test]
-    fn from_deployment_leaves_replicas_unset() {
-        let config = DeployConfig::try_from(sample_deployment(false)).unwrap();
-        assert_eq!(config.replicas, None);
     }
 
     #[test]
@@ -461,7 +429,7 @@ mod tests {
 
     #[test]
     fn fresh_template_is_all_placeholders() {
-        let config = DeployConfig::template(None);
+        let config = DeployConfig::template(Default::default());
         assert!(config.has_placeholders());
     }
 
@@ -469,8 +437,7 @@ mod tests {
     fn filled_config_with_pull_secret_still_placeholder_is_detected() {
         // Previously this case slipped through: all FILL_IN fields replaced,
         // but the pull-secret sentinel left intact.
-        let mut config = DeployConfig::template(None);
-        config.app_id = "app_123".into();
+        let mut config = DeployConfig::template(Default::default());
         config.qos_version = "0.6.1".into();
         config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
         config.pivot_path = "/bin/pivot".into();
@@ -486,8 +453,7 @@ mod tests {
         // If every field is already set, fill_interactively must not attempt
         // to prompt — this is the contract that lets unit tests run without
         // injecting stdin.
-        let mut config = DeployConfig::template(None);
-        config.app_id = "app_xyz".into();
+        let mut config = DeployConfig::template(Default::default());
         config.qos_version = "0.6.1".into();
         config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
         config.pivot_path = "/bin/pivot".into();
@@ -496,8 +462,7 @@ mod tests {
 
         let shell = EmptyShell::default();
         let mut ctx = Ctx::new(shell, false);
-        config.fill_interactively(&mut ctx, None).unwrap();
-        assert_eq!(config.app_id, "app_xyz");
+        config.fill_interactively(&mut ctx).unwrap();
         assert_eq!(config.qos_version, "0.6.1");
         assert_eq!(config.pivot_container_image_url, "ghcr.io/x/y:v1");
         assert_eq!(config.pivot_path, "/bin/pivot");
@@ -507,8 +472,8 @@ mod tests {
 
     #[test]
     fn fully_filled_config_has_no_placeholders() {
-        let mut config = DeployConfig::template(None);
-        config.app_id = "651b573c-861b-4f10-a478-cbcfe0c226af".into();
+        let app_id = "651b573c-861b-4f10-a478-cbcfe0c226af".parse().unwrap();
+        let mut config = DeployConfig::template(app_id);
         config.qos_version = "0.6.1".into();
         config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
         config.pivot_path = "/bin/pivot".into();
@@ -517,49 +482,12 @@ mod tests {
         assert!(!config.has_placeholders());
     }
 
-    /// Build a config with every required field filled by a valid (non-placeholder)
-    /// value, so `validate()` returns `Ok` unless a test perturbs one field.
-    fn valid_config() -> DeployConfig {
-        let mut config = DeployConfig::template(None);
-        config.app_id = "651b573c-861b-4f10-a478-cbcfe0c226af".into();
-        config.qos_version = "0.6.1".into();
-        config.pivot_container_image_url = "ghcr.io/x/y:v1".into();
-        config.pivot_path = "/bin/pivot".into();
-        config.expected_pivot_digest = "sha256:abc".into();
-        config.pivot_container_encrypted_pull_secret = None;
-        config
-    }
-
-    #[test]
-    fn validate_rejects_non_uuid_app_id() {
-        let mut config = valid_config();
-        config.app_id = "not-a-uuid".into();
-        let errors = config.validate().unwrap_err();
-        assert!(errors.to_string().contains("not a valid UUID"), "{errors}");
-        // A malformed app_id is a hard error, so interactive mode bails instead
-        // of prompting the user to "fill in" an already-present value.
-        assert!(errors.has_non_placeholder_error());
-    }
-
-    #[test]
-    fn validate_accepts_well_formed_uuid() {
-        // Turnkey resource IDs come in both UUID v4 and v7 forms; accept either.
-        for app_id in [
-            "651b573c-861b-4f10-a478-cbcfe0c226af", // v4
-            "019660f7-801d-75d8-a40e-e4f69944b711", // v7
-        ] {
-            let mut config = valid_config();
-            config.app_id = app_id.into();
-            assert!(config.validate().is_ok(), "should accept {app_id}");
-        }
-    }
-
     /// The placeholder branch takes precedence over the UUID check, so an
     /// unfilled `<FILL_IN_APP_ID>` is reported as a placeholder (which interactive
     /// mode prompts to fill), not as an "invalid UUID" hard error.
     #[test]
     fn validate_reports_placeholder_app_id_as_placeholder() {
-        let config = DeployConfig::template(None);
+        let config = DeployConfig::template(Default::default());
         let errors = config.validate().unwrap_err();
         let msg = errors.to_string();
         assert!(msg.contains("placeholder"), "{msg}");

--- a/tvc/src/config/placeholder.rs
+++ b/tvc/src/config/placeholder.rs
@@ -1,0 +1,676 @@
+//! Typed placeholder values used by configuration templates.
+
+use serde::{
+    Deserialize, Serialize,
+    de::{Error as _, Unexpected},
+};
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+/// Supplies the fixed placeholder text for a configuration field.
+pub trait PlaceholderText {
+    const TEXT: &'static str;
+}
+
+/// A configuration value that is either populated or still a placeholder.
+#[derive(PartialEq, Eq)]
+pub enum WithPlaceholder<T, P> {
+    Value(T),
+    Placeholder(PhantomData<P>),
+}
+
+impl<T, P: PlaceholderText> WithPlaceholder<T, P> {
+    pub const TEXT: &'static str = P::TEXT;
+
+    pub fn placeholder() -> Self {
+        Self::Placeholder(PhantomData)
+    }
+
+    /// Try to convert into the value. [`Result::Err`] variant is the placeholder text
+    pub fn try_into(self) -> Result<T, &'static str> {
+        match self {
+            WithPlaceholder::Value(val) => Ok(val),
+            WithPlaceholder::Placeholder(_) => Err(P::TEXT),
+        }
+    }
+}
+
+impl<T: Clone, P> Clone for WithPlaceholder<T, P> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Value(val) => Self::Value(val.clone()),
+            Self::Placeholder(_) => Self::Placeholder(PhantomData),
+        }
+    }
+}
+
+impl<T: Copy, P> Copy for WithPlaceholder<T, P> {}
+
+impl<T, P> Default for WithPlaceholder<T, P> {
+    fn default() -> Self {
+        Self::Placeholder(PhantomData)
+    }
+}
+
+impl<T: Debug, P> Debug for WithPlaceholder<T, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Value(value) => f
+                .debug_tuple("WithPlaceholder::Value")
+                .field(value)
+                .finish(),
+            Self::Placeholder(_) => f.debug_tuple("WithPlaceholder::Placeholder").finish(),
+        }
+    }
+}
+
+impl<T: Display, P: PlaceholderText> Display for WithPlaceholder<T, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WithPlaceholder::Value(val) => Display::fmt(val, f),
+            WithPlaceholder::Placeholder(_) => f.write_fmt(format_args!("<{}>", P::TEXT)),
+        }
+    }
+}
+
+impl<T, P> From<T> for WithPlaceholder<T, P> {
+    fn from(value: T) -> Self {
+        Self::Value(value)
+    }
+}
+
+impl<T: Serialize, P: PlaceholderText> Serialize for WithPlaceholder<T, P> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            WithPlaceholder::Value(val) => val.serialize(serializer),
+            WithPlaceholder::Placeholder(_) => {
+                serializer.collect_str(&format_args!("<{}>", P::TEXT))
+            }
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>, P: PlaceholderText> Deserialize<'de> for WithPlaceholder<T, P> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        /// T cannot be a `String` or `&str` here, it won't work properly
+        enum StringOrValue<'a, T> {
+            /// Serde derive implementation attempts to deserialize into the first variant first
+            /// for untagged enums
+            Value(T),
+            /// Not every deserializer will borrow here properly
+            #[serde(borrow)]
+            String(Cow<'a, str>),
+        }
+
+        StringOrValue::<'de, T>::deserialize(deserializer).and_then(|string_or_value| {
+            match string_or_value {
+                StringOrValue::Value(value) => Ok(Self::Value(value)),
+                StringOrValue::String(s) => {
+                    let is_match = s.len() == P::TEXT.len() + 2
+                        && s.starts_with('<')
+                        && s.ends_with('>')
+                        && &s[1..s.len() - 1] == P::TEXT;
+
+                    if is_match {
+                        Ok(Self::Placeholder(PhantomData))
+                    } else {
+                        Err(D::Error::invalid_type(
+                            Unexpected::Str(s.as_ref()),
+                            &format!("only {} is valid as a placeholder", P::TEXT)
+                                .to_string()
+                                .as_str(),
+                        ))
+                    }
+                }
+            }
+        })
+    }
+}
+
+pub type StringWithPlaceholder<P> = WithPlaceholder<NonPlaceHolderString, P>;
+
+#[derive(Debug, Default, Serialize, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct NonPlaceHolderString(String);
+
+impl Deref for NonPlaceHolderString {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for NonPlaceHolderString {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Display for NonPlaceHolderString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<String> for NonPlaceHolderString {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl<P> From<String> for StringWithPlaceholder<P> {
+    fn from(value: String) -> Self {
+        NonPlaceHolderString::from(value).into()
+    }
+}
+
+impl From<&'static str> for NonPlaceHolderString {
+    fn from(value: &'static str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<P> From<&'static str> for StringWithPlaceholder<P> {
+    fn from(value: &'static str) -> Self {
+        NonPlaceHolderString::from(value).into()
+    }
+}
+
+impl<'de> Deserialize<'de> for NonPlaceHolderString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let borrowed = Cow::<'de, str>::deserialize(deserializer)?;
+
+        let mut chars = borrowed.chars();
+
+        match (chars.next(), chars.last()) {
+            (Some('<'), Some('>')) => Err(D::Error::custom(
+                "String be surrounded by placeholder brackets '<' and '>'",
+            )),
+            _ => Ok(Self(borrowed.into_owned())),
+        }
+    }
+}
+
+pub mod text {
+    use super::PlaceholderText;
+
+    pub struct FillInAppName;
+    pub struct FillInManifestSetName;
+    pub struct FillInOperatorPublicKey;
+    pub struct RemoveMeIfPivotContainerUrlIsPublic;
+    pub struct FillInAppId;
+    pub struct FillInPivotContainerImageUrl;
+    pub struct FillInPivotPath;
+    pub struct FillInExpectedPivotDigest;
+
+    impl PlaceholderText for FillInAppName {
+        const TEXT: &'static str = "FILL_IN_APP_NAME";
+    }
+
+    impl PlaceholderText for FillInManifestSetName {
+        const TEXT: &'static str = "FILL_IN_MANIFEST_SET_NAME";
+    }
+
+    impl PlaceholderText for FillInOperatorPublicKey {
+        const TEXT: &'static str = "FILL_IN_OPERATOR_PUBLIC_KEY";
+    }
+
+    impl PlaceholderText for RemoveMeIfPivotContainerUrlIsPublic {
+        const TEXT: &'static str = "REMOVE_ME_IF_PIVOT_CONTAINER_URL_IS_PUBLIC";
+    }
+
+    impl PlaceholderText for FillInAppId {
+        const TEXT: &'static str = "FILL_IN_APP_ID";
+    }
+
+    impl PlaceholderText for FillInPivotContainerImageUrl {
+        const TEXT: &'static str = "FILL_IN_PIVOT_CONTAINER_IMAGE_URL";
+    }
+
+    impl PlaceholderText for FillInPivotPath {
+        const TEXT: &'static str = "FILL_IN_PIVOT_PATH";
+    }
+
+    impl PlaceholderText for FillInExpectedPivotDigest {
+        const TEXT: &'static str = "FILL_IN_EXPECTED_PIVOT_DIGEST";
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Serialize, de::DeserializeOwned};
+    use std::fmt::Debug;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestPlaceholder;
+
+    impl PlaceholderText for TestPlaceholder {
+        const TEXT: &'static str = "TEST_PLACEHOLDER";
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Outer<T> {
+        value: T,
+    }
+
+    fn assert_json_serializes_value<T>(value: T, json_value: &str)
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let value = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Value(value),
+        };
+        let expected_json = format!(r#"{{"value":{json_value}}}"#);
+
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, expected_json);
+
+        let round_trip: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, value);
+    }
+
+    fn assert_json_deserializes_value<T>(value: T, json_value: &str)
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let expected = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Value(value),
+        };
+        let json = format!(r#"{{"value":{json_value}}}"#);
+
+        let deserialized: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, expected);
+
+        let round_trip = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(round_trip, json);
+    }
+
+    fn assert_toml_serializes_value<T>(value: T, expected_toml: &str)
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let value = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Value(value),
+        };
+
+        let toml = toml::to_string(&value).unwrap();
+        assert_eq!(toml, expected_toml);
+
+        let round_trip: Outer<WithPlaceholder<T, TestPlaceholder>> = toml::from_str(&toml).unwrap();
+        assert_eq!(round_trip, value);
+    }
+
+    fn assert_toml_deserializes_value<T>(value: T, toml: &str)
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let expected = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Value(value),
+        };
+
+        let deserialized: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            toml::from_str(toml).unwrap();
+        assert_eq!(deserialized, expected);
+
+        let round_trip = toml::to_string(&deserialized).unwrap();
+        assert_eq!(round_trip, toml);
+    }
+
+    fn assert_json_serializes_placeholder<T>()
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let value = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Placeholder(PhantomData),
+        };
+        let expected_json = format!(r#"{{"value":"<{}>"}}"#, TestPlaceholder::TEXT);
+
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, expected_json);
+
+        let round_trip: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, value);
+    }
+
+    fn assert_json_deserializes_placeholder<T>()
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let expected = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Placeholder(PhantomData),
+        };
+        let json = format!(r#"{{"value":"<{}>"}}"#, TestPlaceholder::TEXT);
+
+        let deserialized: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, expected);
+
+        let round_trip = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(round_trip, json);
+    }
+
+    fn assert_toml_serializes_placeholder<T>()
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let value = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Placeholder(PhantomData),
+        };
+        let expected_toml = format!(
+            r#"value = "<{}>"
+"#,
+            TestPlaceholder::TEXT
+        );
+
+        let toml = toml::to_string(&value).unwrap();
+        assert_eq!(toml, expected_toml);
+
+        let round_trip: Outer<WithPlaceholder<T, TestPlaceholder>> = toml::from_str(&toml).unwrap();
+        assert_eq!(round_trip, value);
+    }
+
+    fn assert_toml_deserializes_placeholder<T>()
+    where
+        T: Debug + PartialEq + Serialize + DeserializeOwned,
+    {
+        let expected = Outer {
+            value: WithPlaceholder::<T, TestPlaceholder>::Placeholder(PhantomData),
+        };
+        let toml = format!(
+            r#"value = "<{}>"
+"#,
+            TestPlaceholder::TEXT
+        );
+
+        let deserialized: Outer<WithPlaceholder<T, TestPlaceholder>> =
+            toml::from_str(&toml).unwrap();
+        assert_eq!(deserialized, expected);
+
+        let round_trip = toml::to_string(&deserialized).unwrap();
+        assert_eq!(round_trip, toml);
+    }
+
+    macro_rules! primitive_test {
+        ($module:ident, $ty:ty, $value:expr, $json:literal, $toml:literal) => {
+            mod $module {
+                use super::*;
+
+                #[test]
+                fn json_serializes_value() {
+                    assert_json_serializes_value::<$ty>($value, $json);
+                }
+
+                #[test]
+                fn json_deserializes_value() {
+                    assert_json_deserializes_value::<$ty>($value, $json);
+                }
+
+                #[test]
+                fn toml_serializes_value() {
+                    assert_toml_serializes_value::<$ty>($value, $toml);
+                }
+
+                #[test]
+                fn toml_deserializes_value() {
+                    assert_toml_deserializes_value::<$ty>($value, $toml);
+                }
+
+                #[test]
+                fn json_serializes_placeholder() {
+                    assert_json_serializes_placeholder::<$ty>();
+                }
+
+                #[test]
+                fn json_deserializes_placeholder() {
+                    assert_json_deserializes_placeholder::<$ty>();
+                }
+
+                #[test]
+                fn toml_serializes_placeholder() {
+                    assert_toml_serializes_placeholder::<$ty>();
+                }
+
+                #[test]
+                fn toml_deserializes_placeholder() {
+                    assert_toml_deserializes_placeholder::<$ty>();
+                }
+            }
+        };
+    }
+
+    primitive_test!(bool_value, bool, true, "true", "value = true\n");
+    primitive_test!(char_value, char, 'x', r#""x""#, "value = \"x\"\n");
+    primitive_test!(i8_value, i8, -8, "-8", "value = -8\n");
+    primitive_test!(i16_value, i16, -16, "-16", "value = -16\n");
+    primitive_test!(i32_value, i32, -32, "-32", "value = -32\n");
+    primitive_test!(i64_value, i64, -64, "-64", "value = -64\n");
+    primitive_test!(isize_value, isize, -42, "-42", "value = -42\n");
+    primitive_test!(u8_value, u8, 8, "8", "value = 8\n");
+    primitive_test!(u16_value, u16, 16, "16", "value = 16\n");
+    primitive_test!(u32_value, u32, 32, "32", "value = 32\n");
+    primitive_test!(u64_value, u64, 64, "64", "value = 64\n");
+    primitive_test!(usize_value, usize, 42, "42", "value = 42\n");
+    primitive_test!(f32_value, f32, 1.25, "1.25", "value = 1.25\n");
+    primitive_test!(f64_value, f64, -2.5, "-2.5", "value = -2.5\n");
+
+    mod unit_value {
+        use super::*;
+
+        #[test]
+        fn json_serializes_value() {
+            assert_json_serializes_value::<()>((), "null");
+        }
+
+        #[test]
+        fn json_deserializes_value() {
+            assert_json_deserializes_value::<()>((), "null");
+        }
+
+        #[test]
+        fn json_serializes_placeholder() {
+            assert_json_serializes_placeholder::<()>();
+        }
+
+        #[test]
+        fn json_deserializes_placeholder() {
+            assert_json_deserializes_placeholder::<()>();
+        }
+
+        #[test]
+        fn toml_serializes_placeholder() {
+            assert_toml_serializes_placeholder::<()>();
+        }
+
+        #[test]
+        fn toml_deserializes_placeholder() {
+            assert_toml_deserializes_placeholder::<()>();
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct ExampleStruct {
+        enabled: bool,
+        retries: u16,
+    }
+
+    primitive_test!(
+        struct_value,
+        ExampleStruct,
+        ExampleStruct {
+            enabled: true,
+            retries: 3,
+        },
+        r#"{"enabled":true,"retries":3}"#,
+        r#"[value]
+enabled = true
+retries = 3
+"#
+    );
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum ExampleEnum {
+        Ready,
+        Waiting,
+    }
+
+    primitive_test!(
+        enum_value,
+        ExampleEnum,
+        ExampleEnum::Ready,
+        r#""ready""#,
+        "value = \"ready\"\n"
+    );
+
+    primitive_test!(
+        optional_primitive_some,
+        Option<u16>,
+        Some(16),
+        "16",
+        "value = 16\n"
+    );
+
+    mod optional_primitive_none {
+        use super::*;
+
+        #[test]
+        fn json_serializes_value() {
+            assert_json_serializes_value::<Option<u16>>(None, "null");
+        }
+
+        #[test]
+        fn json_deserializes_value() {
+            assert_json_deserializes_value::<Option<u16>>(None, "null");
+        }
+    }
+
+    mod placeholder_string {
+        use super::*;
+
+        const STRING_VALUE: &str = TestPlaceholder::TEXT;
+        type TestString = StringWithPlaceholder<TestPlaceholder>;
+
+        fn value() -> TestString {
+            WithPlaceholder::Value(NonPlaceHolderString(STRING_VALUE.to_owned()))
+        }
+
+        fn assert_json_serializes_value() {
+            let value = Outer { value: value() };
+            let expected_json = format!(r#"{{"value":"{STRING_VALUE}"}}"#);
+
+            let json = serde_json::to_string(&value).unwrap();
+            assert_eq!(json, expected_json);
+
+            let round_trip: Outer<TestString> = serde_json::from_str(&json).unwrap();
+            assert_eq!(round_trip, value);
+        }
+
+        fn assert_json_deserializes_value() {
+            let expected = Outer { value: value() };
+            let json = format!(r#"{{"value":"{STRING_VALUE}"}}"#);
+
+            let deserialized: Outer<TestString> = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, expected);
+
+            let round_trip = serde_json::to_string(&deserialized).unwrap();
+            assert_eq!(round_trip, json);
+        }
+
+        fn assert_toml_serializes_value() {
+            let value = Outer { value: value() };
+            let expected_toml = format!(
+                r#"value = "{STRING_VALUE}"
+"#
+            );
+
+            let toml = toml::to_string(&value).unwrap();
+            assert_eq!(toml, expected_toml);
+
+            let round_trip: Outer<TestString> = toml::from_str(&toml).unwrap();
+            assert_eq!(round_trip, value);
+        }
+
+        fn assert_toml_deserializes_value() {
+            let expected = Outer { value: value() };
+            let toml = format!(
+                r#"value = "{STRING_VALUE}"
+"#
+            );
+
+            let deserialized: Outer<TestString> = toml::from_str(&toml).unwrap();
+            assert_eq!(deserialized, expected);
+
+            let round_trip = toml::to_string(&deserialized).unwrap();
+            assert_eq!(round_trip, toml);
+        }
+
+        #[test]
+        fn json_serializes_value() {
+            assert_json_serializes_value();
+        }
+
+        #[test]
+        fn json_deserializes_value() {
+            assert_json_deserializes_value();
+        }
+
+        #[test]
+        fn toml_serializes_value() {
+            assert_toml_serializes_value();
+        }
+
+        #[test]
+        fn toml_deserializes_value() {
+            assert_toml_deserializes_value();
+        }
+
+        #[test]
+        fn json_serializes_placeholder() {
+            super::assert_json_serializes_placeholder::<NonPlaceHolderString>();
+        }
+
+        #[test]
+        fn json_deserializes_placeholder() {
+            super::assert_json_deserializes_placeholder::<NonPlaceHolderString>();
+        }
+
+        #[test]
+        fn toml_serializes_placeholder() {
+            super::assert_toml_serializes_placeholder::<NonPlaceHolderString>();
+        }
+
+        #[test]
+        fn toml_deserializes_placeholder() {
+            super::assert_toml_deserializes_placeholder::<NonPlaceHolderString>();
+        }
+
+        #[test]
+        fn json_rejects_different_bracketed_placeholder() {
+            let json = r#"{"value":"<OTHER_PLACEHOLDER>"}"#;
+
+            assert!(serde_json::from_str::<Outer<TestString>>(json).is_err());
+        }
+
+        #[test]
+        fn toml_rejects_different_bracketed_placeholder() {
+            let toml = r#"value = "<OTHER_PLACEHOLDER>"
+"#;
+
+            assert!(toml::from_str::<Outer<TestString>>(toml).is_err());
+        }
+    }
+}

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -61,7 +61,7 @@ pub struct Config {
     /// Org registry keyed by organization ID, in config-file order.
     #[serde(default)]
     pub orgs: IndexMap<Uuid, OrgConfig>,
-    /// Edge-side names for organizations.
+    /// User-facing names for organizations.
     #[serde(default)]
     pub aliases: Aliases,
     /// Registered YubiKey devices, shared across organizations. Absent from
@@ -80,7 +80,7 @@ pub struct Config {
     pub extra: toml::Table,
 }
 
-/// Edge-side names for UUID-identified resources.
+/// User-facing names for UUID-identified resources.
 ///
 /// The one serialized alias surface: a name maps to exactly one ID by map
 /// construction, and every mutation goes through these methods. Nothing in
@@ -465,6 +465,7 @@ mod disk {
     }
 
     pub(super) mod v0 {
+        use indexmap::IndexMap;
         use serde::Deserialize;
         use std::collections::HashMap;
         use uuid::Uuid;
@@ -475,8 +476,10 @@ mod disk {
         pub(super) struct Config {
             #[serde(default)]
             pub(super) active_org: Option<String>,
+            /// File order is preserved: the duplicate-organization merge keeps
+            /// the first profile in file order, for v0 exactly as for v1.
             #[serde(default)]
-            pub(super) orgs: HashMap<String, toml::Table>,
+            pub(super) orgs: IndexMap<String, toml::Table>,
             #[serde(default)]
             pub(super) last_created_app_id: HashMap<String, Uuid>,
             #[serde(default)]
@@ -1175,6 +1178,8 @@ mod tests {
 
     const ORG_1: Uuid = Uuid::from_u128(1);
     const ORG_2: Uuid = Uuid::from_u128(2);
+    const OPERATOR_ID: Uuid = Uuid::from_u128(0x123);
+    const APP_ID: Uuid = Uuid::from_u128(0x321);
 
     fn test_org(api_base_url: &str, dir: &Path) -> OrgConfig {
         OrgConfig {
@@ -1332,6 +1337,261 @@ api_base_url = "https://b.example"
         assert_eq!(config.aliases.resolve("alias-a").unwrap().id(), ORG_1);
         assert_eq!(config.aliases.resolve("alias-b").unwrap().id(), ORG_1);
         assert_eq!(config.active_org, Some(ORG_1));
+    }
+
+    #[tokio::test]
+    async fn migrates_v1_to_v2_eagerly_with_backup_lifecycle() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            format!(
+                r#"
+version = 1
+active_org = "prod"
+future_root = "keep-root"
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+future_org = 42
+
+[last_created_app_id]
+prod = "{APP_ID}"
+
+[last_operator_ids]
+prod = ["{OPERATOR_ID}"]
+"#
+            ),
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        // Registry and side maps re-key from alias to organization ID, and
+        // unknown fields survive at both levels.
+        assert_eq!(config.aliases.resolve("prod").unwrap().id(), ORG_1);
+        assert_eq!(config.active_org, Some(ORG_1));
+        assert_eq!(config.last_created_app_id[&ORG_1], APP_ID);
+        assert_eq!(config.last_operator_ids[&ORG_1], vec![OPERATOR_ID]);
+        assert_eq!(
+            config.orgs[&ORG_1].extra["future_org"],
+            toml::Value::Integer(42)
+        );
+        assert_eq!(
+            config.extra["future_root"],
+            toml::Value::String("keep-root".into())
+        );
+
+        // Eagerly rewritten: the file on disk is v2 and the backup is gone.
+        let saved = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(saved.contains("version = 2"), "{saved}");
+        assert!(!backup_file_path(&path).exists());
+
+        let reloaded = Config::load_from_path(&path).await.unwrap();
+        assert_eq!(reloaded, config);
+    }
+
+    /// The fence blocks even when the config file itself already carries the
+    /// migrated schema: a crash between writing the new file and removing
+    /// the backup must surface, not be silently absorbed.
+    #[tokio::test]
+    async fn an_existing_backup_blocks_even_an_already_migrated_config() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+
+        let mut config = Config::default();
+        config
+            .add_org(
+                ORG_1,
+                API_BASE_URL_PROD.to_string(),
+                NewOrgOperator::LocalKeyFile,
+            )
+            .unwrap();
+        config.save_to_path(&path).await.unwrap();
+        tokio::fs::write(backup_file_path(&path), V0_CONFIG)
+            .await
+            .unwrap();
+
+        let error = Config::load_from_path(&path)
+            .await
+            .expect_err("backup must block");
+
+        assert!(
+            error.to_string().contains("interrupted config migration"),
+            "{error}"
+        );
+    }
+
+    /// Deleting the backup — the manual fix for a crash after the migrated
+    /// file was written — unblocks loading with the migration intact.
+    #[tokio::test]
+    async fn removing_the_backup_recovers_the_post_write_crash_window() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(&path, V0_CONFIG).await.unwrap();
+        let migrated = Config::load_from_path(&path).await.unwrap();
+
+        // Recreate the crash window: the migrated file was written but the
+        // process died before the backup was removed.
+        tokio::fs::write(backup_file_path(&path), V0_CONFIG)
+            .await
+            .unwrap();
+        Config::load_from_path(&path)
+            .await
+            .expect_err("fence engaged");
+
+        tokio::fs::remove_file(backup_file_path(&path))
+            .await
+            .unwrap();
+
+        assert_eq!(Config::load_from_path(&path).await.unwrap(), migrated);
+    }
+
+    /// Restoring the backup over the config path — the manual fix for a
+    /// crash between parking the original and writing the new file — re-runs
+    /// the migration cleanly.
+    #[tokio::test]
+    async fn restoring_the_backup_recovers_the_pre_write_crash_window() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        // The crash window: original parked at the backup path, no config.
+        tokio::fs::write(backup_file_path(&path), V0_CONFIG)
+            .await
+            .unwrap();
+        Config::load_from_path(&path)
+            .await
+            .expect_err("fence engaged");
+
+        tokio::fs::rename(backup_file_path(&path), &path)
+            .await
+            .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.active_org, Some(ORG_1));
+        assert!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .unwrap()
+                .contains("version = 2")
+        );
+        assert!(!backup_file_path(&path).exists());
+    }
+
+    /// v0 kept its organizations in file order too: a duplicated
+    /// organization ID merges to the first profile in file order, exactly as
+    /// it does for v1, not to a hash-ordered arbitrary one.
+    #[tokio::test]
+    async fn v0_duplicate_org_ids_merge_to_the_first_profile_in_file_order() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            r#"
+[orgs.first]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/first/api.json"
+operator_key_path = "/keys/first/operator.json"
+
+[orgs.second]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/second/api.json"
+operator_key_path = "/keys/second/operator.json"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.orgs.len(), 1);
+        assert_eq!(
+            config.orgs[&ORG_1].api_key_path,
+            PathBuf::from("/keys/first/api.json")
+        );
+        // Both names survive as aliases for the kept profile.
+        assert_eq!(config.aliases.resolve("first").unwrap().id(), ORG_1);
+        assert_eq!(config.aliases.resolve("second").unwrap().id(), ORG_1);
+    }
+
+    #[test]
+    fn v0_missing_operator_key_path_names_the_organization() {
+        let error = disk::from_toml(
+            r#"
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+"#,
+        )
+        .map(|_| ())
+        .expect_err("v0 without operator_key_path must fail");
+
+        assert!(
+            format!("{error:#}")
+                .contains("v0 config for organization 'prod' is missing operator_key_path"),
+            "{error:#}"
+        );
+    }
+
+    /// Side-map entries whose alias has no surviving profile are dropped —
+    /// there is no organization ID to re-key them under.
+    #[tokio::test]
+    async fn v1_side_maps_drop_entries_for_unknown_aliases() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            format!(
+                r#"
+version = 1
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+
+[last_created_app_id]
+ghost = "{APP_ID}"
+
+[last_operator_ids]
+prod = ["{OPERATOR_ID}"]
+"#
+            ),
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert!(config.last_created_app_id.is_empty());
+        assert_eq!(config.last_operator_ids[&ORG_1], vec![OPERATOR_ID]);
+    }
+
+    /// An active_org naming an alias with no profile cannot survive the
+    /// re-keying; the migrated config simply has no active organization.
+    #[tokio::test]
+    async fn v1_dangling_active_org_migrates_to_none() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(
+            &path,
+            r#"
+version = 1
+active_org = "ghost"
+
+[orgs.prod]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/api.json"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(config.active_org, None);
+        assert_eq!(config.aliases.resolve("prod").unwrap().id(), ORG_1);
     }
 
     #[tokio::test]

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -71,10 +71,10 @@ pub struct Config {
     pub yubikeys: YubiKeyRegistry,
     /// Last created app ID per organization (for convenience).
     #[serde(default)]
-    pub last_created_app_id: HashMap<Uuid, String>,
+    pub last_created_app_id: HashMap<Uuid, Uuid>,
     /// Last manifest set operator IDs per organization (for convenience).
     #[serde(default)]
-    pub last_operator_ids: HashMap<Uuid, Vec<String>>,
+    pub last_operator_ids: HashMap<Uuid, Vec<Uuid>>,
     /// Unrecognized top-level fields retained across supported config rewrites.
     #[serde(default, flatten)]
     pub extra: toml::Table,
@@ -442,9 +442,9 @@ mod disk {
             #[serde(default)]
             pub(super) yubikeys: YubiKeyRegistry,
             #[serde(default)]
-            pub(super) last_created_app_id: HashMap<String, String>,
+            pub(super) last_created_app_id: HashMap<String, Uuid>,
             #[serde(default)]
-            pub(super) last_operator_ids: HashMap<String, Vec<String>>,
+            pub(super) last_operator_ids: HashMap<String, Vec<Uuid>>,
             #[serde(default, flatten)]
             pub(super) extra: toml::Table,
         }
@@ -467,6 +467,7 @@ mod disk {
     pub(super) mod v0 {
         use serde::Deserialize;
         use std::collections::HashMap;
+        use uuid::Uuid;
 
         /// Legacy top-level schema. Organization tables remain untyped until
         /// migration extracts `operator_key_path` and parses the v1 shape.
@@ -477,9 +478,9 @@ mod disk {
             #[serde(default)]
             pub(super) orgs: HashMap<String, toml::Table>,
             #[serde(default)]
-            pub(super) last_created_app_id: HashMap<String, String>,
+            pub(super) last_created_app_id: HashMap<String, Uuid>,
             #[serde(default)]
-            pub(super) last_operator_ids: HashMap<String, Vec<String>>,
+            pub(super) last_operator_ids: HashMap<String, Vec<Uuid>>,
             /// Unknown root values are carried forward so a migration does not
             /// discard data owned by another writer.
             #[serde(default, flatten)]
@@ -1133,27 +1134,29 @@ file may be missing or already migrated), keep the right contents at
     }
 
     /// Store the last created app ID for the active org
-    pub fn set_last_app_id(&mut self, app_id: &str) -> Result<()> {
+    pub fn set_last_app_id(&mut self, app_id: Uuid) -> Result<()> {
         let org_id = self.active_org.context("no active organization set")?;
-        self.last_created_app_id.insert(org_id, app_id.to_string());
+        self.last_created_app_id.insert(org_id, app_id);
         Ok(())
     }
 
     /// Get the last created app ID for the active org, if any
-    pub fn get_last_app_id(&self) -> Option<String> {
-        self.last_created_app_id.get(&self.active_org?).cloned()
+    pub fn get_last_app_id(&self) -> Option<Uuid> {
+        self.last_created_app_id.get(&self.active_org?).copied()
     }
 
     /// Store the last manifest set operator IDs for the active org
-    pub fn set_last_operator_ids(&mut self, operator_ids: &[String]) -> Result<()> {
+    pub fn set_last_operator_ids(&mut self, operator_ids: Vec<Uuid>) -> Result<()> {
         let org_id = self.active_org.context("no active organization set")?;
-        self.last_operator_ids.insert(org_id, operator_ids.to_vec());
+        self.last_operator_ids.insert(org_id, operator_ids);
         Ok(())
     }
 
     /// Get the last manifest set operator IDs for the active org
-    pub fn get_last_operator_ids(&self) -> Option<Vec<String>> {
-        self.last_operator_ids.get(&self.active_org?).cloned()
+    pub fn get_last_operator_ids(&self) -> Option<&[Uuid]> {
+        self.last_operator_ids
+            .get(&self.active_org?)
+            .map(Vec::as_slice)
     }
 }
 
@@ -1256,10 +1259,10 @@ operator_key_path = "/keys/operator.json"
 future_org = 42
 
 [last_created_app_id]
-default = "app-123"
+default = "00000000-0000-0000-0000-000000000321"
 
 [last_operator_ids]
-default = ["operator-123"]
+default = ["00000000-0000-0000-0000-000000000123"]
 "#;
 
     #[tokio::test]
@@ -1284,10 +1287,10 @@ default = ["operator-123"]
             config.extra["future_root"],
             toml::Value::String("keep-root".into())
         );
-        assert_eq!(config.last_created_app_id[&ORG_1], "app-123");
+        assert_eq!(config.last_created_app_id[&ORG_1], Uuid::from_u128(0x321));
         assert_eq!(
             config.last_operator_ids[&ORG_1],
-            vec!["operator-123".to_string()]
+            vec![Uuid::from_u128(0x123)]
         );
 
         // Eagerly rewritten: the file on disk is v2 and the backup is gone.

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -716,6 +716,23 @@ impl Config {
         }
     }
 
+    /// Profiles whose key files sit exactly in the legacy alias-keyed default
+    /// layout, in config order — the candidates interactive login migrates to
+    /// the id-keyed layout. A profile whose alias spells its own organization
+    /// ID (the two layouts coincide) is not a candidate.
+    pub(crate) fn legacy_layout_profiles(&self) -> Result<Vec<(String, Uuid)>> {
+        self.orgs
+            .iter()
+            .map(|(alias, org)| {
+                let legacy = legacy_org_dir(alias)?;
+                let migrates =
+                    legacy != default_org_dir(org.id)? && org.has_default_layout_at(&legacy);
+                Ok(migrates.then(|| (alias.clone(), org.id)))
+            })
+            .filter_map(Result::transpose)
+            .collect()
+    }
+
     /// Organization IDs registered under more than one profile, with the
     /// aliases that share them. Groups are sorted by organization ID; the
     /// aliases within a group keep their config order.

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -21,11 +21,13 @@ pub use yubikey::{
 };
 
 use anyhow::{Context, Result, bail};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::convert::Infallible;
 use std::fmt::{self, Display, Formatter};
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use thiserror::Error;
 use tracing::debug;
 use uuid::Uuid;
@@ -49,9 +51,11 @@ pub struct Config {
     /// The currently active organization alias
     #[serde(default)]
     pub active_org: Option<String>,
-    /// Map of org alias -> org config
+    /// Map of org alias -> org config, in config-file order. The order is
+    /// preserved so saves don't churn the file and so "first profile in the
+    /// config" is well-defined.
     #[serde(default)]
-    pub orgs: HashMap<String, OrgConfig>,
+    pub orgs: IndexMap<String, OrgConfig>,
     /// Registered YubiKey devices, shared across organizations. Absent from
     /// disk entirely while empty, so configs predating the registry rewrite
     /// byte-identically.
@@ -75,8 +79,8 @@ mod disk {
         YubiKeyRegistry,
     };
     use anyhow::{Context, Result, bail};
+    use indexmap::IndexMap;
     use serde::Serialize;
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     /// Every supported shape of `tvc.config.toml`.
@@ -193,7 +197,7 @@ mod disk {
             .orgs
             .into_iter()
             .map(|(alias, org)| migrate_v0_org(&alias, org).map(|org| (alias, org)))
-            .collect::<Result<HashMap<_, _>>>()?;
+            .collect::<Result<IndexMap<_, _>>>()?;
 
         Ok(Config {
             active_org: config.active_org,
@@ -360,11 +364,16 @@ pub struct HostedOperatorRecord {
 }
 
 /// Configuration for a single organization.
+///
+/// A profile's alias is the key it is registered under in [`Config::orgs`];
+/// it is deliberately not repeated here so the name cannot diverge from the
+/// registry. Lookups that need both return `(alias, config)` pairs — see
+/// [`Config::matching_profiles`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct OrgConfig {
     /// The Turnkey organization ID
-    pub id: String,
+    pub id: Uuid,
     /// Path to the API key file
     pub api_key_path: PathBuf,
     /// API base URL for this organization
@@ -553,6 +562,35 @@ fn default_api_base_url() -> String {
     API_BASE_URL_PROD.to_string()
 }
 
+/// A user-supplied organization reference, as taken by `--org` flags.
+///
+/// Organization IDs are UUIDs, so anything that parses as one is an ID and
+/// everything else is a profile alias; parsing never fails.
+#[derive(Debug, Clone)]
+pub enum OrgQuery {
+    Id(Uuid),
+    Alias(String),
+}
+
+impl FromStr for OrgQuery {
+    type Err = Infallible;
+
+    fn from_str(query: &str) -> Result<Self, Infallible> {
+        Ok(Uuid::parse_str(query)
+            .map(Self::Id)
+            .unwrap_or_else(|_| Self::Alias(query.to_string())))
+    }
+}
+
+impl Display for OrgQuery {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Id(id) => id.fmt(f),
+            Self::Alias(alias) => alias.fmt(f),
+        }
+    }
+}
+
 /// Returns the base config directory: `~/.config/turnkey/`
 pub fn config_dir() -> Result<PathBuf> {
     let home = std::env::var("HOME").context("HOME environment variable not set")?;
@@ -629,26 +667,43 @@ impl Config {
         self.orgs.get(alias).map(|config| (alias, config))
     }
 
-    /// Organization IDs registered under more than one alias, with the
-    /// aliases that share them. Sorted by organization ID and by alias so
-    /// callers report and prompt in a stable order.
-    pub fn duplicated_org_ids(&self) -> Vec<(String, Vec<String>)> {
-        let mut groups: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-
-        for (alias, org) in &self.orgs {
-            groups.entry(&org.id).or_default().push(alias);
+    /// Every configured profile matching an org query, in config order.
+    ///
+    /// An alias query names at most one profile; an organization-ID query
+    /// returns every profile registered for that organization.
+    pub fn matching_profiles(&self, query: &OrgQuery) -> Vec<(&str, &OrgConfig)> {
+        match query {
+            OrgQuery::Alias(alias) => self
+                .orgs
+                .get_key_value(alias)
+                .map(|(alias, org)| (alias.as_str(), org))
+                .into_iter()
+                .collect(),
+            OrgQuery::Id(id) => self
+                .orgs
+                .iter()
+                .filter(|(_, org)| org.id == *id)
+                .map(|(alias, org)| (alias.as_str(), org))
+                .collect(),
         }
+    }
 
-        groups
+    /// Organization IDs registered under more than one profile, with the
+    /// aliases that share them. Groups are sorted by organization ID; the
+    /// aliases within a group keep their config order.
+    pub fn duplicated_org_ids(&self) -> Vec<(Uuid, Vec<String>)> {
+        self.orgs
+            .iter()
+            .fold(
+                BTreeMap::<Uuid, Vec<&str>>::new(),
+                |mut groups, (alias, org)| {
+                    groups.entry(org.id).or_default().push(alias);
+                    groups
+                },
+            )
             .into_iter()
             .filter(|(_, aliases)| aliases.len() > 1)
-            .map(|(id, mut aliases)| {
-                aliases.sort_unstable();
-                (
-                    id.to_string(),
-                    aliases.into_iter().map(String::from).collect(),
-                )
-            })
+            .map(|(id, aliases)| (id, aliases.into_iter().map(String::from).collect()))
             .collect()
     }
 
@@ -662,7 +717,7 @@ impl Config {
     pub fn add_org(
         &mut self,
         alias: &str,
-        org_id: String,
+        org_id: Uuid,
         api_base_url: String,
         operator: NewOrgOperator,
     ) -> Result<()> {
@@ -698,7 +753,7 @@ impl Config {
     /// was configured. This only touches the config registry; deleting the
     /// org's key files on disk is the caller's responsibility.
     pub fn remove_org(&mut self, alias: &str) -> Option<OrgConfig> {
-        let removed = self.orgs.remove(alias)?;
+        let removed = self.orgs.shift_remove(alias)?;
         debug!(org_alias = alias, "removing organization config");
         self.last_created_app_id.remove(alias);
         self.last_operator_ids.remove(alias);
@@ -768,7 +823,7 @@ active_org = "default"
 future_root = "keep-root"
 
 [orgs.default]
-id = "org-123"
+id = "11111111-1111-4111-8111-111111111111"
 api_key_path = "/keys/api.json"
 operator_key_path = "/keys/operator.json"
 future_org = 42
@@ -786,7 +841,7 @@ active_org = "default"
 future_root = "keep-root"
 
 [orgs.default]
-id = "org-123"
+id = "11111111-1111-4111-8111-111111111111"
 api_key_path = "/keys/api.json"
 api_base_url = "https://api.turnkey.com"
 default_operator_kind = "local"
@@ -855,7 +910,7 @@ public_key = "{}"
 future_entry = "keep"
 
 [orgs.default]
-id = "org-123"
+id = "11111111-1111-4111-8111-111111111111"
 api_key_path = "/keys/api.json"
 default_operator_kind = "yubikey"
 
@@ -921,7 +976,7 @@ serial = "1C95C1F"
 version = 1
 
 [orgs.default]
-id = "org-123"
+id = "11111111-1111-4111-8111-111111111111"
 api_key_path = "/keys/api.json"
 
 [[orgs.default.operators]]
@@ -941,7 +996,7 @@ serial = "01c95c1f"
     }
     fn yubikey_org(serials: &[u32]) -> OrgConfig {
         OrgConfig {
-            id: "org-123".to_string(),
+            id: Uuid::from_u128(0x123),
             api_key_path: PathBuf::from("/keys/api.json"),
             api_base_url: default_api_base_url(),
             default_operator_kind: OperatorKind::Yubikey,
@@ -1058,15 +1113,19 @@ serial = "01c95c1f"
         assert_eq!(yubikey.serial, YubiKeySerial::from(0xdead_beef));
     }
 
-    fn config_with_org_entries(entries: &[(&str, &str)]) -> Config {
+    const ORG_1: Uuid = Uuid::from_u128(1);
+    const ORG_2: Uuid = Uuid::from_u128(2);
+    const ORG_3: Uuid = Uuid::from_u128(3);
+
+    fn config_with_org_entries<'a>(entries: impl IntoIterator<Item = (&'a str, Uuid)>) -> Config {
         Config {
             orgs: entries
-                .iter()
+                .into_iter()
                 .map(|(alias, org_id)| {
                     (
                         alias.to_string(),
                         OrgConfig {
-                            id: org_id.to_string(),
+                            id: org_id,
                             api_key_path: PathBuf::from("api_key.json"),
                             api_base_url: API_BASE_URL_PROD.to_string(),
                             default_operator_kind: OperatorKind::Local,
@@ -1082,27 +1141,49 @@ serial = "01c95c1f"
 
     #[test]
     fn duplicated_org_ids_ignores_unique_ids() {
-        let config = config_with_org_entries(&[("a", "org-1"), ("b", "org-2")]);
+        let config = config_with_org_entries([("a", ORG_1), ("b", ORG_2)]);
 
         assert_eq!(config.duplicated_org_ids(), Vec::new());
     }
 
     #[test]
-    fn duplicated_org_ids_groups_and_sorts() {
-        let config = config_with_org_entries(&[
-            ("c", "org-2"),
-            ("b", "org-1"),
-            ("a", "org-2"),
-            ("e", "org-1"),
-            ("d", "org-3"),
+    fn duplicated_org_ids_groups_in_config_order() {
+        let config = config_with_org_entries([
+            ("c", ORG_2),
+            ("b", ORG_1),
+            ("a", ORG_2),
+            ("e", ORG_1),
+            ("d", ORG_3),
         ]);
 
         assert_eq!(
             config.duplicated_org_ids(),
             vec![
-                ("org-1".to_string(), vec!["b".to_string(), "e".to_string()]),
-                ("org-2".to_string(), vec!["a".to_string(), "c".to_string()]),
+                (ORG_1, vec!["b".to_string(), "e".to_string()]),
+                (ORG_2, vec!["c".to_string(), "a".to_string()]),
             ]
+        );
+    }
+
+    #[test]
+    fn matching_profiles_prefers_alias_over_id_lookup() {
+        let config = config_with_org_entries([("a", ORG_1), ("b", ORG_1)]);
+
+        let by_alias = config.matching_profiles(&OrgQuery::Alias("b".to_string()));
+        assert_eq!(by_alias.len(), 1);
+        assert_eq!(by_alias[0].0, "b");
+
+        let by_id = config
+            .matching_profiles(&OrgQuery::Id(ORG_1))
+            .into_iter()
+            .map(|(alias, _)| alias)
+            .collect::<Vec<_>>();
+        assert_eq!(by_id, ["a", "b"]);
+
+        assert!(
+            config
+                .matching_profiles(&OrgQuery::Alias("missing".to_string()))
+                .is_empty()
         );
     }
 
@@ -1112,7 +1193,7 @@ serial = "01c95c1f"
         config
             .add_org(
                 "default",
-                "org-123".to_string(),
+                Uuid::from_u128(0x123),
                 API_BASE_URL_PROD.to_string(),
                 NewOrgOperator::Yubikey(YubiKeySerial::from(0x01c9_5c1f)),
             )

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -2,10 +2,13 @@
 //!
 //! Config files are stored at `~/.config/turnkey/`:
 //! - `tvc.config.toml` - Main config with org registry, active org, and key paths
-//! - `orgs/<alias>/api_key.json` - Default location for API keys
-//! - `orgs/<alias>/operator.json` - Default location for operator keys
+//! - `orgs/<org-id>/api_key.json` - Default location for API keys
+//! - `orgs/<org-id>/operator.json` - Default location for operator keys
 //!
 //! Key paths are stored in the config so users can customize storage locations.
+//! Directories keyed by the legacy `orgs/<alias>/` layout remain readable —
+//! paths are data, not schema — and interactive login migrates them to the
+//! id-keyed layout.
 
 mod api_key;
 mod qos_operator_key;
@@ -465,6 +468,24 @@ impl OrgConfig {
         }
     }
 
+    /// Whether this profile's key files sit exactly in `dir` under the
+    /// default file names — i.e. `dir` is a default-layout directory the
+    /// profile owns. A profile with no local operators only needs its API key
+    /// there.
+    pub(crate) fn has_default_layout_at(&self, dir: &Path) -> bool {
+        let operator_key = dir.join(OPERATOR_KEY_FILE);
+
+        self.api_key_path == dir.join(API_KEY_FILE)
+            && self
+                .operators
+                .iter()
+                .filter_map(|operator| match &operator.kind {
+                    OperatorRecordKind::Local(local) => Some(&local.key_path),
+                    _ => None,
+                })
+                .all(|key_path| *key_path == operator_key)
+    }
+
     /// The hosted operator registry entries, each with its kind-specific
     /// record, in config order.
     pub(crate) fn hosted_operators(&self) -> impl Iterator<Item = (&str, &HostedOperatorRecord)> {
@@ -607,19 +628,26 @@ pub fn orgs_dir() -> Result<PathBuf> {
     Ok(config_dir()?.join(ORGS_DIR))
 }
 
-/// Returns the default directory for a specific org: `~/.config/turnkey/orgs/<alias>/`
-pub fn default_org_dir(alias: &str) -> Result<PathBuf> {
-    Ok(orgs_dir()?.join(alias))
+/// Returns the default directory for a specific org: `~/.config/turnkey/orgs/<org-id>/`
+pub fn default_org_dir(org_id: Uuid) -> Result<PathBuf> {
+    Ok(orgs_dir()?.join(org_id.to_string()))
 }
 
 /// Returns the default API key path for an org
-pub fn default_api_key_path(alias: &str) -> Result<PathBuf> {
-    Ok(default_org_dir(alias)?.join(API_KEY_FILE))
+pub fn default_api_key_path(org_id: Uuid) -> Result<PathBuf> {
+    Ok(default_org_dir(org_id)?.join(API_KEY_FILE))
 }
 
 /// Returns the default operator key path for an org
-pub fn default_operator_key_path(alias: &str) -> Result<PathBuf> {
-    Ok(default_org_dir(alias)?.join(OPERATOR_KEY_FILE))
+pub fn default_operator_key_path(org_id: Uuid) -> Result<PathBuf> {
+    Ok(default_org_dir(org_id)?.join(OPERATOR_KEY_FILE))
+}
+
+/// The legacy default directory for a profile: `~/.config/turnkey/orgs/<alias>/`.
+/// Never used for new profiles; still recognized so deletion cleans it up and
+/// interactive login can migrate it to the id-keyed layout.
+pub(crate) fn legacy_org_dir(alias: &str) -> Result<PathBuf> {
+    Ok(orgs_dir()?.join(alias))
 }
 
 impl Config {
@@ -726,7 +754,7 @@ impl Config {
         let (default_operator_kind, operators) = match operator {
             NewOrgOperator::LocalKeyFile => (
                 OperatorKind::Local,
-                vec![OperatorRecord::local(default_operator_key_path(alias)?)],
+                vec![OperatorRecord::local(default_operator_key_path(org_id)?)],
             ),
             NewOrgOperator::Yubikey(serial) => {
                 (OperatorKind::Yubikey, vec![OperatorRecord::yubikey(serial)])
@@ -735,7 +763,7 @@ impl Config {
 
         let org_config = OrgConfig {
             id: org_id,
-            api_key_path: default_api_key_path(alias)?,
+            api_key_path: default_api_key_path(org_id)?,
             api_base_url,
             default_operator_kind,
             operators,
@@ -1163,6 +1191,36 @@ serial = "01c95c1f"
                 (ORG_2, vec!["c".to_string(), "a".to_string()]),
             ]
         );
+    }
+
+    #[test]
+    fn has_default_layout_at_requires_both_default_file_names() {
+        let dir = Path::new("/keys/org");
+        let org = OrgConfig {
+            id: ORG_1,
+            api_key_path: dir.join("api_key.json"),
+            api_base_url: API_BASE_URL_PROD.to_string(),
+            default_operator_kind: OperatorKind::Local,
+            operators: vec![OperatorRecord::local(dir.join("operator.json"))],
+            extra: toml::Table::new(),
+        };
+
+        assert!(org.has_default_layout_at(dir));
+        assert!(!org.has_default_layout_at(Path::new("/keys/other")));
+
+        let custom_operator = OrgConfig {
+            operators: vec![OperatorRecord::local(PathBuf::from(
+                "/elsewhere/operator.json",
+            ))],
+            ..org.clone()
+        };
+        assert!(!custom_operator.has_default_layout_at(dir));
+
+        let custom_api_key = OrgConfig {
+            api_key_path: PathBuf::from("/elsewhere/api_key.json"),
+            ..org
+        };
+        assert!(!custom_api_key.has_default_layout_at(dir));
     }
 
     #[test]

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -27,7 +27,8 @@ use anyhow::{Context, Result, bail};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap},
+    borrow::Borrow,
+    collections::HashMap,
     convert::Infallible,
     fmt::{self, Display, Formatter},
     path::{Path, PathBuf},
@@ -42,58 +43,172 @@ pub const CONFIG_FILE: &str = "tvc.config.toml";
 const ORGS_DIR: &str = "orgs";
 const API_KEY_FILE: &str = "api_key.json";
 const OPERATOR_KEY_FILE: &str = "operator.json";
-const CONFIG_VERSION: u16 = 1;
+const CONFIG_VERSION: u16 = 2;
 const DEFAULT_OPERATOR_NAME: &str = "default";
 
-/// Current in-memory TVC configuration.
+/// Current in-memory TVC configuration (the v2 disk schema).
 ///
-/// Disk schemas are versioned separately below. Loading a legacy v0 config
-/// converts it to this model without writing it back; the next existing save
-/// point persists it as v1.
+/// Older disk schemas are migrated eagerly at load: the original file is
+/// renamed to `tvc.config.toml.backup`, the migrated config is written, and
+/// only then is the backup removed, so a crash at any point leaves either the
+/// old file or the backup intact.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Config {
-    /// The currently active organization alias
+    /// The currently active organization.
     #[serde(default)]
-    pub active_org: Option<String>,
-    /// Map of org alias -> org config, in config-file order. The order is
-    /// preserved so saves don't churn the file and so "first profile in the
-    /// config" is well-defined.
+    pub active_org: Option<Uuid>,
+    /// Org registry keyed by organization ID, in config-file order.
     #[serde(default)]
-    pub orgs: IndexMap<String, OrgConfig>,
+    pub orgs: IndexMap<Uuid, OrgConfig>,
+    /// Edge-side names for organizations.
+    #[serde(default)]
+    pub aliases: Aliases,
     /// Registered YubiKey devices, shared across organizations. Absent from
     /// disk entirely while empty, so configs predating the registry rewrite
     /// byte-identically.
     #[serde(default, skip_serializing_if = "YubiKeyRegistry::is_empty")]
     pub yubikeys: YubiKeyRegistry,
-    /// Map of org alias -> last created app ID (for convenience)
+    /// Last created app ID per organization (for convenience).
     #[serde(default)]
-    pub last_created_app_id: HashMap<String, String>,
-    /// Map of org alias -> last manifest set operator IDs (for convenience)
+    pub last_created_app_id: HashMap<Uuid, String>,
+    /// Last manifest set operator IDs per organization (for convenience).
     #[serde(default)]
-    pub last_operator_ids: HashMap<String, Vec<String>>,
+    pub last_operator_ids: HashMap<Uuid, Vec<String>>,
     /// Unrecognized top-level fields retained across supported config rewrites.
     #[serde(default, flatten)]
     pub extra: toml::Table,
 }
 
+/// Edge-side names for UUID-identified resources.
+///
+/// The one serialized alias surface: a name maps to exactly one ID by map
+/// construction, and every mutation goes through these methods. Nothing in
+/// here is org-specific, so future resource aliases (apps, deployments) can
+/// reuse the shape unchanged.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct Aliases(IndexMap<String, Uuid>);
+
+impl Aliases {
+    /// Resolve a name, remembering it for output echoing.
+    pub fn resolve(&self, name: &str) -> Option<Resolved<'_>> {
+        self.0.get_key_value(name).map(|(name, id)| Resolved {
+            name: Some(name.as_str()),
+            id: *id,
+        })
+    }
+
+    /// Names bound to `id`, in config-file order.
+    pub fn names_of(&self, id: Uuid) -> impl Iterator<Item = &str> {
+        self.0
+            .iter()
+            .filter(move |(_, bound)| **bound == id)
+            .map(|(name, _)| name.as_str())
+    }
+
+    /// Bind `name` to `id`, returning the ID it previously pointed at.
+    pub fn bind(&mut self, name: String, id: Uuid) -> Option<Uuid> {
+        self.0.insert(name, id)
+    }
+
+    /// Drop every name bound to `id`, returning the removed names in
+    /// config-file order.
+    pub fn unbind_all(&mut self, id: Uuid) -> Vec<String> {
+        let removed = self.names_of(id).map(str::to_string).collect();
+        self.0.retain(|_, bound| *bound != id);
+        removed
+    }
+
+    /// All bindings, in config-file order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, Uuid)> {
+        self.0.iter().map(|(name, id)| (name.as_str(), *id))
+    }
+}
+
+/// A resolved org reference that remembers how the user named it, so output
+/// echoes the input: alias in -> alias out, UUID in -> UUID out.
+///
+/// Derefs to the [`Uuid`], so it drops into every ID-keyed lookup unchanged.
+#[derive(Debug, Clone, Copy)]
+pub struct Resolved<'a> {
+    name: Option<&'a str>,
+    id: Uuid,
+}
+
+impl Resolved<'_> {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// The name the user typed, when they typed one.
+    pub fn name(&self) -> Option<&str> {
+        self.name
+    }
+}
+
+impl From<Uuid> for Resolved<'static> {
+    fn from(id: Uuid) -> Self {
+        Self { name: None, id }
+    }
+}
+
+impl std::ops::Deref for Resolved<'_> {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Uuid {
+        &self.id
+    }
+}
+
+impl Borrow<Uuid> for Resolved<'_> {
+    fn borrow(&self) -> &Uuid {
+        &self.id
+    }
+}
+
+impl Display for Resolved<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.name {
+            Some(name) => name.fmt(f),
+            None => self.id.fmt(f),
+        }
+    }
+}
+
 /// Versioned on-disk schemas and migrations into the current runtime model.
 mod disk {
     use super::{
-        CONFIG_VERSION, Config, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
-        YubiKeyRegistry,
+        Aliases, CONFIG_VERSION, Config, OperatorKind, OperatorRecord, OperatorRecordKind,
+        OrgConfig,
     };
     use anyhow::{Context, Result, bail};
     use indexmap::IndexMap;
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use std::path::PathBuf;
+    use uuid::Uuid;
+
+    /// A parsed config plus how it got here, so the load path knows whether
+    /// an eager write-back (with its backup fence) is required.
+    pub(super) enum Loaded {
+        Current(Config),
+        Migrated {
+            config: Config,
+            /// Human-facing notes about lossy migration decisions
+            /// (e.g. merged duplicate profiles).
+            notes: Vec<String>,
+        },
+    }
 
     /// Every supported shape of `tvc.config.toml`.
     enum DiskConfig {
         /// The legacy, unversioned config schema.
         V0(v0::Config),
-        /// The current config schema, identified by `version = 1` on disk.
-        V1(Config),
+        /// The alias-keyed schema, identified by `version = 1` on disk.
+        V1(v1::Config),
+        /// The current schema, identified by `version = 2` on disk.
+        V2(Config),
     }
 
     impl DiskConfig {
@@ -102,17 +217,32 @@ mod disk {
         fn from_toml(content: &str) -> Result<Self> {
             let mut table: toml::Table =
                 toml::from_str(content).context("failed to parse config TOML")?;
-            let header = ConfigVersionHeader::take_from(&mut table)?;
+
+            // The version marker is removed before deserializing a schema
+            // payload so it cannot be captured as an unknown field in
+            // `Config::extra`.
+            let version = table
+                .remove("version")
+                .map(|value| {
+                    u16::deserialize(value)
+                        .context("config version must be an unsigned 16-bit integer")
+                })
+                .transpose()?;
+
             let config = toml::Value::Table(table);
 
-            match header.version {
+            match version {
                 None => config
                     .try_into()
                     .map(Self::V0)
                     .context("failed to parse v0 config"),
+                Some(1) => config
+                    .try_into()
+                    .map(Self::V1)
+                    .context("failed to parse v1 config"),
                 Some(CONFIG_VERSION) => {
-                    let config = config.try_into().context("failed to parse v1 config")?;
-                    Ok(Self::V1(config))
+                    let config = config.try_into().context("failed to parse v2 config")?;
+                    Ok(Self::V2(config))
                 }
                 Some(version) if version > CONFIG_VERSION => bail!(
                     "config written by a newer tvc (version {version}); this tvc supports through version {CONFIG_VERSION}"
@@ -120,108 +250,172 @@ mod disk {
                 Some(version) => bail!("unsupported tvc config version {version}"),
             }
         }
+    }
 
-        /// Convert any supported disk schema into the current runtime model.
-        fn into_current(self) -> Result<Config> {
-            let config = match self {
-                Self::V0(config) => migrate_v0(config)?,
-                Self::V1(config) => config,
-            };
+    pub(super) fn from_toml(content: &str) -> Result<Loaded> {
+        let loaded = match DiskConfig::from_toml(content)? {
+            DiskConfig::V0(config) => migrate_v1(migrate_v0(config)?),
+            DiskConfig::V1(config) => migrate_v1(config),
+            DiskConfig::V2(config) => Loaded::Current(config),
+        };
 
-            // An organization operator may only reference a registered
-            // device; rejecting a dangling serial here keeps everything
-            // downstream of the parse free of that state.
-            let dangling = config.orgs.iter().find_map(|(alias, org)| {
-                org.operators
-                    .iter()
-                    .find_map(|operator| match &operator.kind {
-                        OperatorRecordKind::Yubikey(record)
-                            if !config.yubikeys.contains(record.serial) =>
-                        {
-                            Some((alias, &operator.name, record.serial))
-                        }
-                        _ => None,
-                    })
-            });
+        let config = match &loaded {
+            Loaded::Current(config) => config,
+            Loaded::Migrated { config, .. } => config,
+        };
+        validate_yubikey_references(config)?;
 
-            if let Some((alias, name, serial)) = dangling {
-                bail!(
-                    "organization '{alias}' operator '{name}' references YubiKey {serial}, \
-                     which is not in the yubikeys registry; edit tvc.config.toml to add the \
-                     matching [[yubikeys]] entry or remove this operator record"
-                );
-            }
+        Ok(loaded)
+    }
 
-            Ok(config)
+    /// An organization operator may only reference a registered device;
+    /// rejecting a dangling serial here keeps everything downstream of the
+    /// parse free of that state.
+    fn validate_yubikey_references(config: &Config) -> Result<()> {
+        let dangling = config.orgs.iter().find_map(|(org_id, org)| {
+            org.operators
+                .iter()
+                .find_map(|operator| match &operator.kind {
+                    OperatorRecordKind::Yubikey(record)
+                        if !config.yubikeys.contains(record.serial) =>
+                    {
+                        Some((org_id, &operator.name, record.serial))
+                    }
+                    _ => None,
+                })
+        });
+
+        if let Some((org_id, name, serial)) = dangling {
+            bail!(
+                "organization '{}' operator '{name}' references YubiKey {serial}, \
+                 which is not in the yubikeys registry; edit tvc.config.toml to add the \
+                 matching [[yubikeys]] entry or remove this operator record",
+                config.display_name(*org_id)
+            );
         }
+
+        Ok(())
     }
 
-    pub(super) fn from_toml(content: &str) -> Result<Config> {
-        DiskConfig::from_toml(content)?.into_current()
-    }
-
-    /// The version marker is removed before deserializing a schema payload so
-    /// it cannot be captured as an unknown field in `Config::extra`.
-    struct ConfigVersionHeader {
-        version: Option<u16>,
-    }
-
-    impl ConfigVersionHeader {
-        fn take_from(table: &mut toml::Table) -> Result<Self> {
-            let Some(value) = table.remove("version") else {
-                return Ok(Self { version: None });
-            };
-            let version = value
-                .try_into()
-                .context("config version must be an unsigned 16-bit integer")?;
-            Ok(Self {
-                version: Some(version),
-            })
-        }
-    }
-
-    /// Serialization-only v1 envelope. Its private construction guarantees
-    /// that every saved current config is labeled with the current version.
+    /// Serialization-only envelope. Its private construction guarantees that
+    /// every saved config is labeled with the current version.
     #[derive(Serialize)]
-    struct V1Envelope<'a> {
+    struct V2Envelope<'a> {
         version: u16,
         #[serde(flatten)]
         config: &'a Config,
     }
 
     pub(super) fn to_toml(config: &Config) -> Result<String> {
-        toml::to_string_pretty(&V1Envelope {
+        toml::to_string_pretty(&V2Envelope {
             version: CONFIG_VERSION,
             config,
         })
         .context("failed to serialize config")
     }
 
-    fn migrate_v0(config: v0::Config) -> Result<Config> {
+    /// Rekey a v1 config: aliases move to the alias map, orgs and the side
+    /// maps key by organization ID. A v1 organization registered under
+    /// several aliases collapses to one entry — the first profile in file
+    /// order wins — and every alias survives as a name for it; dropped
+    /// profiles are reported in the notes (their key files are left on disk
+    /// untouched).
+    fn migrate_v1(config: v1::Config) -> Loaded {
+        let mut aliases = Aliases::default();
+        let mut orgs: IndexMap<Uuid, OrgConfig> = IndexMap::new();
+        let mut notes = Vec::new();
+
+        for (alias, org) in config.orgs {
+            aliases.bind(alias.clone(), org.id);
+
+            let v1::OrgConfig {
+                id,
+                api_key_path,
+                api_base_url,
+                default_operator_kind,
+                operators,
+                extra,
+            } = org;
+
+            if orgs.contains_key(&id) {
+                // The alias keeps working (it now names the kept profile);
+                // only this profile's settings and key-file registration are
+                // superseded, and its files stay on disk.
+                notes.push(format!(
+                    "merged duplicate profile '{alias}' for organization {id}: the alias now \
+                     names the kept profile; key files at {} were left on disk",
+                    api_key_path.display()
+                ));
+            } else {
+                orgs.insert(
+                    id,
+                    OrgConfig {
+                        api_key_path,
+                        api_base_url,
+                        default_operator_kind,
+                        operators,
+                        extra,
+                    },
+                );
+            }
+        }
+
+        let active_org = config
+            .active_org
+            .and_then(|alias| aliases.resolve(&alias).map(|resolved| resolved.id()));
+
+        fn rekey<V>(
+            map: std::collections::HashMap<String, V>,
+            aliases: &Aliases,
+        ) -> std::collections::HashMap<Uuid, V> {
+            map.into_iter()
+                .filter_map(|(alias, value)| {
+                    aliases
+                        .resolve(&alias)
+                        .map(|resolved| (resolved.id(), value))
+                })
+                .collect()
+        }
+
+        Loaded::Migrated {
+            config: Config {
+                active_org,
+                orgs,
+                yubikeys: config.yubikeys,
+                last_created_app_id: rekey(config.last_created_app_id, &aliases),
+                last_operator_ids: rekey(config.last_operator_ids, &aliases),
+                aliases,
+                extra: config.extra,
+            },
+            notes,
+        }
+    }
+
+    fn migrate_v0(config: v0::Config) -> Result<v1::Config> {
         let orgs = config
             .orgs
             .into_iter()
             .map(|(alias, org)| migrate_v0_org(&alias, org).map(|org| (alias, org)))
             .collect::<Result<IndexMap<_, _>>>()?;
 
-        Ok(Config {
+        Ok(v1::Config {
             active_org: config.active_org,
             orgs,
-            yubikeys: YubiKeyRegistry::default(),
+            yubikeys: super::YubiKeyRegistry::default(),
             last_created_app_id: config.last_created_app_id,
             last_operator_ids: config.last_operator_ids,
             extra: config.extra,
         })
     }
 
-    fn migrate_v0_org(alias: &str, mut table: toml::Table) -> Result<OrgConfig> {
+    fn migrate_v0_org(alias: &str, mut table: toml::Table) -> Result<v1::OrgConfig> {
         let operator_key_path = table.remove("operator_key_path").with_context(|| {
             format!("v0 config for organization '{alias}' is missing operator_key_path")
         })?;
         let operator_key_path: PathBuf = operator_key_path.try_into().with_context(|| {
             format!("invalid operator_key_path in v0 config for organization '{alias}'")
         })?;
-        let mut org: OrgConfig = toml::Value::Table(table)
+        let mut org: v1::OrgConfig = toml::Value::Table(table)
             .try_into()
             .with_context(|| format!("failed to migrate v0 config for organization '{alias}'"))?;
 
@@ -230,12 +424,52 @@ mod disk {
         Ok(org)
     }
 
+    /// The alias-keyed v1 schema (read-only: parsed for migration).
+    mod v1 {
+        use super::super::{OperatorKind, OperatorRecord, YubiKeyRegistry};
+        use indexmap::IndexMap;
+        use serde::Deserialize;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        use uuid::Uuid;
+
+        #[derive(Deserialize)]
+        pub(super) struct Config {
+            #[serde(default)]
+            pub(super) active_org: Option<String>,
+            #[serde(default)]
+            pub(super) orgs: IndexMap<String, OrgConfig>,
+            #[serde(default)]
+            pub(super) yubikeys: YubiKeyRegistry,
+            #[serde(default)]
+            pub(super) last_created_app_id: HashMap<String, String>,
+            #[serde(default)]
+            pub(super) last_operator_ids: HashMap<String, Vec<String>>,
+            #[serde(default, flatten)]
+            pub(super) extra: toml::Table,
+        }
+
+        #[derive(Deserialize)]
+        pub(super) struct OrgConfig {
+            pub(super) id: Uuid,
+            pub(super) api_key_path: PathBuf,
+            #[serde(default = "super::super::default_api_base_url")]
+            pub(super) api_base_url: String,
+            #[serde(default)]
+            pub(super) default_operator_kind: OperatorKind,
+            #[serde(default)]
+            pub(super) operators: Vec<OperatorRecord>,
+            #[serde(default, flatten)]
+            pub(super) extra: toml::Table,
+        }
+    }
+
     pub(super) mod v0 {
         use serde::Deserialize;
         use std::collections::HashMap;
 
         /// Legacy top-level schema. Organization tables remain untyped until
-        /// migration extracts `operator_key_path` and parses the current shape.
+        /// migration extracts `operator_key_path` and parses the v1 shape.
         #[derive(Deserialize)]
         pub(super) struct Config {
             #[serde(default)]
@@ -246,8 +480,8 @@ mod disk {
             pub(super) last_created_app_id: HashMap<String, String>,
             #[serde(default)]
             pub(super) last_operator_ids: HashMap<String, Vec<String>>,
-            /// Unknown root values are carried into the current config so a
-            /// migration does not discard data owned by another writer.
+            /// Unknown root values are carried forward so a migration does not
+            /// discard data owned by another writer.
             #[serde(default, flatten)]
             pub(super) extra: toml::Table,
         }
@@ -368,17 +602,12 @@ pub struct HostedOperatorRecord {
     pub extra: toml::Table,
 }
 
-/// Configuration for a single organization.
-///
-/// A profile's alias is the key it is registered under in [`Config::orgs`];
-/// it is deliberately not repeated here so the name cannot diverge from the
-/// registry. Lookups that need both return `(alias, config)` pairs — see
-/// [`Config::matching_profiles`].
+/// Configuration for a single organization, keyed by its organization ID in
+/// [`Config::orgs`]; the ID is deliberately not repeated here so identity has
+/// exactly one home. Human names live in [`Config::aliases`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct OrgConfig {
-    /// The Turnkey organization ID
-    pub id: Uuid,
     /// Path to the API key file
     pub api_key_path: PathBuf,
     /// API base URL for this organization
@@ -653,8 +882,98 @@ pub(crate) fn legacy_org_dir(alias: &str) -> Result<PathBuf> {
 }
 
 impl Config {
-    pub fn from_toml(content: &str) -> Result<Self> {
-        disk::from_toml(content)
+    /// Load the config at `path`, or return the default when no file exists.
+    ///
+    /// Older schemas are migrated eagerly behind a backup fence: the original
+    /// file is renamed to `<name>.backup`, the migrated config is written,
+    /// and only after a successful write is the backup removed. An existing
+    /// backup file therefore means a previous migration crashed, and loading
+    /// refuses to proceed until it is resolved manually.
+    pub async fn load_from_path(path: &Path) -> Result<Self> {
+        let backup_path = backup_file_path(path);
+
+        if backup_path.exists() {
+            bail!(
+                r#"found {backup} from an interrupted config migration.
+
+Compare it with {config} (the backup is the pre-migration version; the config
+file may be missing or already migrated), keep the right contents at
+{config}, delete {backup}, and re-run."#,
+                backup = backup_path.display(),
+                config = path.display(),
+            );
+        }
+
+        debug!(config_path = %path.display(), "loading tvc config");
+
+        if !path.exists() {
+            debug!(config_path = %path.display(), "tvc config not found; using defaults");
+            let config = Config::default();
+            config.save_to_path(path).await?;
+            return Ok(config);
+        }
+
+        let content = tokio::fs::read_to_string(path)
+            .await
+            .with_context(|| format!("failed to read config file: {}", path.display()))?;
+        let loaded = disk::from_toml(&content)
+            .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+
+        let config = match loaded {
+            disk::Loaded::Current(config) => config,
+            disk::Loaded::Migrated { config, notes } => {
+                config
+                    .persist_migration(path, &backup_path)
+                    .await
+                    .with_context(|| {
+                        format!("failed to migrate config file: {}", path.display())
+                    })?;
+
+                // One-time migration event with user-relevant, lossy
+                // decisions (merged duplicates, orphaned key files): loading
+                // has no shell handle, tracing defaults to off, and the
+                // stdout contract stays untouched — so stderr directly is
+                // the only channel that reliably reaches the user.
+                #[allow(clippy::print_stderr)]
+                for note in &notes {
+                    eprintln!("config migration: {note}");
+                }
+
+                config
+            }
+        };
+
+        debug!(
+            config_path = %path.display(),
+            active_org = ?config.active_org,
+            org_count = config.orgs.len(),
+            "loaded tvc config"
+        );
+
+        Ok(config)
+    }
+
+    /// The eager-migration backup fence: park the original, write the
+    /// migrated config, and only then remove the original. A crash between
+    /// any two steps leaves the pre-migration contents recoverable at one of
+    /// the two paths, and the backup's presence blocks the next load.
+    async fn persist_migration(&self, path: &Path, backup_path: &Path) -> Result<()> {
+        tokio::fs::rename(path, backup_path)
+            .await
+            .with_context(|| format!("failed to back up config to {}", backup_path.display()))?;
+
+        self.save_to_path(path).await?;
+
+        tokio::fs::remove_file(backup_path).await.with_context(|| {
+            format!(
+                "failed to remove migration backup {}",
+                backup_path.display()
+            )
+        })?;
+
+        debug!(config_path = %path.display(), "eagerly migrated config schema");
+
+        Ok(())
     }
 
     /// Save config to disk
@@ -691,84 +1010,75 @@ impl Config {
         Ok(())
     }
 
+    /// Resolve an org query to a configured organization, remembering the
+    /// typed name for output echoing. `None` covers an unknown alias, an
+    /// unknown ID, and an alias whose organization table is missing.
+    pub fn resolve(&self, query: &OrgQuery) -> Option<(Resolved<'_>, &OrgConfig)> {
+        let resolved = match query {
+            OrgQuery::Alias(name) => self.aliases.resolve(name)?,
+            OrgQuery::Id(id) => Resolved::from(*id),
+        };
+
+        self.orgs.get(&resolved.id()).map(|org| (resolved, org))
+    }
+
+    /// The active organization as a [`Resolved`] reference. The user typed
+    /// nothing to echo, so it is named by its first alias when one exists —
+    /// the human name — and by its ID otherwise.
+    pub fn resolve_active(&self) -> Option<(Resolved<'_>, &OrgConfig)> {
+        let (id, org) = self.active_org_config()?;
+        let name = self.aliases.names_of(id).next();
+        Some((Resolved { name, id }, org))
+    }
+
+    /// The name to show for an organization the user did not name themselves:
+    /// its first alias, else the bare ID.
+    pub fn display_name(&self, id: Uuid) -> String {
+        self.aliases
+            .names_of(id)
+            .next()
+            .map(str::to_string)
+            .unwrap_or_else(|| id.to_string())
+    }
+
     /// Get the active organization config, if any
-    pub fn active_org_config(&self) -> Option<(&String, &OrgConfig)> {
-        let alias = self.active_org.as_ref()?;
-        self.orgs.get(alias).map(|config| (alias, config))
+    pub fn active_org_config(&self) -> Option<(Uuid, &OrgConfig)> {
+        let id = self.active_org?;
+        self.orgs.get(&id).map(|config| (id, config))
     }
 
-    /// Every configured profile matching an org query, in config order.
-    ///
-    /// An alias query names at most one profile; an organization-ID query
-    /// returns every profile registered for that organization.
-    pub fn matching_profiles(&self, query: &OrgQuery) -> Vec<(&str, &OrgConfig)> {
-        match query {
-            OrgQuery::Alias(alias) => self
-                .orgs
-                .get_key_value(alias)
-                .map(|(alias, org)| (alias.as_str(), org))
-                .into_iter()
-                .collect(),
-            OrgQuery::Id(id) => self
-                .orgs
-                .iter()
-                .filter(|(_, org)| org.id == *id)
-                .map(|(alias, org)| (alias.as_str(), org))
-                .collect(),
-        }
-    }
-
-    /// Profiles whose key files sit exactly in the legacy alias-keyed default
-    /// layout, in config order — the candidates interactive login migrates to
-    /// the id-keyed layout. A profile whose alias spells its own organization
-    /// ID (the two layouts coincide) is not a candidate.
+    /// Organizations whose key files sit exactly in the legacy alias-keyed
+    /// default layout, as `(alias, org_id)` pairs in config order — the
+    /// candidates interactive login migrates to the id-keyed layout. A name
+    /// that spells its own organization ID (the two layouts coincide) is not
+    /// a candidate.
     pub(crate) fn legacy_layout_profiles(&self) -> Result<Vec<(String, Uuid)>> {
-        self.orgs
+        self.aliases
             .iter()
-            .map(|(alias, org)| {
-                let legacy = legacy_org_dir(alias)?;
-                let migrates =
-                    legacy != default_org_dir(org.id)? && org.has_default_layout_at(&legacy);
-                Ok(migrates.then(|| (alias.clone(), org.id)))
+            .map(|(name, id)| {
+                let legacy = legacy_org_dir(name)?;
+                let migrates = legacy != default_org_dir(id)?
+                    && self
+                        .orgs
+                        .get(&id)
+                        .is_some_and(|org| org.has_default_layout_at(&legacy));
+                Ok(migrates.then(|| (name.to_string(), id)))
             })
             .filter_map(Result::transpose)
             .collect()
     }
 
-    /// Organization IDs registered under more than one profile, with the
-    /// aliases that share them. Groups are sorted by organization ID; the
-    /// aliases within a group keep their config order.
-    pub fn duplicated_org_ids(&self) -> Vec<(Uuid, Vec<String>)> {
-        self.orgs
-            .iter()
-            .fold(
-                BTreeMap::<Uuid, Vec<&str>>::new(),
-                |mut groups, (alias, org)| {
-                    groups.entry(org.id).or_default().push(alias);
-                    groups
-                },
-            )
-            .into_iter()
-            .filter(|(_, aliases)| aliases.len() > 1)
-            .map(|(id, aliases)| (id, aliases.into_iter().map(String::from).collect()))
-            .collect()
-    }
-
-    /// Add or update an organization with default key paths, starting with
-    /// the given operator backend as its default.
-    ///
-    /// Callers are responsible for ensuring the alias and organization ID are
-    /// not already registered under another profile; the login command
-    /// enforces one profile per organization before constructing new-org
-    /// inputs. An existing entry under the same alias is replaced wholesale.
+    /// Register an organization with default key paths, starting with the
+    /// given operator backend as its default. An existing entry for the same
+    /// organization is replaced wholesale; names are bound separately through
+    /// [`Config::aliases`].
     pub fn add_org(
         &mut self,
-        alias: &str,
         org_id: Uuid,
         api_base_url: String,
         operator: NewOrgOperator,
     ) -> Result<()> {
-        debug!(org_alias = alias, %api_base_url, "adding organization config");
+        debug!(%org_id, %api_base_url, "adding organization config");
 
         let (default_operator_kind, operators) = match operator {
             NewOrgOperator::LocalKeyFile => (
@@ -781,83 +1091,78 @@ impl Config {
         };
 
         let org_config = OrgConfig {
-            id: org_id,
             api_key_path: default_api_key_path(org_id)?,
             api_base_url,
             default_operator_kind,
             operators,
             extra: toml::Table::new(),
         };
-        self.orgs.insert(alias.to_string(), org_config);
+        self.orgs.insert(org_id, org_config);
         Ok(())
     }
 
-    /// Remove an organization from the config, along with the convenience state
-    /// (last app ID, last operator IDs) tracked for it. If the removed org was
-    /// the active one, the active org is cleared.
+    /// Remove an organization: its registry entry, every alias bound to it,
+    /// and the convenience state tracked for it. If it was the active org,
+    /// the active org is cleared.
     ///
-    /// Returns the removed [`OrgConfig`], or `None` if no org with that alias
-    /// was configured. This only touches the config registry; deleting the
-    /// org's key files on disk is the caller's responsibility.
-    pub fn remove_org(&mut self, alias: &str) -> Option<OrgConfig> {
-        let removed = self.orgs.shift_remove(alias)?;
-        debug!(org_alias = alias, "removing organization config");
-        self.last_created_app_id.remove(alias);
-        self.last_operator_ids.remove(alias);
-        if self.active_org.as_deref() == Some(alias) {
+    /// Returns the removed [`OrgConfig`] and the unbound aliases, or `None`
+    /// if the organization is not configured. This only touches the config;
+    /// deleting key files on disk is the caller's responsibility.
+    pub fn remove_org(&mut self, org_id: Uuid) -> Option<(OrgConfig, Vec<String>)> {
+        let removed = self.orgs.shift_remove(&org_id)?;
+        debug!(%org_id, "removing organization config");
+        let unbound = self.aliases.unbind_all(org_id);
+        self.last_created_app_id.remove(&org_id);
+        self.last_operator_ids.remove(&org_id);
+
+        if self.active_org == Some(org_id) {
             self.active_org = None;
         }
-        Some(removed)
+
+        Some((removed, unbound))
     }
 
     /// Set the active organization
-    pub fn set_active_org(&mut self, alias: &str) -> Result<()> {
-        debug!(org_alias = alias, "setting active organization");
-        if !self.orgs.contains_key(alias) {
-            bail!("organization '{}' not found in config", alias);
+    pub fn set_active_org(&mut self, org_id: Uuid) -> Result<()> {
+        debug!(%org_id, "setting active organization");
+        if !self.orgs.contains_key(&org_id) {
+            bail!("organization '{org_id}' not found in config");
         }
-        self.active_org = Some(alias.to_string());
+        self.active_org = Some(org_id);
         Ok(())
-    }
-
-    /// Get list of configured org aliases
-    pub fn org_aliases(&self) -> Vec<&String> {
-        self.orgs.keys().collect()
     }
 
     /// Store the last created app ID for the active org
     pub fn set_last_app_id(&mut self, app_id: &str) -> Result<()> {
-        let alias = self
-            .active_org
-            .as_ref()
-            .context("no active organization set")?;
-        self.last_created_app_id
-            .insert(alias.clone(), app_id.to_string());
+        let org_id = self.active_org.context("no active organization set")?;
+        self.last_created_app_id.insert(org_id, app_id.to_string());
         Ok(())
     }
 
     /// Get the last created app ID for the active org, if any
     pub fn get_last_app_id(&self) -> Option<String> {
-        let alias = self.active_org.as_ref()?;
-        self.last_created_app_id.get(alias).cloned()
+        self.last_created_app_id.get(&self.active_org?).cloned()
     }
 
     /// Store the last manifest set operator IDs for the active org
     pub fn set_last_operator_ids(&mut self, operator_ids: &[String]) -> Result<()> {
-        let alias = self
-            .active_org
-            .as_ref()
-            .context("no active organization set")?;
-        self.last_operator_ids
-            .insert(alias.clone(), operator_ids.to_vec());
+        let org_id = self.active_org.context("no active organization set")?;
+        self.last_operator_ids.insert(org_id, operator_ids.to_vec());
         Ok(())
     }
 
     /// Get the last manifest set operator IDs for the active org
     pub fn get_last_operator_ids(&self) -> Option<Vec<String>> {
-        let alias = self.active_org.as_ref()?;
-        self.last_operator_ids.get(alias).cloned()
+        self.last_operator_ids.get(&self.active_org?).cloned()
     }
+}
+
+/// The eager-migration backup path for a config file:
+/// `tvc.config.toml.backup` next to `tvc.config.toml`.
+fn backup_file_path(config_path: &Path) -> PathBuf {
+    let mut backup = config_path.as_os_str().to_owned();
+    backup.push(".backup");
+    PathBuf::from(backup)
 }
 
 #[cfg(test)]
@@ -865,12 +1170,87 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    const ORG_1: Uuid = Uuid::from_u128(1);
+    const ORG_2: Uuid = Uuid::from_u128(2);
+
+    fn test_org(api_base_url: &str, dir: &Path) -> OrgConfig {
+        OrgConfig {
+            api_key_path: dir.join("api_key.json"),
+            api_base_url: api_base_url.to_string(),
+            default_operator_kind: OperatorKind::Local,
+            operators: vec![OperatorRecord::local(dir.join("operator.json"))],
+            extra: toml::Table::new(),
+        }
+    }
+
+    /// Parse a config that must already be the current schema.
+    fn parse_current(content: &str) -> Result<Config> {
+        match disk::from_toml(content)? {
+            disk::Loaded::Current(config) => Ok(config),
+            disk::Loaded::Migrated { .. } => panic!("fixture must be the current schema"),
+        }
+    }
+
+    #[test]
+    fn aliases_resolve_remembers_the_typed_name() {
+        let mut aliases = Aliases::default();
+        aliases.bind("prod".to_string(), ORG_1);
+
+        let resolved = aliases.resolve("prod").expect("bound name resolves");
+
+        assert_eq!(resolved.id(), ORG_1);
+        assert_eq!(resolved.to_string(), "prod");
+        assert!(aliases.resolve("staging").is_none());
+    }
+
+    #[test]
+    fn resolved_from_an_id_displays_the_id() {
+        let resolved = Resolved::from(ORG_1);
+
+        assert_eq!(resolved.name(), None);
+        assert_eq!(resolved.to_string(), ORG_1.to_string());
+    }
+
+    #[test]
+    fn names_of_lists_synonyms_in_config_order() {
+        let mut aliases = Aliases::default();
+        aliases.bind("prod".to_string(), ORG_1);
+        aliases.bind("staging".to_string(), ORG_2);
+        aliases.bind("production".to_string(), ORG_1);
+
+        let names = aliases.names_of(ORG_1).collect::<Vec<_>>();
+
+        assert_eq!(names, ["prod", "production"]);
+    }
+
+    #[test]
+    fn bind_returns_the_previous_target_and_unbind_all_drops_names() {
+        let mut aliases = Aliases::default();
+        assert_eq!(aliases.bind("prod".to_string(), ORG_1), None);
+        assert_eq!(aliases.bind("prod".to_string(), ORG_2), Some(ORG_1));
+
+        aliases.bind("backup".to_string(), ORG_2);
+
+        assert_eq!(aliases.unbind_all(ORG_2), ["prod", "backup"]);
+        assert_eq!(aliases.names_of(ORG_2).count(), 0);
+    }
+
+    #[test]
+    fn config_resolve_rejects_a_dangling_alias() {
+        let mut config = Config::default();
+        config.aliases.bind("prod".to_string(), ORG_1);
+
+        // The alias points at an organization with no registry entry.
+        let Ok(query) = OrgQuery::from_str("prod");
+        assert!(config.resolve(&query).is_none());
+    }
+
     const V0_CONFIG: &str = r#"
 active_org = "default"
 future_root = "keep-root"
 
 [orgs.default]
-id = "11111111-1111-4111-8111-111111111111"
+id = "00000000-0000-0000-0000-000000000001"
 api_key_path = "/keys/api.json"
 operator_key_path = "/keys/operator.json"
 future_org = 42
@@ -882,86 +1262,197 @@ default = "app-123"
 default = ["operator-123"]
 "#;
 
-    const MIGRATED_V1_CONFIG: &str = r#"
-version = 1
-active_org = "default"
-future_root = "keep-root"
-
-[orgs.default]
-id = "11111111-1111-4111-8111-111111111111"
-api_key_path = "/keys/api.json"
-api_base_url = "https://api.turnkey.com"
-default_operator_kind = "local"
-future_org = 42
-
-[[orgs.default.operators]]
-name = "default"
-kind = "local"
-key_path = "/keys/operator.json"
-
-[last_created_app_id]
-default = "app-123"
-
-[last_operator_ids]
-default = ["operator-123"]
-"#;
-
     #[tokio::test]
-    async fn migrates_v0_in_memory_and_writes_v1_lazily() {
+    async fn migrates_v0_to_v2_eagerly_with_backup_lifecycle() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("tvc.config.toml");
         tokio::fs::write(&path, V0_CONFIG).await.unwrap();
 
-        let content = tokio::fs::read_to_string(&path).await.unwrap();
-        let config = Config::from_toml(&content).unwrap();
-        let original = tokio::fs::read_to_string(&path).await.unwrap();
-        assert_eq!(original, V0_CONFIG);
+        let config = Config::load_from_path(&path).await.unwrap();
 
-        let org = &config.orgs["default"];
-        assert_eq!(org.default_operator_kind, OperatorKind::Local);
-        assert_eq!(org.operators.len(), 1);
-        assert_eq!(org.operators[0].name, DEFAULT_OPERATOR_NAME);
-        let OperatorRecordKind::Local(local) = &org.operators[0].kind else {
-            panic!("migrated operator must be local");
-        };
-        assert_eq!(local.key_path, PathBuf::from("/keys/operator.json"));
+        assert_eq!(config.aliases.resolve("default").unwrap().id(), ORG_1);
+        assert_eq!(config.active_org, Some(ORG_1));
+        assert_eq!(
+            config.orgs[&ORG_1].api_key_path,
+            PathBuf::from("/keys/api.json")
+        );
+        assert_eq!(
+            config.orgs[&ORG_1].extra["future_org"],
+            toml::Value::Integer(42)
+        );
+        assert_eq!(
+            config.extra["future_root"],
+            toml::Value::String("keep-root".into())
+        );
+        assert_eq!(config.last_created_app_id[&ORG_1], "app-123");
+        assert_eq!(
+            config.last_operator_ids[&ORG_1],
+            vec!["operator-123".to_string()]
+        );
+
+        // Eagerly rewritten: the file on disk is v2 and the backup is gone.
+        let saved = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(saved.contains("version = 2"), "{saved}");
+        assert!(!backup_file_path(&path).exists());
+
+        // A second load takes the already-current path and changes nothing.
+        let reloaded = Config::load_from_path(&path).await.unwrap();
+        assert_eq!(reloaded, config);
+    }
+
+    const V1_DUPLICATES: &str = r#"
+version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/a/api.json"
+api_base_url = "https://a.example"
+
+[orgs.alias-b]
+id = "00000000-0000-0000-0000-000000000001"
+api_key_path = "/keys/b/api.json"
+api_base_url = "https://b.example"
+"#;
+
+    #[tokio::test]
+    async fn v1_duplicates_merge_to_the_first_profile_keeping_every_alias() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(&path, V1_DUPLICATES).await.unwrap();
+
+        let config = Config::load_from_path(&path).await.unwrap();
+
+        // The first profile in file order wins; both names survive.
+        assert_eq!(config.orgs.len(), 1);
+        assert_eq!(config.orgs[&ORG_1].api_base_url, "https://a.example");
+        assert_eq!(config.aliases.resolve("alias-a").unwrap().id(), ORG_1);
+        assert_eq!(config.aliases.resolve("alias-b").unwrap().id(), ORG_1);
+        assert_eq!(config.active_org, Some(ORG_1));
+    }
+
+    #[tokio::test]
+    async fn an_existing_backup_blocks_loading() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(&path, V0_CONFIG).await.unwrap();
+        tokio::fs::write(backup_file_path(&path), "old contents")
+            .await
+            .unwrap();
+
+        let error = Config::load_from_path(&path)
+            .await
+            .expect_err("backup file must block the load");
+
+        assert!(
+            error.to_string().contains("interrupted config migration"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_backup_without_a_config_still_blocks_instead_of_defaulting() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+        tokio::fs::write(backup_file_path(&path), "old contents")
+            .await
+            .unwrap();
+
+        let error = Config::load_from_path(&path)
+            .await
+            .expect_err("the user's data is in the backup; a fresh default would hide it");
+
+        assert!(
+            error.to_string().contains("interrupted config migration"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v2_round_trips_without_a_migration() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("tvc.config.toml");
+
+        let mut config = Config::default();
+        config
+            .add_org(
+                ORG_1,
+                API_BASE_URL_PROD.to_string(),
+                NewOrgOperator::LocalKeyFile,
+            )
+            .unwrap();
+        config.aliases.bind("prod".to_string(), ORG_1);
+        config.set_active_org(ORG_1).unwrap();
 
         config.save_to_path(&path).await.unwrap();
-        let saved = tokio::fs::read_to_string(&path).await.unwrap();
-        let actual = disk::from_toml(&saved).unwrap();
-        let expected = disk::from_toml(MIGRATED_V1_CONFIG).unwrap();
-        assert_eq!(actual, expected);
+        let loaded = Config::load_from_path(&path).await.unwrap();
+
+        assert_eq!(loaded, config);
+        assert!(!backup_file_path(&path).exists());
     }
 
     #[test]
-    fn rejects_malformed_version() {
-        let error = disk::from_toml("version = \"one\"").expect_err("malformed version must fail");
+    fn rejects_malformed_and_newer_versions() {
+        let malformed = disk::from_toml("version = \"one\"")
+            .map(|_| ())
+            .expect_err("malformed must fail");
         assert!(
-            error
+            malformed
                 .to_string()
                 .contains("config version must be an unsigned 16-bit integer")
         );
+
+        let newer = disk::from_toml("version = 3")
+            .map(|_| ())
+            .expect_err("newer must fail");
+        assert!(
+            newer.to_string().contains("written by a newer tvc"),
+            "{newer}"
+        );
+    }
+
+    #[test]
+    fn remove_org_unbinds_every_alias_and_clears_active() {
+        let mut config = Config::default();
+        config
+            .add_org(
+                ORG_1,
+                API_BASE_URL_PROD.to_string(),
+                NewOrgOperator::LocalKeyFile,
+            )
+            .unwrap();
+        config.aliases.bind("prod".to_string(), ORG_1);
+        config.aliases.bind("production".to_string(), ORG_1);
+        config.set_active_org(ORG_1).unwrap();
+
+        let (_, unbound) = config.remove_org(ORG_1).expect("org is configured");
+
+        assert_eq!(unbound, ["prod", "production"]);
+        assert_eq!(config.active_org, None);
+        assert!(config.aliases.resolve("prod").is_none());
     }
 
     /// Serials are deliberately non-canonical (uppercase, unpadded) to pin
     /// the parse-then-canonicalize behavior on save.
-    fn v1_yubikey_config() -> String {
+    fn v2_yubikey_config() -> String {
         format!(
             r#"
-version = 1
-active_org = "default"
+version = 2
+active_org = "11111111-1111-4111-8111-111111111111"
+
+[aliases]
+default = "11111111-1111-4111-8111-111111111111"
 
 [[yubikeys]]
 serial = "1C95C1F"
 public_key = "{}"
 future_entry = "keep"
 
-[orgs.default]
-id = "11111111-1111-4111-8111-111111111111"
+[orgs.11111111-1111-4111-8111-111111111111]
 api_key_path = "/keys/api.json"
 default_operator_kind = "yubikey"
 
-[[orgs.default.operators]]
+[[orgs.11111111-1111-4111-8111-111111111111.operators]]
 name = "yubikey"
 kind = "yubikey"
 serial = "1C95C1F"
@@ -972,13 +1463,14 @@ serial = "1C95C1F"
 
     #[test]
     fn round_trips_yubikey_registry_and_operator_records() {
-        let config = disk::from_toml(&v1_yubikey_config()).unwrap();
+        let config = parse_current(&v2_yubikey_config()).unwrap();
 
         let serial = YubiKeySerial::from(0x01c9_5c1f);
         let entry = config.yubikeys.get(serial).unwrap();
         assert_eq!(entry.public_key.to_string(), "07".repeat(130));
 
-        let org = &config.orgs["default"];
+        let org_id: Uuid = "11111111-1111-4111-8111-111111111111".parse().unwrap();
+        let org = &config.orgs[&org_id];
         assert_eq!(org.default_operator_kind, OperatorKind::Yubikey);
         let OperatorRecordKind::Yubikey(record) = &org.operators[0].kind else {
             panic!("operator must be a yubikey record");
@@ -991,12 +1483,12 @@ serial = "1C95C1F"
         assert!(saved.contains("kind = \"yubikey\""));
         assert!(saved.contains("default_operator_kind = \"yubikey\""));
         assert!(saved.contains("future_entry = \"keep\""));
-        assert_eq!(disk::from_toml(&saved).unwrap(), config);
+        assert_eq!(parse_current(&saved).unwrap(), config);
     }
 
     #[test]
     fn empty_registry_stays_off_disk() {
-        let config = disk::from_toml(MIGRATED_V1_CONFIG).unwrap();
+        let config = Config::default();
 
         assert!(!disk::to_toml(&config).unwrap().contains("yubikeys"));
     }
@@ -1008,7 +1500,8 @@ serial = "1C95C1F"
             "07".repeat(130)
         );
 
-        let error = disk::from_toml(&format!("version = 1\n{entry}{entry}"))
+        let error = disk::from_toml(&format!("version = 2\n{entry}{entry}"))
+            .map(|_| ())
             .expect_err("duplicate serials must fail");
 
         assert!(
@@ -1020,18 +1513,21 @@ serial = "1C95C1F"
     fn rejects_a_dangling_yubikey_operator_reference() {
         let error = disk::from_toml(
             r#"
-version = 1
+version = 2
 
-[orgs.default]
-id = "11111111-1111-4111-8111-111111111111"
+[aliases]
+default = "11111111-1111-4111-8111-111111111111"
+
+[orgs.11111111-1111-4111-8111-111111111111]
 api_key_path = "/keys/api.json"
 
-[[orgs.default.operators]]
+[[orgs.11111111-1111-4111-8111-111111111111.operators]]
 name = "yubikey"
 kind = "yubikey"
 serial = "01c95c1f"
 "#,
         )
+        .map(|_| ())
         .expect_err("a reference without a registry entry must fail");
 
         assert_eq!(
@@ -1041,9 +1537,9 @@ serial = "01c95c1f"
              [[yubikeys]] entry or remove this operator record"
         );
     }
+
     fn yubikey_org(serials: &[u32]) -> OrgConfig {
         OrgConfig {
-            id: Uuid::from_u128(0x123),
             api_key_path: PathBuf::from("/keys/api.json"),
             api_base_url: default_api_base_url(),
             default_operator_kind: OperatorKind::Yubikey,
@@ -1133,11 +1629,9 @@ serial = "01c95c1f"
             YubiKeySerial::from(0x01c9_5c1f),
             QosOperatorPublicKey::try_from([7u8; 130].as_slice()).unwrap(),
         );
-        config
-            .orgs
-            .insert("default".to_string(), yubikey_org(&[0x01c9_5c1f]));
+        config.orgs.insert(ORG_1, yubikey_org(&[0x01c9_5c1f]));
 
-        let removed = config.remove_org("default").unwrap();
+        let (removed, _) = config.remove_org(ORG_1).unwrap();
 
         assert_eq!(removed.operators.len(), 1);
         assert!(config.orgs.is_empty());
@@ -1160,69 +1654,10 @@ serial = "01c95c1f"
         assert_eq!(yubikey.serial, YubiKeySerial::from(0xdead_beef));
     }
 
-    const ORG_1: Uuid = Uuid::from_u128(1);
-    const ORG_2: Uuid = Uuid::from_u128(2);
-    const ORG_3: Uuid = Uuid::from_u128(3);
-
-    fn config_with_org_entries<'a>(entries: impl IntoIterator<Item = (&'a str, Uuid)>) -> Config {
-        Config {
-            orgs: entries
-                .into_iter()
-                .map(|(alias, org_id)| {
-                    (
-                        alias.to_string(),
-                        OrgConfig {
-                            id: org_id,
-                            api_key_path: PathBuf::from("api_key.json"),
-                            api_base_url: API_BASE_URL_PROD.to_string(),
-                            default_operator_kind: OperatorKind::Local,
-                            operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
-                            extra: toml::Table::new(),
-                        },
-                    )
-                })
-                .collect(),
-            ..Config::default()
-        }
-    }
-
-    #[test]
-    fn duplicated_org_ids_ignores_unique_ids() {
-        let config = config_with_org_entries([("a", ORG_1), ("b", ORG_2)]);
-
-        assert_eq!(config.duplicated_org_ids(), Vec::new());
-    }
-
-    #[test]
-    fn duplicated_org_ids_groups_in_config_order() {
-        let config = config_with_org_entries([
-            ("c", ORG_2),
-            ("b", ORG_1),
-            ("a", ORG_2),
-            ("e", ORG_1),
-            ("d", ORG_3),
-        ]);
-
-        assert_eq!(
-            config.duplicated_org_ids(),
-            vec![
-                (ORG_1, vec!["b".to_string(), "e".to_string()]),
-                (ORG_2, vec!["c".to_string(), "a".to_string()]),
-            ]
-        );
-    }
-
     #[test]
     fn has_default_layout_at_requires_both_default_file_names() {
         let dir = Path::new("/keys/org");
-        let org = OrgConfig {
-            id: ORG_1,
-            api_key_path: dir.join("api_key.json"),
-            api_base_url: API_BASE_URL_PROD.to_string(),
-            default_operator_kind: OperatorKind::Local,
-            operators: vec![OperatorRecord::local(dir.join("operator.json"))],
-            extra: toml::Table::new(),
-        };
+        let org = test_org(API_BASE_URL_PROD, dir);
 
         assert!(org.has_default_layout_at(dir));
         assert!(!org.has_default_layout_at(Path::new("/keys/other")));
@@ -1243,40 +1678,17 @@ serial = "01c95c1f"
     }
 
     #[test]
-    fn matching_profiles_prefers_alias_over_id_lookup() {
-        let config = config_with_org_entries([("a", ORG_1), ("b", ORG_1)]);
-
-        let by_alias = config.matching_profiles(&OrgQuery::Alias("b".to_string()));
-        assert_eq!(by_alias.len(), 1);
-        assert_eq!(by_alias[0].0, "b");
-
-        let by_id = config
-            .matching_profiles(&OrgQuery::Id(ORG_1))
-            .into_iter()
-            .map(|(alias, _)| alias)
-            .collect::<Vec<_>>();
-        assert_eq!(by_id, ["a", "b"]);
-
-        assert!(
-            config
-                .matching_profiles(&OrgQuery::Alias("missing".to_string()))
-                .is_empty()
-        );
-    }
-
-    #[test]
     fn add_org_with_a_yubikey_starts_on_the_yubikey_backend() {
         let mut config = Config::default();
         config
             .add_org(
-                "default",
-                Uuid::from_u128(0x123),
+                ORG_1,
                 API_BASE_URL_PROD.to_string(),
                 NewOrgOperator::Yubikey(YubiKeySerial::from(0x01c9_5c1f)),
             )
             .unwrap();
 
-        let org = &config.orgs["default"];
+        let org = &config.orgs[&ORG_1];
         assert_eq!(org.default_operator_kind, OperatorKind::Yubikey);
         assert_eq!(
             org.operators,

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -22,7 +22,7 @@ pub use yubikey::{
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::path::PathBuf;
@@ -629,6 +629,29 @@ impl Config {
         self.orgs.get(alias).map(|config| (alias, config))
     }
 
+    /// Organization IDs registered under more than one alias, with the
+    /// aliases that share them. Sorted by organization ID and by alias so
+    /// callers report and prompt in a stable order.
+    pub fn duplicated_org_ids(&self) -> Vec<(String, Vec<String>)> {
+        let mut groups: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+
+        for (alias, org) in &self.orgs {
+            groups.entry(&org.id).or_default().push(alias);
+        }
+
+        groups
+            .into_iter()
+            .filter(|(_, aliases)| aliases.len() > 1)
+            .map(|(id, mut aliases)| {
+                aliases.sort_unstable();
+                (
+                    id.to_string(),
+                    aliases.into_iter().map(String::from).collect(),
+                )
+            })
+            .collect()
+    }
+
     /// Add or update an organization with default key paths, starting with
     /// the given operator backend as its default.
     ///
@@ -1033,6 +1056,54 @@ serial = "01c95c1f"
             .unwrap();
         assert_eq!(record.name, "backup");
         assert_eq!(yubikey.serial, YubiKeySerial::from(0xdead_beef));
+    }
+
+    fn config_with_org_entries(entries: &[(&str, &str)]) -> Config {
+        Config {
+            orgs: entries
+                .iter()
+                .map(|(alias, org_id)| {
+                    (
+                        alias.to_string(),
+                        OrgConfig {
+                            id: org_id.to_string(),
+                            api_key_path: PathBuf::from("api_key.json"),
+                            api_base_url: API_BASE_URL_PROD.to_string(),
+                            default_operator_kind: OperatorKind::Local,
+                            operators: vec![OperatorRecord::local(PathBuf::from("operator.json"))],
+                            extra: toml::Table::new(),
+                        },
+                    )
+                })
+                .collect(),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn duplicated_org_ids_ignores_unique_ids() {
+        let config = config_with_org_entries(&[("a", "org-1"), ("b", "org-2")]);
+
+        assert_eq!(config.duplicated_org_ids(), Vec::new());
+    }
+
+    #[test]
+    fn duplicated_org_ids_groups_and_sorts() {
+        let config = config_with_org_entries(&[
+            ("c", "org-2"),
+            ("b", "org-1"),
+            ("a", "org-2"),
+            ("e", "org-1"),
+            ("d", "org-3"),
+        ]);
+
+        assert_eq!(
+            config.duplicated_org_ids(),
+            vec![
+                ("org-1".to_string(), vec!["b".to_string(), "e".to_string()]),
+                ("org-2".to_string(), vec!["a".to_string(), "c".to_string()]),
+            ]
+        );
     }
 
     #[test]

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -26,11 +26,13 @@ pub use yubikey::{
 use anyhow::{Context, Result, bail};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
-use std::convert::Infallible;
-use std::fmt::{self, Display, Formatter};
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{
+    collections::{BTreeMap, HashMap},
+    convert::Infallible,
+    fmt::{self, Display, Formatter},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use thiserror::Error;
 use tracing::debug;
 use uuid::Uuid;

--- a/tvc/src/config/turnkey.rs
+++ b/tvc/src/config/turnkey.rs
@@ -631,6 +631,11 @@ impl Config {
 
     /// Add or update an organization with default key paths, starting with
     /// the given operator backend as its default.
+    ///
+    /// Callers are responsible for ensuring the alias and organization ID are
+    /// not already registered under another profile; the login command
+    /// enforces one profile per organization before constructing new-org
+    /// inputs. An existing entry under the same alias is replaced wholesale.
     pub fn add_org(
         &mut self,
         alias: &str,

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -492,8 +492,9 @@ mod tests {
     use crate::pair::LocalPair;
     use crate::yubikey::test_support::{self, FakeDevice};
     use crate::yubikey::{Pin, SlotStatus};
+    use indexmap::IndexMap;
     use qos_p256::P256Pair;
-    use std::{collections::HashMap, path::PathBuf};
+    use std::path::PathBuf;
 
     fn public_keys() -> (String, String) {
         let first = P256Pair::generate().unwrap().public_key().to_bytes();
@@ -506,10 +507,10 @@ mod tests {
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
         Config {
             active_org: Some("active".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "active".to_string(),
                 OrgConfig {
-                    id: "org-id".to_string(),
+                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -889,7 +890,7 @@ mod tests {
         assert_eq!(
             candidates[1],
             OperatorCandidate {
-                id: "44444444-4444-4444-8444-444444444444".to_string(),
+                id: "44444444-4444-4444-8444-444444444444".parse().unwrap(),
                 name: None,
                 public_key: None,
             }

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -506,11 +506,10 @@ mod tests {
 
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
         Config {
-            active_org: Some("active".to_string()),
+            active_org: Some(Uuid::from_u128(0xA1)),
             orgs: IndexMap::from([(
-                "active".to_string(),
+                Uuid::from_u128(0xA1),
                 OrgConfig {
-                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -560,7 +559,11 @@ mod tests {
 
     fn yubikey_default_config(serial: YubiKeySerial) -> Config {
         let mut config = config_with_operators(vec![yubikey_operator(serial)]);
-        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
+        config
+            .orgs
+            .get_mut(&Uuid::from_u128(0xA1))
+            .unwrap()
+            .default_operator_kind = OperatorKind::Yubikey;
         config
     }
 
@@ -710,7 +713,7 @@ mod tests {
         let mut config = registered_yubikey_config(&device);
         config
             .orgs
-            .get_mut("active")
+            .get_mut(&Uuid::from_u128(0xA1))
             .unwrap()
             .operators
             .push(hosted_operator("hosted"));
@@ -822,7 +825,11 @@ mod tests {
     #[test]
     fn operator_pair_hosted_default_is_redirected() {
         let mut config = config_with_operators(vec![hosted_operator("hosted")]);
-        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Hosted;
+        config
+            .orgs
+            .get_mut(&Uuid::from_u128(0xA1))
+            .unwrap()
+            .default_operator_kind = OperatorKind::Hosted;
 
         let error = config
             .select_operator_pair_source(None, None)
@@ -837,7 +844,11 @@ mod tests {
             yubikey_operator(test_support::serial()),
             yubikey_operator(YubiKeySerial::from(0xdead_beef)),
         ]);
-        config.orgs.get_mut("active").unwrap().default_operator_kind = OperatorKind::Yubikey;
+        config
+            .orgs
+            .get_mut(&Uuid::from_u128(0xA1))
+            .unwrap()
+            .default_operator_kind = OperatorKind::Yubikey;
         config
             .yubikeys
             .register(test_support::serial(), device.operator_public_key());

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -214,7 +214,7 @@ impl SelectedYubiKey {
 /// parse at their own boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OperatorCandidate {
-    pub id: String,
+    pub id: Uuid,
     pub name: Option<String>,
     /// The key this identity is proven to use. IDs remembered from an app
     /// response predate key-aware persistence, so they deliberately carry
@@ -226,7 +226,7 @@ impl Display for OperatorCandidate {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.name {
             Some(name) => write!(f, "{name} ({})", self.id),
-            None => f.write_str(&self.id),
+            None => write!(f, "{}", self.id),
         }
     }
 }
@@ -453,7 +453,7 @@ impl Config {
         let mut candidates: Vec<OperatorCandidate> = org
             .hosted_operators()
             .map(|(name, hosted)| OperatorCandidate {
-                id: hosted.operator_id.to_string(),
+                id: hosted.operator_id,
                 name: name.to_owned().into(),
                 public_key: format!("{}{}", hosted.encrypt_public_key, hosted.sign_public_key)
                     .parse()
@@ -461,15 +461,19 @@ impl Config {
             })
             .collect();
 
-        for id in self.get_last_operator_ids().unwrap_or_default() {
-            if candidates.iter().all(|candidate| candidate.id != id) {
-                candidates.push(OperatorCandidate {
-                    id,
-                    name: None,
-                    public_key: None,
-                });
-            }
-        }
+        self.get_last_operator_ids()
+            .unwrap_or_default()
+            .iter()
+            .copied()
+            .for_each(|id| {
+                if candidates.iter().all(|candidate| candidate.id != id) {
+                    candidates.push(OperatorCandidate {
+                        id,
+                        name: None,
+                        public_key: None,
+                    });
+                }
+            });
 
         candidates
     }
@@ -889,13 +893,15 @@ mod tests {
     fn candidates_are_registered_hosted_operators_then_saved_ids() {
         let mut config = config_with_operators(vec![local_operator(), hosted_operator("hosted")]);
         config
-            .set_last_operator_ids(&["44444444-4444-4444-8444-444444444444".to_string()])
+            .set_last_operator_ids(vec![
+                "44444444-4444-4444-8444-444444444444".parse().unwrap(),
+            ])
             .unwrap();
 
         let candidates = config.known_operator_candidates();
 
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].id, HOSTED_ID);
+        assert_eq!(candidates[0].id.to_string(), HOSTED_ID);
         assert_eq!(candidates[0].name.as_deref(), Some("hosted"));
         assert!(candidates[0].public_key.is_some());
         assert_eq!(
@@ -912,13 +918,13 @@ mod tests {
     fn candidates_dedupe_saved_ids_against_the_registry() {
         let mut config = config_with_operators(vec![hosted_operator("hosted")]);
         config
-            .set_last_operator_ids(&[HOSTED_ID.to_string()])
+            .set_last_operator_ids(vec![HOSTED_ID.parse().unwrap()])
             .unwrap();
 
         let candidates = config.known_operator_candidates();
 
         assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].id, HOSTED_ID);
+        assert_eq!(candidates[0].id.to_string(), HOSTED_ID);
         assert_eq!(candidates[0].name.as_deref(), Some("hosted"));
         assert!(candidates[0].public_key.is_some());
     }
@@ -931,12 +937,12 @@ mod tests {
     #[test]
     fn candidate_display_labels_named_operators() {
         let named = OperatorCandidate {
-            id: HOSTED_ID.to_string(),
+            id: HOSTED_ID.parse().unwrap(),
             name: Some("hosted".to_string()),
             public_key: None,
         };
         let unnamed = OperatorCandidate {
-            id: HOSTED_ID.to_string(),
+            id: HOSTED_ID.parse().unwrap(),
             name: None,
             public_key: None,
         };

--- a/tvc/src/operator.rs
+++ b/tvc/src/operator.rs
@@ -147,8 +147,8 @@ impl ResolvedOperator {
 }
 
 pub(crate) fn ensure_authenticated_org(
-    authenticated_org_id: &str,
-    configured_org_id: &str,
+    authenticated_org_id: Uuid,
+    configured_org_id: Uuid,
 ) -> Result<()> {
     ensure!(
         authenticated_org_id == configured_org_id,
@@ -361,7 +361,7 @@ impl Config {
                 }
 
                 let auth = build_client(self).await?;
-                ensure_authenticated_org(&auth.org_id, hosted.organization_id())?;
+                ensure_authenticated_org(auth.org_id, hosted.organization_id())?;
 
                 Ok(ResolvedOperator {
                     name: Some(hosted.name().to_string()),
@@ -974,11 +974,17 @@ mod tests {
 
     #[test]
     fn authenticated_org_must_match_configured_org() {
+        let authenticated = Uuid::from_u128(0xAA);
+        let configured = Uuid::from_u128(0xCC);
+
         assert_eq!(
-            ensure_authenticated_org("authenticated", "configured")
+            ensure_authenticated_org(authenticated, configured)
                 .unwrap_err()
                 .to_string(),
-            "authenticated organization (authenticated) does not match configured organization (configured)"
+            format!(
+                "authenticated organization ({authenticated}) does not match \
+                 configured organization ({configured})"
+            )
         );
     }
 }

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -242,7 +242,7 @@ impl Config {
         &self,
         operator_id: &Uuid,
     ) -> Result<Option<ResolvedHostedOperator>> {
-        let Some((_, org)) = self.active_org_config() else {
+        let Some((org_id, org)) = self.active_org_config() else {
             return Ok(None);
         };
 
@@ -253,7 +253,7 @@ impl Config {
         match (matches.next(), matches.next()) {
             (None, _) => Ok(None),
             (Some((name, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
-                org.id, name, hosted,
+                org_id, name, hosted,
             )?)),
             (Some(_), Some(_)) => bail!("multiple hosted operators have ID {operator_id}"),
         }
@@ -264,12 +264,15 @@ impl Config {
         &self,
         operator_id: &Uuid,
     ) -> Result<ResolvedHostedOperator> {
-        let (alias, _) = self
+        let (org_id_active, _) = self
             .active_org_config()
             .context("No active organization. Run `tvc login` first.")?;
 
         self.find_hosted_operator(operator_id)?.ok_or_else(|| {
-            anyhow!("hosted operator ID '{operator_id}' was not found in org '{alias}'")
+            anyhow!(
+                "hosted operator ID '{operator_id}' was not found in org '{}'",
+                self.display_name(org_id_active)
+            )
         })
     }
 
@@ -394,12 +397,11 @@ mod tests {
     }
 
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
-        Config {
-            active_org: Some("active".to_string()),
+        let mut config = Config {
+            active_org: Some(Uuid::from_u128(0xA1)),
             orgs: IndexMap::from([(
-                "active".to_string(),
+                Uuid::from_u128(0xA1),
                 OrgConfig {
-                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -408,7 +410,11 @@ mod tests {
                 },
             )]),
             ..Config::default()
-        }
+        };
+        config
+            .aliases
+            .bind("active".to_string(), Uuid::from_u128(0xA1));
+        config
     }
 
     fn hosted_operator(name: &str, record: HostedOperatorRecord) -> OperatorRecord {
@@ -484,10 +490,9 @@ mod tests {
         );
 
         let mut cross_org = config_with_operators(Vec::new());
-        let mut inactive_org = cross_org.orgs["active"].clone();
-        inactive_org.id = Uuid::from_u128(0x1AC);
+        let mut inactive_org = cross_org.orgs[&Uuid::from_u128(0xA1)].clone();
         inactive_org.operators = vec![hosted_operator("hosted", hosted_record())];
-        cross_org.orgs.insert("inactive".to_string(), inactive_org);
+        cross_org.orgs.insert(Uuid::from_u128(0x1AC), inactive_org);
         assert_eq!(
             cross_org
                 .resolve_hosted_operator_encrypt_key(&operator_id)
@@ -536,7 +541,7 @@ mod tests {
             }),
         };
         let config = config_with_operators(vec![local, hosted_operator("hosted", hosted_record())]);
-        let org = &config.orgs["active"];
+        let org = &config.orgs[&Uuid::from_u128(0xA1)];
 
         let (name, hosted) = org.select_hosted_operator().unwrap();
 
@@ -547,7 +552,7 @@ mod tests {
     #[test]
     fn selecting_a_hosted_operator_requires_one_to_exist() {
         let config = config_with_operators(Vec::new());
-        let org = &config.orgs["active"];
+        let org = &config.orgs[&Uuid::from_u128(0xA1)];
 
         assert!(matches!(
             org.select_hosted_operator(),
@@ -561,7 +566,7 @@ mod tests {
             hosted_operator("first", hosted_record()),
             hosted_operator("second", hosted_record()),
         ]);
-        let org = &config.orgs["active"];
+        let org = &config.orgs[&Uuid::from_u128(0xA1)];
 
         assert!(matches!(
             org.select_hosted_operator(),
@@ -573,12 +578,11 @@ mod tests {
     fn hosted_operator_lookup_is_scoped_to_active_organization() {
         let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
         let config = Config {
-            active_org: Some("active".to_string()),
+            active_org: Some(Uuid::from_u128(0xAC)),
             orgs: IndexMap::from([
                 (
-                    "active".to_string(),
+                    Uuid::from_u128(0xAC),
                     OrgConfig {
-                        id: Uuid::from_u128(0xAC),
                         api_key_path: "active-api.json".into(),
                         api_base_url: "https://api.turnkey.com".to_string(),
                         default_operator_kind: OperatorKind::Local,
@@ -587,9 +591,8 @@ mod tests {
                     },
                 ),
                 (
-                    "inactive".to_string(),
+                    Uuid::from_u128(0x1AC),
                     OrgConfig {
-                        id: Uuid::from_u128(0x1AC),
                         api_key_path: "inactive-api.json".into(),
                         api_base_url: "https://api.turnkey.com".to_string(),
                         default_operator_kind: OperatorKind::Hosted,

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -253,7 +253,7 @@ impl Config {
         match (matches.next(), matches.next()) {
             (None, _) => Ok(None),
             (Some((name, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
-                org.id.clone(),
+                org.id.to_string(),
                 name,
                 hosted,
             )?)),
@@ -370,8 +370,8 @@ mod tests {
         LocalOperatorRecord, OperatorKind, OrgConfig, SelectHostedOperatorError,
     };
     use crate::operator::OperatorPublicKeyParseError;
+    use indexmap::IndexMap;
     use qos_p256::P256Pair;
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     const OPERATOR_ID: &str = "11111111-1111-4111-8111-111111111111";
@@ -398,10 +398,10 @@ mod tests {
     fn config_with_operators(operators: Vec<OperatorRecord>) -> Config {
         Config {
             active_org: Some("active".to_string()),
-            orgs: HashMap::from([(
+            orgs: IndexMap::from([(
                 "active".to_string(),
                 OrgConfig {
-                    id: "org-id".to_string(),
+                    id: Uuid::from_u128(0xA1),
                     api_key_path: PathBuf::from("api-key.json"),
                     api_base_url: "https://api.turnkey.com".to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -439,7 +439,7 @@ mod tests {
         let record = hosted_record();
         let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
         let expected = ResolvedHostedOperator {
-            organization_id: "org-id".to_string(),
+            organization_id: Uuid::from_u128(0xA1).to_string(),
             name: "hosted".to_string(),
             operator_id,
             keys: OperatorKeyPair {
@@ -487,7 +487,7 @@ mod tests {
 
         let mut cross_org = config_with_operators(Vec::new());
         let mut inactive_org = cross_org.orgs["active"].clone();
-        inactive_org.id = "inactive-org-id".to_string();
+        inactive_org.id = Uuid::from_u128(0x1AC);
         inactive_org.operators = vec![hosted_operator("hosted", hosted_record())];
         cross_org.orgs.insert("inactive".to_string(), inactive_org);
         assert_eq!(
@@ -576,11 +576,11 @@ mod tests {
         let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
         let config = Config {
             active_org: Some("active".to_string()),
-            orgs: HashMap::from([
+            orgs: IndexMap::from([
                 (
                     "active".to_string(),
                     OrgConfig {
-                        id: "active-org".to_string(),
+                        id: Uuid::from_u128(0xAC),
                         api_key_path: "active-api.json".into(),
                         api_base_url: "https://api.turnkey.com".to_string(),
                         default_operator_kind: OperatorKind::Local,
@@ -591,7 +591,7 @@ mod tests {
                 (
                     "inactive".to_string(),
                     OrgConfig {
-                        id: "inactive-org".to_string(),
+                        id: Uuid::from_u128(0x1AC),
                         api_key_path: "inactive-api.json".into(),
                         api_base_url: "https://api.turnkey.com".to_string(),
                         default_operator_kind: OperatorKind::Hosted,

--- a/tvc/src/operator/hosted.rs
+++ b/tvc/src/operator/hosted.rs
@@ -162,7 +162,7 @@ impl TryFrom<CreateOperatorRequestResult> for OperatorRecord {
 /// Its keys are parsed exactly once, at resolution.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub(crate) struct ResolvedHostedOperator {
-    organization_id: String,
+    organization_id: Uuid,
     name: String,
     operator_id: Uuid,
     keys: OperatorKeyPair,
@@ -171,7 +171,7 @@ pub(crate) struct ResolvedHostedOperator {
 impl ResolvedHostedOperator {
     /// Parse and validate a hosted registry record into a resolved operator.
     pub(crate) fn from_registry(
-        organization_id: String,
+        organization_id: Uuid,
         name: &str,
         record: &HostedOperatorRecord,
     ) -> Result<Self> {
@@ -210,8 +210,8 @@ impl ResolvedHostedOperator {
         })
     }
 
-    pub(crate) fn organization_id(&self) -> &str {
-        &self.organization_id
+    pub(crate) fn organization_id(&self) -> Uuid {
+        self.organization_id
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -253,9 +253,7 @@ impl Config {
         match (matches.next(), matches.next()) {
             (None, _) => Ok(None),
             (Some((name, hosted)), None) => Ok(Some(ResolvedHostedOperator::from_registry(
-                org.id.to_string(),
-                name,
-                hosted,
+                org.id, name, hosted,
             )?)),
             (Some(_), Some(_)) => bail!("multiple hosted operators have ID {operator_id}"),
         }
@@ -318,7 +316,7 @@ impl Signer for HostedSigner {
             let result = self
                 .auth
                 .client
-                .sign_raw_payload(self.auth.org_id.clone(), timestamp_ms()?, intent)
+                .sign_raw_payload(self.auth.org_id.to_string(), timestamp_ms()?, intent)
                 .await
                 .map_err(|error| {
                     hosted_activity_error("sign manifest with hosted operator", error)
@@ -439,7 +437,7 @@ mod tests {
         let record = hosted_record();
         let operator_id = Uuid::parse_str(OPERATOR_ID).unwrap();
         let expected = ResolvedHostedOperator {
-            organization_id: Uuid::from_u128(0xA1).to_string(),
+            organization_id: Uuid::from_u128(0xA1),
             name: "hosted".to_string(),
             operator_id,
             keys: OperatorKeyPair {

--- a/tvc/src/provisioning.rs
+++ b/tvc/src/provisioning.rs
@@ -67,7 +67,7 @@ pub(crate) async fn fetch_provisioning_details(
     deployment_id: &Uuid,
 ) -> anyhow::Result<FetchedProvisioningDetails> {
     let request = GetTvcDeploymentProvisioningDetailsRequest {
-        organization_id: auth.org_id.clone(),
+        organization_id: auth.org_id.to_string(),
         deployment_id: deployment_id.to_string(),
     };
     let fetched_at_unix_ms = u64::try_from(

--- a/tvc/tests/app_create.rs
+++ b/tvc/tests/app_create.rs
@@ -1,6 +1,7 @@
 //! Integration tests for `tvc app create`'s operator-reuse decision.
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use qos_p256::P256Pair;
 use std::collections::HashMap;
@@ -25,10 +26,10 @@ fn write_two_candidate_config(home: &Path) -> String {
 
     let config = Config {
         active_org: Some("hosted-org".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "hosted-org".to_string(),
             OrgConfig {
-                id: "44444444-4444-4444-8444-444444444444".to_string(),
+                id: "44444444-4444-4444-8444-444444444444".parse().unwrap(),
                 api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
                 api_base_url: "http://127.0.0.1:1".to_string(),
                 default_operator_kind: OperatorKind::Hosted,

--- a/tvc/tests/app_create.rs
+++ b/tvc/tests/app_create.rs
@@ -62,7 +62,7 @@ fn write_two_candidate_config(home: &Path) -> String {
     config.set_active_org(org_id).unwrap();
     config.last_operator_ids.insert(
         org_id,
-        vec!["66666666-6666-4666-8666-666666666666".to_string()],
+        vec!["66666666-6666-4666-8666-666666666666".parse().unwrap()],
     );
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),

--- a/tvc/tests/app_create.rs
+++ b/tvc/tests/app_create.rs
@@ -1,16 +1,15 @@
 //! Integration tests for `tvc app create`'s operator-reuse decision.
 
 use assert_cmd::cargo::cargo_bin_cmd;
-use indexmap::IndexMap;
 use predicates::prelude::*;
 use qos_p256::P256Pair;
-use std::collections::HashMap;
 use std::path::Path;
 use tempfile::TempDir;
 use tvc::config::app::KNOWN_QUORUM_KEY;
 use tvc::config::turnkey::{
     Config, HostedOperatorRecord, OperatorKind, OperatorRecord, OperatorRecordKind, OrgConfig,
 };
+use uuid::Uuid;
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
 
@@ -24,53 +23,50 @@ fn write_two_candidate_config(home: &Path) -> String {
     let composite = hex::encode(P256Pair::generate().unwrap().public_key().to_bytes());
     let (encrypt_public_key, sign_public_key) = composite.split_at(composite.len() / 2);
 
-    let config = Config {
-        active_org: Some("hosted-org".to_string()),
-        orgs: IndexMap::from([(
-            "hosted-org".to_string(),
-            OrgConfig {
-                id: "44444444-4444-4444-8444-444444444444".parse().unwrap(),
-                api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
-                api_base_url: "http://127.0.0.1:1".to_string(),
-                default_operator_kind: OperatorKind::Hosted,
-                operators: vec![
-                    OperatorRecord {
-                        name: "hosted-op".to_string(),
-                        kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
-                            operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
-                            wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
-                            path: "m/5527107'/0'/0'".to_string(),
-                            encrypt_public_key: encrypt_public_key.to_string(),
-                            sign_public_key: sign_public_key.to_string(),
-                            extra: toml::Table::new(),
-                        }),
-                    },
-                    OperatorRecord {
-                        name: "hosted-op-2".to_string(),
-                        kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
-                            operator_id: "33333333-3333-4333-8333-333333333333".parse().unwrap(),
-                            wallet_id: "55555555-5555-4555-8555-555555555555".parse().unwrap(),
-                            path: "m/5527107'/0'/0'".to_string(),
-                            encrypt_public_key: encrypt_public_key.to_string(),
-                            sign_public_key: sign_public_key.to_string(),
-                            extra: toml::Table::new(),
-                        }),
-                    },
-                ],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::from([(
-            "hosted-org".to_string(),
-            vec!["66666666-6666-4666-8666-666666666666".to_string()],
-        )]),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = "44444444-4444-4444-8444-444444444444".parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
+            api_base_url: "http://127.0.0.1:1".to_string(),
+            default_operator_kind: OperatorKind::Hosted,
+            operators: vec![
+                OperatorRecord {
+                    name: "hosted-op".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                        wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: encrypt_public_key.to_string(),
+                        sign_public_key: sign_public_key.to_string(),
+                        extra: toml::Table::new(),
+                    }),
+                },
+                OperatorRecord {
+                    name: "hosted-op-2".to_string(),
+                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                        operator_id: "33333333-3333-4333-8333-333333333333".parse().unwrap(),
+                        wallet_id: "55555555-5555-4555-8555-555555555555".parse().unwrap(),
+                        path: "m/5527107'/0'/0'".to_string(),
+                        encrypt_public_key: encrypt_public_key.to_string(),
+                        sign_public_key: sign_public_key.to_string(),
+                        extra: toml::Table::new(),
+                    }),
+                },
+            ],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("hosted-org".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
+    config.last_operator_ids.insert(
+        org_id,
+        vec!["66666666-6666-4666-8666-666666666666".to_string()],
+    );
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -1,13 +1,12 @@
 use assert_cmd::cargo::cargo_bin_cmd;
-use indexmap::IndexMap;
 use predicates::prelude::*;
-use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use tvc::config::turnkey::{
     Config, KeyCurve, OperatorKind, OperatorRecord, OrgConfig, StoredApiKey,
 };
+use uuid::Uuid;
 
 const ENV_ORG_ID: &str = "TVC_ORG_ID";
 const ENV_API_KEY_PUBLIC: &str = "TVC_API_KEY_PUBLIC";
@@ -101,27 +100,23 @@ fn auth_falls_back_to_disk_config_when_required_env_vars_are_unset() {
     )
     .unwrap();
 
-    let config = Config {
-        active_org: Some("test".to_string()),
-        orgs: IndexMap::from([(
-            "test".to_string(),
-            OrgConfig {
-                id: "10000000-0000-4000-8000-000000000002".parse().unwrap(),
-                api_key_path,
-                api_base_url: LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Local,
-                operators: vec![OperatorRecord::local(operator_key_path)],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = "10000000-0000-4000-8000-000000000002".parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path,
+            api_base_url: LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Local,
+            operators: vec![OperatorRecord::local(operator_key_path)],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("test".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -41,7 +41,7 @@ fn env_auth_accepts_all_three_required_vars() {
 
     app_status_cmd()
         .env("HOME", home.path())
-        .env(ENV_ORG_ID, "org-env")
+        .env(ENV_ORG_ID, "10000000-0000-4000-8000-000000000003")
         .env(ENV_API_KEY_PUBLIC, public_key)
         .env(ENV_API_KEY_PRIVATE, private_key)
         .assert()
@@ -58,7 +58,7 @@ fn env_auth_rejects_two_required_vars() {
 
     app_status_cmd()
         .env("HOME", home.path())
-        .env(ENV_ORG_ID, "org-env")
+        .env(ENV_ORG_ID, "10000000-0000-4000-8000-000000000003")
         .env(ENV_API_KEY_PUBLIC, public_key)
         .assert()
         .failure()
@@ -72,7 +72,7 @@ fn env_auth_rejects_one_required_var() {
 
     app_status_cmd()
         .env("HOME", home.path())
-        .env(ENV_ORG_ID, "org-env")
+        .env(ENV_ORG_ID, "10000000-0000-4000-8000-000000000003")
         .assert()
         .failure()
         .stderr(predicate::str::contains("partial env var auth"))

--- a/tvc/tests/auth_env.rs
+++ b/tvc/tests/auth_env.rs
@@ -1,4 +1,5 @@
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
@@ -102,10 +103,10 @@ fn auth_falls_back_to_disk_config_when_required_env_vars_are_unset() {
 
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-from-disk".to_string(),
+                id: "10000000-0000-4000-8000-000000000002".parse().unwrap(),
                 api_key_path,
                 api_base_url: LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Local,

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -24,8 +24,11 @@ fn org_dir(home: &Path, alias: &str) -> PathBuf {
 }
 
 /// Write a v1 `tvc.config.toml` under `home` with one profile per
-/// `(alias, org_id)` pair, using the default alias-keyed key-file layout and
-/// a dead-port API base URL.
+/// `(alias, org_id)` pair, using the legacy alias-keyed key-file layout and a
+/// dead-port API base URL. The legacy layout is deliberate: these fixtures
+/// seed pre-existing user state (which interactive login migrates to the
+/// id-keyed layout); the current layout is exercised through the real CLI's
+/// new-profile flow. Profiles are written in slice order.
 pub fn write_profiles_config(home: &Path, profiles: &[(&str, &str)], active_org: Option<&str>) {
     let turnkey_dir = home.join(".config/turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -5,9 +5,7 @@
 // unused items here; without this, each `cargo test` target warns.
 #![allow(dead_code)]
 
-use indexmap::IndexMap;
 use std::{
-    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -17,6 +15,7 @@ use tvc::config::turnkey::{
     OrgConfig, QosOperatorPublicKey, StoredApiKey, StoredQosOperatorKey, YubiKeyOperatorRecord,
     YubiKeyRegistryEntry, YubiKeySerial,
 };
+use uuid::Uuid;
 
 /// Dead port: connection attempts fail immediately, so commands stop at their
 /// first network step without hanging.
@@ -26,59 +25,68 @@ fn org_dir(home: &Path, alias: &str) -> PathBuf {
     home.join(".config/turnkey/orgs").join(alias)
 }
 
-/// Write a v1 `tvc.config.toml` under `home` with one profile per
+/// Write a v2 `tvc.config.toml` under `home` with one organization per
 /// `(alias, org_id)` pair, using the legacy alias-keyed key-file layout and a
 /// dead-port API base URL. The legacy layout is deliberate: these fixtures
 /// seed pre-existing user state (which interactive login migrates to the
 /// id-keyed layout); the current layout is exercised through the real CLI's
-/// new-profile flow. Profiles are written in slice order.
+/// new-org flow.
 pub fn write_profiles_config(home: &Path, profiles: &[(&str, &str)], active_org: Option<&str>) {
     let turnkey_dir = home.join(".config/turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
 
-    let orgs: IndexMap<_, _> = profiles
-        .iter()
-        .map(|(alias, org_id)| {
-            let dir = org_dir(home, alias);
-            (
-                alias.to_string(),
-                OrgConfig {
-                    id: org_id.parse().expect("test org ids must be UUIDs"),
-                    api_key_path: dir.join("api_key.json"),
-                    api_base_url: LOCAL_API_BASE_URL.to_string(),
-                    default_operator_kind: OperatorKind::Local,
-                    operators: vec![OperatorRecord::local(dir.join("operator.json"))],
-                    extra: toml::Table::new(),
-                },
-            )
-        })
-        .collect();
+    let mut config = Config::default();
 
-    let config = Config {
-        active_org: active_org.map(String::from),
-        orgs,
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
-    };
+    for (alias, org_id) in profiles {
+        let id: Uuid = org_id.parse().expect("test org ids must be UUIDs");
+        let dir = org_dir(home, alias);
+
+        config.orgs.insert(
+            id,
+            OrgConfig {
+                api_key_path: dir.join("api_key.json"),
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+                default_operator_kind: OperatorKind::Local,
+                operators: vec![OperatorRecord::local(dir.join("operator.json"))],
+                extra: toml::Table::new(),
+            },
+        );
+        config.aliases.bind(alias.to_string(), id);
+    }
+
+    if let Some(active) = active_org {
+        let id = config
+            .aliases
+            .resolve(active)
+            .expect("active_org must name a fixture profile")
+            .id();
+        config.set_active_org(id).unwrap();
+    }
+
+    write_config(home, &config);
+}
+
+/// Serialize `config` as the current on-disk schema at the default path.
+pub fn write_config(home: &Path, config: &Config) {
+    let turnkey_dir = home.join(".config/turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
 
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(config).unwrap()),
     )
     .unwrap();
 }
 
-/// Write a v1 `tvc.config.toml` under `home` whose sole, active organization
+/// Write a v2 `tvc.config.toml` under `home` whose sole, active organization
 /// defaults to the hosted backend and registers exactly one operator, hosted
 /// — the fixture for commands that need local key material a hosted-only org
 /// does not have. The record carries a real generated composite key split
 /// into its two points, the way `operator create` stores it.
 pub fn write_hosted_only_config(home: &Path, alias: &str, org_id: &str) {
     let turnkey_dir = home.join(".config/turnkey");
-    fs::create_dir_all(&turnkey_dir).unwrap();
 
+    let id: Uuid = org_id.parse().expect("test org ids must be UUIDs");
     let composite = hex::encode(
         qos_p256::P256Pair::generate()
             .unwrap()
@@ -87,43 +95,34 @@ pub fn write_hosted_only_config(home: &Path, alias: &str, org_id: &str) {
     );
     let (encrypt_public_key, sign_public_key) = composite.split_at(composite.len() / 2);
 
-    let config = Config {
-        active_org: Some(alias.to_string()),
-        orgs: IndexMap::from([(
-            alias.to_string(),
-            OrgConfig {
-                id: org_id.parse().expect("test org ids must be UUIDs"),
-                api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
-                api_base_url: LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Hosted,
-                operators: vec![OperatorRecord {
-                    name: "hosted-op".to_string(),
-                    kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
-                        operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
-                        wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
-                        path: "m/5527107'/0'/0'".to_string(),
-                        encrypt_public_key: encrypt_public_key.to_string(),
-                        sign_public_key: sign_public_key.to_string(),
-                        extra: toml::Table::new(),
-                    }),
-                }],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
-    };
+    let mut config = Config::default();
+    config.orgs.insert(
+        id,
+        OrgConfig {
+            api_key_path: turnkey_dir.join(format!("orgs/{id}/api_key.json")),
+            api_base_url: LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Hosted,
+            operators: vec![OperatorRecord {
+                name: "hosted-op".to_string(),
+                kind: OperatorRecordKind::Hosted(HostedOperatorRecord {
+                    operator_id: "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+                    wallet_id: "22222222-2222-4222-8222-222222222222".parse().unwrap(),
+                    path: "m/5527107'/0'/0'".to_string(),
+                    encrypt_public_key: encrypt_public_key.to_string(),
+                    sign_public_key: sign_public_key.to_string(),
+                    extra: toml::Table::new(),
+                }),
+            }],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind(alias.to_string(), id);
+    config.set_active_org(id).unwrap();
 
-    fs::write(
-        turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
-    )
-    .unwrap();
+    write_config(home, &config);
 }
 
-/// Write a v1 `tvc.config.toml` under `home` whose sole, active organization
+/// Write a v2 `tvc.config.toml` under `home` whose sole, active organization
 /// defaults to the yubikey backend: one serial-only operator record plus the
 /// top-level registry entry caching a real generated composite key. Flows
 /// that read the cache need no device; device-touching flows fail at their
@@ -149,29 +148,11 @@ pub fn write_yubikey_only_config_with_public_key(
     public_key: QosOperatorPublicKey,
 ) {
     let turnkey_dir = home.join(".config/turnkey");
-    fs::create_dir_all(&turnkey_dir).unwrap();
 
+    let id: Uuid = org_id.parse().expect("test org ids must be UUIDs");
     let serial = YubiKeySerial::from(0x01c9_5c1f);
 
-    let config = Config {
-        active_org: Some(alias.to_string()),
-        orgs: IndexMap::from([(
-            alias.to_string(),
-            OrgConfig {
-                id: org_id.parse().expect("test org ids must be UUIDs"),
-                api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
-                api_base_url: LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Yubikey,
-                operators: vec![OperatorRecord {
-                    name: "yubikey-op".to_string(),
-                    kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
-                        serial,
-                        extra: toml::Table::new(),
-                    }),
-                }],
-                extra: toml::Table::new(),
-            },
-        )]),
+    let mut config = Config {
         yubikeys: vec![YubiKeyRegistryEntry {
             serial,
             public_key,
@@ -179,25 +160,36 @@ pub fn write_yubikey_only_config_with_public_key(
         }]
         .try_into()
         .unwrap(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
+        ..Config::default()
     };
+    config.orgs.insert(
+        id,
+        OrgConfig {
+            api_key_path: turnkey_dir.join(format!("orgs/{id}/api_key.json")),
+            api_base_url: LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Yubikey,
+            operators: vec![OperatorRecord {
+                name: "yubikey-op".to_string(),
+                kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
+                    serial,
+                    extra: toml::Table::new(),
+                }),
+            }],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind(alias.to_string(), id);
+    config.set_active_org(id).unwrap();
 
-    fs::write(
-        turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
-    )
-    .unwrap();
+    write_config(home, &config);
 }
 
-/// Write a v1 `tvc.config.toml` under `home` with one yubikey-default
+/// Write a v2 `tvc.config.toml` under `home` with one yubikey-default
 /// organization per `(alias, org_id)` pair, every org referencing the SAME
 /// registered serial — the fixture for shared-registry-entry behavior. The
 /// first alias is active.
 pub fn write_yubikey_shared_config(home: &Path, profiles: &[(&str, &str)]) {
     let turnkey_dir = home.join(".config/turnkey");
-    fs::create_dir_all(&turnkey_dir).unwrap();
 
     let serial = YubiKeySerial::from(0x01c9_5c1f);
     let public_key = QosOperatorPublicKey::try_from(
@@ -209,32 +201,7 @@ pub fn write_yubikey_shared_config(home: &Path, profiles: &[(&str, &str)]) {
     )
     .unwrap();
 
-    let orgs: IndexMap<_, _> = profiles
-        .iter()
-        .map(|(alias, org_id)| {
-            (
-                alias.to_string(),
-                OrgConfig {
-                    id: org_id.parse().expect("test org ids must be UUIDs"),
-                    api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
-                    api_base_url: LOCAL_API_BASE_URL.to_string(),
-                    default_operator_kind: OperatorKind::Yubikey,
-                    operators: vec![OperatorRecord {
-                        name: "yubikey-op".to_string(),
-                        kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
-                            serial,
-                            extra: toml::Table::new(),
-                        }),
-                    }],
-                    extra: toml::Table::new(),
-                },
-            )
-        })
-        .collect();
-
-    let config = Config {
-        active_org: profiles.first().map(|(alias, _)| alias.to_string()),
-        orgs,
+    let mut config = Config {
         yubikeys: vec![YubiKeyRegistryEntry {
             serial,
             public_key,
@@ -242,16 +209,41 @@ pub fn write_yubikey_shared_config(home: &Path, profiles: &[(&str, &str)]) {
         }]
         .try_into()
         .unwrap(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
+        ..Config::default()
     };
 
-    fs::write(
-        turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
-    )
-    .unwrap();
+    for (alias, org_id) in profiles {
+        let id: Uuid = org_id.parse().expect("test org ids must be UUIDs");
+
+        config.orgs.insert(
+            id,
+            OrgConfig {
+                api_key_path: turnkey_dir.join(format!("orgs/{id}/api_key.json")),
+                api_base_url: LOCAL_API_BASE_URL.to_string(),
+                default_operator_kind: OperatorKind::Yubikey,
+                operators: vec![OperatorRecord {
+                    name: "yubikey-op".to_string(),
+                    kind: OperatorRecordKind::Yubikey(YubiKeyOperatorRecord {
+                        serial,
+                        extra: toml::Table::new(),
+                    }),
+                }],
+                extra: toml::Table::new(),
+            },
+        );
+        config.aliases.bind(alias.to_string(), id);
+    }
+
+    if let Some((alias, _)) = profiles.first() {
+        let id = config
+            .aliases
+            .resolve(alias)
+            .expect("first profile was just bound")
+            .id();
+        config.set_active_org(id).unwrap();
+    }
+
+    write_config(home, &config);
 }
 
 /// Create the default-layout key files for `alias`: a valid generated

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -2,6 +2,7 @@
 //! compiles its own copy and uses a subset, so unused items are expected.
 #![allow(dead_code)]
 
+use indexmap::IndexMap;
 use std::{
     collections::HashMap,
     fs,
@@ -29,14 +30,14 @@ pub fn write_profiles_config(home: &Path, profiles: &[(&str, &str)], active_org:
     let turnkey_dir = home.join(".config/turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
 
-    let orgs: HashMap<_, _> = profiles
+    let orgs: IndexMap<_, _> = profiles
         .iter()
         .map(|(alias, org_id)| {
             let dir = org_dir(home, alias);
             (
                 alias.to_string(),
                 OrgConfig {
-                    id: org_id.to_string(),
+                    id: org_id.parse().expect("test org ids must be UUIDs"),
                     api_key_path: dir.join("api_key.json"),
                     api_base_url: LOCAL_API_BASE_URL.to_string(),
                     default_operator_kind: OperatorKind::Local,
@@ -82,10 +83,10 @@ pub fn write_hosted_only_config(home: &Path, alias: &str, org_id: &str) {
 
     let config = Config {
         active_org: Some(alias.to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             alias.to_string(),
             OrgConfig {
-                id: org_id.to_string(),
+                id: org_id.parse().expect("test org ids must be UUIDs"),
                 api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
                 api_base_url: LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -148,10 +149,10 @@ pub fn write_yubikey_only_config_with_public_key(
 
     let config = Config {
         active_org: Some(alias.to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             alias.to_string(),
             OrgConfig {
-                id: org_id.to_string(),
+                id: org_id.parse().expect("test org ids must be UUIDs"),
                 api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
                 api_base_url: LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Yubikey,
@@ -202,13 +203,13 @@ pub fn write_yubikey_shared_config(home: &Path, profiles: &[(&str, &str)]) {
     )
     .unwrap();
 
-    let orgs: HashMap<_, _> = profiles
+    let orgs: IndexMap<_, _> = profiles
         .iter()
         .map(|(alias, org_id)| {
             (
                 alias.to_string(),
                 OrgConfig {
-                    id: org_id.to_string(),
+                    id: org_id.parse().expect("test org ids must be UUIDs"),
                     api_key_path: turnkey_dir.join(format!("orgs/{alias}/api_key.json")),
                     api_base_url: LOCAL_API_BASE_URL.to_string(),
                     default_operator_kind: OperatorKind::Yubikey,

--- a/tvc/tests/common.rs
+++ b/tvc/tests/common.rs
@@ -1,5 +1,8 @@
-//! Fixtures shared across the tvc integration-test binaries. Each binary
-//! compiles its own copy and uses a subset, so unused items are expected.
+//! Fixtures shared across the tvc integration-test binaries.
+
+// Each test binary that declares `mod common;` compiles its own copy and
+// uses a subset of these helpers, so every binary's build has genuinely
+// unused items here; without this, each `cargo test` target warns.
 #![allow(dead_code)]
 
 use indexmap::IndexMap;

--- a/tvc/tests/config_migration.rs
+++ b/tvc/tests/config_migration.rs
@@ -1,0 +1,273 @@
+//! End-to-end config-migration behavior through the real binary: any
+//! config-loading command migrates eagerly, migration notes reach stderr,
+//! the interrupted-migration fence blocks with instructions, and the
+//! instructed manual fixes actually recover.
+//!
+//! The vehicle command is `keys backup-operator-key --output <path>`: it
+//! loads the config right after its non-interactive input check and touches
+//! no network, so every run deterministically exercises the load path.
+
+mod common;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+const ORG_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+fn config_path(home: &Path) -> PathBuf {
+    home.join(".config/turnkey/tvc.config.toml")
+}
+
+fn backup_path(home: &Path) -> PathBuf {
+    home.join(".config/turnkey/tvc.config.toml.backup")
+}
+
+fn write_config(home: &Path, contents: &str) {
+    let dir = home.join(".config/turnkey");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("tvc.config.toml"), contents).unwrap();
+}
+
+fn v0_config() -> String {
+    format!(
+        r#"
+active_org = "default"
+
+[orgs.default]
+id = "{ORG_ID}"
+api_key_path = "/keys/api.json"
+operator_key_path = "/keys/operator.json"
+"#
+    )
+}
+
+fn run_config_loading_command(home: &Path) -> assert_cmd::assert::Assert {
+    cargo_bin_cmd!("tvc")
+        .env("HOME", home)
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("keys")
+        .arg("backup-operator-key")
+        .arg("--output")
+        .arg(home.join("backup-out.json"))
+        .assert()
+}
+
+/// A v0 config is rewritten to the current schema by the first command that
+/// loads it — even one that goes on to fail — and the fence backup is gone
+/// afterwards.
+#[test]
+fn any_config_loading_command_migrates_v0_eagerly() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+
+    // The command itself fails later (the registered key file does not
+    // exist); the migration has already been persisted by then.
+    run_config_loading_command(temp.path()).failure();
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(saved.contains(ORG_ID), "{saved}");
+    assert!(!backup_path(temp.path()).exists());
+}
+
+/// A jump straight from v0 to the current schema is one load, not a chain of
+/// upgrades the user must run in order: the rewritten file keeps the org,
+/// its alias, and the active-org marker.
+#[test]
+fn v0_to_v2_is_a_single_load_with_nothing_left_behind() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+
+    run_config_loading_command(temp.path()).failure();
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(table["version"].as_integer(), Some(2));
+    assert_eq!(table["active_org"].as_str(), Some(ORG_ID));
+    assert_eq!(table["aliases"]["default"].as_str(), Some(ORG_ID));
+    assert!(table["orgs"][ORG_ID].is_table(), "{saved}");
+}
+
+/// Lossy migration decisions are reported on stderr, once, at migration
+/// time.
+#[test]
+fn v1_duplicate_merge_notes_reach_stderr() {
+    let temp = TempDir::new().unwrap();
+    write_config(
+        temp.path(),
+        &format!(
+            r#"
+version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "{ORG_ID}"
+api_key_path = "/keys/a/api.json"
+
+[orgs.alias-b]
+id = "{ORG_ID}"
+api_key_path = "/keys/b/api.json"
+"#
+        ),
+    );
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains(
+            "config migration: merged duplicate profile 'alias-b'",
+        ));
+
+    // The note is one-time: the migrated file loads silently afterwards.
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("config migration").not());
+}
+
+/// An interrupted migration blocks every command with the recovery
+/// instructions, and does not touch either file while blocked.
+#[test]
+fn an_interrupted_migration_blocks_every_command_with_instructions() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+    fs::write(backup_path(temp.path()), "pre-migration bytes").unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"))
+        .stderr(predicate::str::contains("delete"));
+
+    assert_eq!(
+        fs::read_to_string(config_path(temp.path())).unwrap(),
+        v0_config(),
+        "a blocked load must not rewrite the config"
+    );
+    assert_eq!(
+        fs::read_to_string(backup_path(temp.path())).unwrap(),
+        "pre-migration bytes"
+    );
+}
+
+/// The crash window between parking the original and writing the new file
+/// leaves only the backup; starting fresh would shadow the user's data, so
+/// the same fence applies.
+#[test]
+fn a_backup_alone_blocks_instead_of_starting_fresh() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".config/turnkey")).unwrap();
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+}
+
+/// Manual fix for the post-write window: the config is already migrated, so
+/// deleting the backup is the instructed resolution — and it works.
+#[test]
+fn deleting_the_backup_recovers_the_post_write_crash_window() {
+    let temp = TempDir::new().unwrap();
+    write_config(temp.path(), &v0_config());
+    run_config_loading_command(temp.path()).failure();
+
+    // Recreate the window: migrated config on disk, stale backup beside it.
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+
+    fs::remove_file(backup_path(temp.path())).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration").not());
+}
+
+/// Manual fix for the pre-write window: the config file is missing, so
+/// restoring the backup over the config path re-runs the migration cleanly.
+#[test]
+fn restoring_the_backup_recovers_the_pre_write_crash_window() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".config/turnkey")).unwrap();
+    fs::write(backup_path(temp.path()), v0_config()).unwrap();
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+
+    fs::rename(backup_path(temp.path()), config_path(temp.path())).unwrap();
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration").not());
+
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(!backup_path(temp.path()).exists());
+}
+
+/// A config written by a newer tvc is refused by name and left untouched.
+#[test]
+fn a_newer_config_version_is_refused_and_left_untouched() {
+    let temp = TempDir::new().unwrap();
+    let contents = format!("version = 3\n\n[orgs.{ORG_ID}]\napi_key_path = \"/keys/api.json\"\n");
+    write_config(temp.path(), &contents);
+
+    run_config_loading_command(temp.path())
+        .failure()
+        .stderr(predicate::str::contains(
+            "config written by a newer tvc (version 3)",
+        ));
+
+    assert_eq!(
+        fs::read_to_string(config_path(temp.path())).unwrap(),
+        contents
+    );
+}
+
+/// The config-schema migration is eager, but the key-directory migration is
+/// interactive-only: a non-interactive command migrates the file schema and
+/// keeps reading key files from the legacy alias-keyed directory it still
+/// points at.
+#[test]
+fn non_interactive_commands_use_legacy_directories_without_moving_them() {
+    let temp = TempDir::new().unwrap();
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_ID);
+    write_config(
+        temp.path(),
+        &format!(
+            r#"
+version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "{ORG_ID}"
+api_key_path = "{api_key}"
+
+[[orgs.alias-a.operators]]
+name = "default"
+kind = "local"
+key_path = "{operator_key}"
+"#,
+            api_key = legacy_dir.join("api_key.json").display(),
+            operator_key = legacy_dir.join("operator.json").display(),
+        ),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+
+    run_config_loading_command(temp.path()).success();
+
+    // Schema migrated, directories untouched, config still points at the
+    // legacy layout.
+    let saved = fs::read_to_string(config_path(temp.path())).unwrap();
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(legacy_dir.join("operator.json").exists());
+    assert!(!id_dir.exists());
+    assert!(
+        saved.contains(legacy_dir.join("api_key.json").to_str().unwrap()),
+        "{saved}"
+    );
+}

--- a/tvc/tests/config_validation.rs
+++ b/tvc/tests/config_validation.rs
@@ -18,7 +18,7 @@ fn deploy_create_non_interactive_reports_all_placeholder_errors() {
     let config = NamedTempFile::new().unwrap();
     fs::write(
         config.path(),
-        serde_json::to_string_pretty(&DeployConfig::template(None)).unwrap(),
+        serde_json::to_string_pretty(&DeployConfig::template(Default::default())).unwrap(),
     )
     .unwrap();
 
@@ -30,7 +30,6 @@ fn deploy_create_non_interactive_reports_all_placeholder_errors() {
         .arg(config.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("app_id"))
         .stderr(predicate::str::contains("pivot_container_image_url"))
         .stderr(predicate::str::contains("pivot_path"))
         .stderr(predicate::str::contains("expected_pivot_digest"))

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -53,7 +53,7 @@ fn write_config(home: &TempDir, config: &Config) {
     fs::write(
         config_dir.join("tvc.config.toml"),
         format!(
-            r#"version = 1
+            r#"version = 2
 {}"#,
             toml::to_string_pretty(config).unwrap()
         ),
@@ -178,12 +178,11 @@ fn deployment_response(
 
 fn write_hosted_config(home: &TempDir) {
     let public = fixture_manifest_member_key(0);
-    let config = Config {
-        active_org: Some("test".to_string()),
+    let mut config = Config {
+        active_org: Some(ORG_TEST.parse().unwrap()),
         orgs: IndexMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
                 api_key_path: home.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -203,6 +202,9 @@ fn write_hosted_config(home: &TempDir) {
         )]),
         ..Config::default()
     };
+    config
+        .aliases
+        .bind("test".to_string(), ORG_TEST.parse().unwrap());
     write_config(home, &config);
 }
 
@@ -294,12 +296,11 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
     let hosted_key = fixture_manifest_member_key(0);
     let yubikey_key = fixture_manifest_member_key(2);
     let serial = YubiKeySerial::from(0x01c9_5c1f);
-    let config = Config {
-        active_org: Some("test".to_string()),
+    let mut config = Config {
+        active_org: Some(ORG_TEST.parse().unwrap()),
         orgs: IndexMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "http://127.0.0.1:1".to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -335,7 +336,7 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
         .try_into()
         .unwrap(),
         last_operator_ids: HashMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             vec![
                 "66666666-6666-4666-8666-666666666666".to_string(),
                 "77777777-7777-4777-8777-777777777777".to_string(),
@@ -343,6 +344,9 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
         )]),
         ..Config::default()
     };
+    config
+        .aliases
+        .bind("test".to_string(), ORG_TEST.parse().unwrap());
     write_config(&temp, &config);
 
     let body = deployment_response(hosted_key, yubikey_key);
@@ -490,12 +494,11 @@ fn malformed_config_fails_before_dispatch_even_with_explicit_seed() {
 #[test]
 fn remembered_operator_ids_are_not_approval_candidates() {
     let temp = TempDir::new().unwrap();
-    let config = Config {
-        active_org: Some("test".to_string()),
+    let mut config = Config {
+        active_org: Some(ORG_TEST.parse().unwrap()),
         orgs: IndexMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -503,9 +506,15 @@ fn remembered_operator_ids_are_not_approval_candidates() {
                 extra: toml::Table::new(),
             },
         )]),
-        last_operator_ids: HashMap::from([("test".to_string(), vec!["not-a-uuid".to_string()])]),
+        last_operator_ids: HashMap::from([(
+            ORG_TEST.parse().unwrap(),
+            vec!["not-a-uuid".to_string()],
+        )]),
         ..Config::default()
     };
+    config
+        .aliases
+        .bind("test".to_string(), ORG_TEST.parse().unwrap());
     write_config(&temp, &config);
 
     cargo_bin_cmd!("tvc")
@@ -537,12 +546,11 @@ fn malformed_registered_local_operator_id_is_reported() {
         .unwrap(),
     )
     .unwrap();
-    let config = Config {
-        active_org: Some("test".to_string()),
+    let mut config = Config {
+        active_org: Some(ORG_TEST.parse().unwrap()),
         orgs: IndexMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -559,6 +567,9 @@ fn malformed_registered_local_operator_id_is_reported() {
         )]),
         ..Config::default()
     };
+    config
+        .aliases
+        .bind("test".to_string(), ORG_TEST.parse().unwrap());
     write_config(&temp, &config);
 
     cargo_bin_cmd!("tvc")
@@ -591,12 +602,11 @@ fn manifest_membership_controls_signer_resolution_in_mixed_registry() {
         .unwrap(),
     )
     .unwrap();
-    let config = Config {
-        active_org: Some("test".to_string()),
+    let mut config = Config {
+        active_org: Some(ORG_TEST.parse().unwrap()),
         orgs: IndexMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -626,11 +636,14 @@ fn manifest_membership_controls_signer_resolution_in_mixed_registry() {
             },
         )]),
         last_operator_ids: HashMap::from([(
-            "test".to_string(),
+            ORG_TEST.parse().unwrap(),
             vec![HOSTED_OPERATOR_ID.to_string()],
         )]),
         ..Config::default()
     };
+    config
+        .aliases
+        .bind("test".to_string(), ORG_TEST.parse().unwrap());
     write_config(&temp, &config);
 
     cargo_bin_cmd!("tvc")

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -338,8 +338,8 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
         last_operator_ids: HashMap::from([(
             ORG_TEST.parse().unwrap(),
             vec![
-                "66666666-6666-4666-8666-666666666666".to_string(),
-                "77777777-7777-4777-8777-777777777777".to_string(),
+                "66666666-6666-4666-8666-666666666666".parse().unwrap(),
+                "77777777-7777-4777-8777-777777777777".parse().unwrap(),
             ],
         )]),
         ..Config::default()
@@ -508,7 +508,7 @@ fn remembered_operator_ids_are_not_approval_candidates() {
         )]),
         last_operator_ids: HashMap::from([(
             ORG_TEST.parse().unwrap(),
-            vec!["not-a-uuid".to_string()],
+            vec!["99999999-9999-4999-8999-999999999999".parse().unwrap()],
         )]),
         ..Config::default()
     };
@@ -637,7 +637,7 @@ fn manifest_membership_controls_signer_resolution_in_mixed_registry() {
         )]),
         last_operator_ids: HashMap::from([(
             ORG_TEST.parse().unwrap(),
-            vec![HOSTED_OPERATOR_ID.to_string()],
+            vec![HOSTED_OPERATOR_ID.parse().unwrap()],
         )]),
         ..Config::default()
     };

--- a/tvc/tests/deploy_approve.rs
+++ b/tvc/tests/deploy_approve.rs
@@ -1,6 +1,9 @@
 mod common;
 
+const ORG_TEST: &str = "33333333-3333-4333-8333-333333333333";
+
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
@@ -64,7 +67,7 @@ fn authenticated_command(home: &TempDir, api_base_url: &str) -> assert_cmd::Comm
     command
         .env_clear()
         .env("HOME", home.path())
-        .env("TVC_ORG_ID", "org-test")
+        .env("TVC_ORG_ID", ORG_TEST)
         .env(
             "TVC_API_KEY_PUBLIC",
             hex::encode(stamper.compressed_public_key()),
@@ -128,12 +131,12 @@ fn deployment_response(
     serde_json::to_string(&GetTvcDeploymentResponse {
         tvc_deployment: Some(TvcDeployment {
             id: DEPLOYMENT_ID.to_string(),
-            organization_id: "org-test".to_string(),
+            organization_id: ORG_TEST.parse().unwrap(),
             app_id: "app-test".to_string(),
             manifest_set: Some(TvcOperatorSet {
                 id: "manifest-set-test".to_string(),
                 name: "manifest-set".to_string(),
-                organization_id: "org-test".to_string(),
+                organization_id: ORG_TEST.parse().unwrap(),
                 operators: vec![
                     TvcOperator {
                         id: HOSTED_OPERATOR_ID.to_string(),
@@ -177,10 +180,10 @@ fn write_hosted_config(home: &TempDir) {
     let public = fixture_manifest_member_key(0);
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path: home.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -264,7 +267,7 @@ fn selected_yubikey_without_a_prompt_reports_the_pin_requirement() {
     common::write_yubikey_only_config_with_public_key(
         temp.path(),
         "test",
-        "org-test",
+        ORG_TEST,
         fixture_manifest_member_key(0),
     );
 
@@ -293,10 +296,10 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
     let serial = YubiKeySerial::from(0x01c9_5c1f);
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "http://127.0.0.1:1".to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -371,7 +374,7 @@ fn deploy_id_and_serial_resolve_one_operator_identity_by_public_key() {
 #[test]
 fn an_unknown_yubikey_serial_is_rejected_before_manifest_io() {
     let temp = TempDir::new().unwrap();
-    common::write_yubikey_only_config(temp.path(), "test", "org-test");
+    common::write_yubikey_only_config(temp.path(), "test", ORG_TEST);
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
@@ -489,10 +492,10 @@ fn remembered_operator_ids_are_not_approval_candidates() {
     let temp = TempDir::new().unwrap();
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -536,10 +539,10 @@ fn malformed_registered_local_operator_id_is_reported() {
     .unwrap();
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -590,10 +593,10 @@ fn manifest_membership_controls_signer_resolution_in_mixed_registry() {
     .unwrap();
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path: temp.path().join("api-key.json"),
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,

--- a/tvc/tests/error_output.rs
+++ b/tvc/tests/error_output.rs
@@ -34,7 +34,7 @@ fn authenticated_command(home: &TempDir, api_base_url: &str) -> assert_cmd::Comm
     let mut command = tvc_command();
     command
         .env("HOME", home.path())
-        .env("TVC_ORG_ID", "org-test")
+        .env("TVC_ORG_ID", "33333333-3333-4333-8333-333333333333")
         .env(
             "TVC_API_KEY_PUBLIC",
             hex::encode(stamper.compressed_public_key()),

--- a/tvc/tests/keys_backup_operator_key.rs
+++ b/tvc/tests/keys_backup_operator_key.rs
@@ -1,5 +1,7 @@
 mod common;
 
+const ORG_BACKUP: &str = "66666666-6666-4666-8666-666666666666";
+
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use std::fs;
@@ -44,7 +46,7 @@ fn hosted_only_org_explains_there_is_no_key_file_to_back_up() {
 #[test]
 fn backs_up_with_org_and_output() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     let operator_public_key = common::write_profile_key_files(temp.path(), "alias-a");
     let destination = temp.path().join("backups/operator-backup.json");
 
@@ -71,7 +73,7 @@ fn backs_up_with_org_and_output() {
 #[test]
 fn defaults_to_active_org() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     let destination = temp.path().join("operator-backup.json");
 
@@ -92,7 +94,7 @@ fn defaults_to_active_org() {
 #[test]
 fn existing_destination_requires_overwrite() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     let destination = temp.path().join("operator-backup.json");
     fs::write(&destination, "previous backup").unwrap();
@@ -149,7 +151,7 @@ fn piped_stdin_without_output_errors() {
 #[test]
 fn piped_stdin_existing_destination_requires_overwrite_flag() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     let destination = temp.path().join("operator-backup.json");
     fs::write(&destination, "previous backup").unwrap();
@@ -171,7 +173,7 @@ fn piped_stdin_existing_destination_requires_overwrite_flag() {
 #[test]
 fn missing_operator_key_file_errors() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
@@ -189,7 +191,7 @@ fn missing_operator_key_file_errors() {
 #[test]
 fn json_message_format_emits_reason_tag() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
 
     cargo_bin_cmd!("tvc")

--- a/tvc/tests/keys_yubikey.rs
+++ b/tvc/tests/keys_yubikey.rs
@@ -23,7 +23,7 @@ fn write_config(home: &TempDir, config: &Config) {
     fs::create_dir_all(&turnkey_dir).unwrap();
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(config).unwrap()),
     )
     .unwrap();
 }
@@ -43,7 +43,6 @@ fn config_with_registered_device() -> Config {
 
 fn org_with_yubikey_operator() -> OrgConfig {
     OrgConfig {
-        id: "33333333-3333-4333-8333-333333333333".parse().unwrap(),
         api_key_path: "/keys/api.json".into(),
         api_base_url: "http://127.0.0.1:1".to_string(),
         default_operator_kind: Default::default(),
@@ -128,10 +127,17 @@ fn unregister_refuses_an_unregistered_serial() {
 #[test]
 fn unregister_refuses_a_device_an_organization_references() {
     let temp = TempDir::new().unwrap();
-    let config = Config {
-        orgs: IndexMap::from([("test".to_string(), org_with_yubikey_operator())]),
+    let mut config = Config {
+        orgs: IndexMap::from([(
+            "33333333-3333-4333-8333-333333333333".parse().unwrap(),
+            org_with_yubikey_operator(),
+        )]),
         ..config_with_registered_device()
     };
+    config.aliases.bind(
+        "test".to_string(),
+        "33333333-3333-4333-8333-333333333333".parse().unwrap(),
+    );
     write_config(&temp, &config);
 
     cargo_bin_cmd!("tvc")
@@ -192,6 +198,5 @@ fn unregister_removes_only_the_local_registry_entry() {
         ));
 
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    let config = Config::from_toml(&saved).unwrap();
-    assert!(!config.yubikeys.contains(SERIAL.parse().unwrap()));
+    assert!(!saved.contains(SERIAL), "{saved}");
 }

--- a/tvc/tests/keys_yubikey.rs
+++ b/tvc/tests/keys_yubikey.rs
@@ -6,8 +6,8 @@
 //! the yubikey module and its ignored hardware cycle.
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
-use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
 use tvc::config::turnkey::{
@@ -43,7 +43,7 @@ fn config_with_registered_device() -> Config {
 
 fn org_with_yubikey_operator() -> OrgConfig {
     OrgConfig {
-        id: "org-test".to_string(),
+        id: "33333333-3333-4333-8333-333333333333".parse().unwrap(),
         api_key_path: "/keys/api.json".into(),
         api_base_url: "http://127.0.0.1:1".to_string(),
         default_operator_kind: Default::default(),
@@ -129,7 +129,7 @@ fn unregister_refuses_an_unregistered_serial() {
 fn unregister_refuses_a_device_an_organization_references() {
     let temp = TempDir::new().unwrap();
     let config = Config {
-        orgs: HashMap::from([("test".to_string(), org_with_yubikey_operator())]),
+        orgs: IndexMap::from([("test".to_string(), org_with_yubikey_operator())]),
         ..config_with_registered_device()
     };
     write_config(&temp, &config);

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -119,6 +119,40 @@ fn profile_delete_non_interactive_with_duplicate_org_id_lists_profiles() {
     assert!(temp.path().join(".config/turnkey/orgs/alias-b").exists());
 }
 
+/// Custom (non-default-layout) key paths are never deleted: the profile entry
+/// is removed from the config but the files stay on disk with a warning.
+#[test]
+fn profile_delete_warns_and_keeps_custom_key_paths() {
+    let temp = TempDir::new().unwrap();
+    let custom_dir = temp.path().join("custom-keys");
+    let api_key_path = custom_dir.join("api_key.json");
+    let operator_key_path = custom_dir.join("operator.json");
+    fs::create_dir_all(&custom_dir).unwrap();
+    fs::write(&api_key_path, "custom api key").unwrap();
+    fs::write(&operator_key_path, "custom operator key").unwrap();
+    write_login_config(&temp, api_key_path.clone(), operator_key_path.clone());
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("profile")
+        .arg("delete")
+        .arg("--org")
+        .arg("test")
+        .arg("--yes")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "custom key paths are configured and were NOT deleted",
+        ));
+
+    assert!(api_key_path.exists());
+    assert!(operator_key_path.exists());
+
+    let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains("org-test"));
+}
+
 #[test]
 fn login_help_shows_api_base_url_override() {
     cargo_bin_cmd!("tvc")

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -60,6 +60,65 @@ fn login_errors_when_provided_org_not_found() {
         ));
 }
 
+/// TVC-159: an org-ID query matching several profiles must not resolve to an
+/// arbitrary one; non-interactive login fails fast and names them all.
+#[test]
+fn login_non_interactive_with_duplicate_org_id_lists_profiles() {
+    let temp = TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        Some("alias-a"),
+    );
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .arg("--org")
+        .arg("org-dup-test")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Organization 'org-dup-test' is configured under multiple profiles: alias-a, alias-b",
+        ))
+        .stderr(predicate::str::contains("--org <alias>"));
+}
+
+/// TVC-159: same fence for `profile delete` — an ambiguous org-ID query must
+/// not delete an arbitrary profile.
+#[test]
+fn profile_delete_non_interactive_with_duplicate_org_id_lists_profiles() {
+    let temp = TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        Some("alias-a"),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("profile")
+        .arg("delete")
+        .arg("--org")
+        .arg("org-dup-test")
+        .arg("--yes")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Organization 'org-dup-test' is configured under multiple profiles: alias-a, alias-b",
+        ))
+        .stderr(predicate::str::contains(
+            "to select which profile to delete",
+        ));
+
+    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
+    assert!(temp.path().join(".config/turnkey/orgs/alias-b").exists());
+}
+
 #[test]
 fn login_help_shows_api_base_url_override() {
     cargo_bin_cmd!("tvc")

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -36,10 +36,10 @@ fn write_login_config(
     config.set_active_org(org_id).unwrap();
     config
         .last_created_app_id
-        .insert(org_id, "app-1".to_string());
+        .insert(org_id, Uuid::from_u128(0xAA));
     config
         .last_operator_ids
-        .insert(org_id, vec!["operator-1".to_string()]);
+        .insert(org_id, vec![Uuid::from_u128(0xBB)]);
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
         format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
@@ -268,8 +268,8 @@ fn login_delete_removes_legacy_alias_keyed_layout() {
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(saved.contains("version = 2"));
     assert!(!saved.contains(ORG_TEST));
-    assert!(!saved.contains("app-1"));
-    assert!(!saved.contains("operator-1"));
+    assert!(!saved.contains(&Uuid::from_u128(0xAA).to_string()));
+    assert!(!saved.contains(&Uuid::from_u128(0xBB).to_string()));
 }
 
 /// Deleting a profile with the id-keyed directory layout (what login creates

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -1,12 +1,11 @@
 mod common;
 
 use assert_cmd::cargo::cargo_bin_cmd;
-use indexmap::IndexMap;
 use predicates::prelude::*;
-use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
 use tvc::config::turnkey::{Config, OperatorKind, OperatorRecord, OrgConfig};
+use uuid::Uuid;
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
 
@@ -21,27 +20,29 @@ fn write_login_config(
 ) {
     let turnkey_dir = home.path().join(".config/turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
-    let config = Config {
-        active_org: Some("test".to_string()),
-        orgs: IndexMap::from([(
-            "test".to_string(),
-            OrgConfig {
-                id: ORG_TEST.parse().unwrap(),
-                api_key_path,
-                api_base_url: "https://api.turnkey.com".to_string(),
-                default_operator_kind: OperatorKind::Local,
-                operators: vec![OperatorRecord::local(operator_key_path)],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::from([("test".to_string(), "app-1".to_string())]),
-        last_operator_ids: HashMap::from([("test".to_string(), vec!["operator-1".to_string()])]),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = ORG_TEST.parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path,
+            api_base_url: "https://api.turnkey.com".to_string(),
+            default_operator_kind: OperatorKind::Local,
+            operators: vec![OperatorRecord::local(operator_key_path)],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("test".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
+    config
+        .last_created_app_id
+        .insert(org_id, "app-1".to_string());
+    config
+        .last_operator_ids
+        .insert(org_id, vec!["operator-1".to_string()]);
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 }
@@ -65,16 +66,87 @@ fn login_errors_when_provided_org_not_found() {
         ));
 }
 
-/// TVC-159: an org-ID query matching several profiles must not resolve to an
-/// arbitrary one; non-interactive login fails fast and names them all.
+fn saved_config(home: &TempDir) -> String {
+    fs::read_to_string(home.path().join(".config/turnkey/tvc.config.toml")).unwrap()
+}
+
+/// A v1 (alias-keyed) config is migrated eagerly on the first load: the file
+/// is rewritten as v2 behind the backup fence, and the command proceeds
+/// against the migrated model.
 #[test]
-fn login_non_interactive_with_duplicate_org_id_lists_profiles() {
+fn any_command_migrates_a_v1_config_eagerly() {
     let temp = TempDir::new().unwrap();
-    common::write_profiles_config(
-        temp.path(),
-        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
-        Some("alias-a"),
+    let turnkey_dir = temp.path().join(".config/turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!(
+            r#"version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "{ORG_DUP}"
+api_key_path = "/keys/api.json"
+api_base_url = "{}"
+"#,
+            common::LOCAL_API_BASE_URL
+        ),
+    )
+    .unwrap();
+
+    // The command itself fails (no API key at the fixture path), but the
+    // resolution ran against the migrated config and the file was rewritten.
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .arg("--org")
+        .arg("alias-a")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(format!(
+            "Selected org: alias-a ({ORG_DUP})"
+        )));
+
+    let saved = saved_config(&temp);
+    assert!(saved.contains("version = 2"), "{saved}");
+    assert!(saved.contains("[aliases]"), "{saved}");
+    assert!(
+        !temp
+            .path()
+            .join(".config/turnkey/tvc.config.toml.backup")
+            .exists()
     );
+}
+
+/// A leftover migration backup means a previous run crashed mid-migration;
+/// every command refuses to run until it is resolved manually.
+#[test]
+fn a_leftover_migration_backup_blocks_commands() {
+    let temp = TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config/turnkey");
+    fs::create_dir_all(&turnkey_dir).unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_DUP)], Some("alias-a"));
+    fs::write(turnkey_dir.join("tvc.config.toml.backup"), "old contents").unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .arg("--org")
+        .arg("alias-a")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("interrupted config migration"));
+}
+
+/// Logging in by organization ID echoes the ID; the alias only appears in
+/// output when the user typed one (inputs match outputs).
+#[test]
+fn login_by_id_echoes_the_id_not_the_alias() {
+    let temp = TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_DUP)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
@@ -83,45 +155,9 @@ fn login_non_interactive_with_duplicate_org_id_lists_profiles() {
         .arg("--org")
         .arg(ORG_DUP)
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(format!(
-            "Organization '{ORG_DUP}' is configured under multiple profiles: alias-a, alias-b"
-        )))
-        .stderr(predicate::str::contains("--org <alias>"));
-}
-
-/// TVC-159: same fence for `profile delete` — an ambiguous org-ID query must
-/// not delete an arbitrary profile.
-#[test]
-fn profile_delete_non_interactive_with_duplicate_org_id_lists_profiles() {
-    let temp = TempDir::new().unwrap();
-    common::write_profiles_config(
-        temp.path(),
-        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
-        Some("alias-a"),
-    );
-    common::write_profile_key_files(temp.path(), "alias-a");
-    common::write_profile_key_files(temp.path(), "alias-b");
-
-    cargo_bin_cmd!("tvc")
-        .env("HOME", temp.path())
-        .env(NON_INTERACTIVE_ENV, "1")
-        .arg("profile")
-        .arg("delete")
-        .arg("--org")
-        .arg(ORG_DUP)
-        .arg("--yes")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(format!(
-            "Organization '{ORG_DUP}' is configured under multiple profiles: alias-a, alias-b"
-        )))
-        .stderr(predicate::str::contains(
-            "to select which profile to delete",
-        ));
-
-    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
-    assert!(temp.path().join(".config/turnkey/orgs/alias-b").exists());
+        .failure() // dead-port whoami
+        .stdout(predicate::str::contains(format!("Selected org: {ORG_DUP}")))
+        .stdout(predicate::str::contains("Selected org: alias-a").not());
 }
 
 /// Custom (non-default-layout) key paths are never deleted: the profile entry
@@ -230,7 +266,7 @@ fn login_delete_removes_legacy_alias_keyed_layout() {
 
     assert!(!org_dir.exists());
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(saved.contains("version = 1"));
+    assert!(saved.contains("version = 2"));
     assert!(!saved.contains(ORG_TEST));
     assert!(!saved.contains("app-1"));
     assert!(!saved.contains("operator-1"));
@@ -266,10 +302,10 @@ fn login_delete_removes_id_keyed_layout() {
     assert!(!saved.contains(ORG_TEST));
 }
 
-/// A hand-edited config can point several profiles into one id-keyed
-/// directory; deleting one profile must not take the survivor's keys with it.
+/// A hand-edited config can point several organizations into one directory;
+/// deleting one must not take the survivor's keys with it.
 #[test]
-fn profile_delete_keeps_directory_shared_with_another_profile() {
+fn profile_delete_keeps_directory_shared_with_another_org() {
     let temp = TempDir::new().unwrap();
     let turnkey_dir = temp.path().join(".config/turnkey");
     let org_dir = turnkey_dir.join("orgs").join(ORG_DUP);
@@ -278,27 +314,23 @@ fn profile_delete_keeps_directory_shared_with_another_profile() {
     fs::write(org_dir.join("operator.json"), "shared operator key").unwrap();
 
     let shared_profile = || OrgConfig {
-        id: ORG_DUP.parse().unwrap(),
         api_key_path: org_dir.join("api_key.json"),
         api_base_url: "https://api.turnkey.com".to_string(),
         default_operator_kind: OperatorKind::Local,
         operators: vec![OperatorRecord::local(org_dir.join("operator.json"))],
         extra: toml::Table::new(),
     };
-    let config = Config {
-        active_org: Some("alias-b".to_string()),
-        orgs: IndexMap::from([
-            ("alias-a".to_string(), shared_profile()),
-            ("alias-b".to_string(), shared_profile()),
-        ]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
-    };
+    let org_a: Uuid = ORG_DUP.parse().unwrap();
+    let org_b: Uuid = ORG_TEST.parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(org_a, shared_profile());
+    config.orgs.insert(org_b, shared_profile());
+    config.aliases.bind("alias-a".to_string(), org_a);
+    config.aliases.bind("alias-b".to_string(), org_b);
+    config.set_active_org(org_b).unwrap();
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 
@@ -313,7 +345,7 @@ fn profile_delete_keeps_directory_shared_with_another_profile() {
         .assert()
         .success()
         .stderr(predicate::str::contains(
-            "is still used by another profile and was NOT deleted",
+            "is still used by another organization and was NOT deleted",
         ));
 
     assert!(org_dir.join("api_key.json").exists());

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
@@ -8,6 +9,9 @@ use tempfile::TempDir;
 use tvc::config::turnkey::{Config, OperatorKind, OperatorRecord, OrgConfig};
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
+
+const ORG_DUP: &str = "11111111-2222-4333-8444-555555555555";
+const ORG_TEST: &str = "33333333-3333-4333-8333-333333333333";
 
 fn write_login_config(
     home: &TempDir,
@@ -18,10 +22,10 @@ fn write_login_config(
     fs::create_dir_all(&turnkey_dir).unwrap();
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: ORG_TEST.parse().unwrap(),
                 api_key_path,
                 api_base_url: "https://api.turnkey.com".to_string(),
                 default_operator_kind: OperatorKind::Local,
@@ -67,7 +71,7 @@ fn login_non_interactive_with_duplicate_org_id_lists_profiles() {
     let temp = TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
         Some("alias-a"),
     );
 
@@ -76,12 +80,12 @@ fn login_non_interactive_with_duplicate_org_id_lists_profiles() {
         .env(NON_INTERACTIVE_ENV, "1")
         .arg("login")
         .arg("--org")
-        .arg("org-dup-test")
+        .arg(ORG_DUP)
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "Organization 'org-dup-test' is configured under multiple profiles: alias-a, alias-b",
-        ))
+        .stderr(predicate::str::contains(format!(
+            "Organization '{ORG_DUP}' is configured under multiple profiles: alias-a, alias-b"
+        )))
         .stderr(predicate::str::contains("--org <alias>"));
 }
 
@@ -92,7 +96,7 @@ fn profile_delete_non_interactive_with_duplicate_org_id_lists_profiles() {
     let temp = TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
         Some("alias-a"),
     );
     common::write_profile_key_files(temp.path(), "alias-a");
@@ -104,13 +108,13 @@ fn profile_delete_non_interactive_with_duplicate_org_id_lists_profiles() {
         .arg("profile")
         .arg("delete")
         .arg("--org")
-        .arg("org-dup-test")
+        .arg(ORG_DUP)
         .arg("--yes")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "Organization 'org-dup-test' is configured under multiple profiles: alias-a, alias-b",
-        ))
+        .stderr(predicate::str::contains(format!(
+            "Organization '{ORG_DUP}' is configured under multiple profiles: alias-a, alias-b"
+        )))
         .stderr(predicate::str::contains(
             "to select which profile to delete",
         ));
@@ -150,7 +154,7 @@ fn profile_delete_warns_and_keeps_custom_key_paths() {
     assert!(operator_key_path.exists());
 
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(!saved.contains("org-test"));
+    assert!(!saved.contains(ORG_TEST));
 }
 
 #[test]
@@ -190,7 +194,7 @@ fn login_delete_removes_default_registry_key_layout() {
     assert!(!org_dir.exists());
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(saved.contains("version = 1"));
-    assert!(!saved.contains("org-test"));
+    assert!(!saved.contains(ORG_TEST));
     assert!(!saved.contains("app-1"));
     assert!(!saved.contains("operator-1"));
 }
@@ -201,7 +205,7 @@ fn login_delete_removes_default_registry_key_layout() {
 #[test]
 fn login_delete_keeps_the_yubikey_registry_entry() {
     let temp = TempDir::new().unwrap();
-    common::write_yubikey_only_config(temp.path(), "test", "org-test");
+    common::write_yubikey_only_config(temp.path(), "test", ORG_TEST);
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
@@ -217,7 +221,7 @@ fn login_delete_keeps_the_yubikey_registry_entry() {
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(saved.contains("[[yubikeys]]"), "{saved}");
     assert!(saved.contains("serial = \"01c95c1f\""), "{saved}");
-    assert!(!saved.contains("org-test"), "{saved}");
+    assert!(!saved.contains(ORG_TEST), "{saved}");
 }
 
 /// With two profiles sharing one registered serial, deleting one leaves the
@@ -225,7 +229,13 @@ fn login_delete_keeps_the_yubikey_registry_entry() {
 #[test]
 fn login_delete_preserves_a_shared_yubikey_registry_entry() {
     let temp = TempDir::new().unwrap();
-    common::write_yubikey_shared_config(temp.path(), &[("one", "org-1"), ("two", "org-2")]);
+    common::write_yubikey_shared_config(
+        temp.path(),
+        &[
+            ("one", "10000000-0000-4000-8000-000000000011"),
+            ("two", "10000000-0000-4000-8000-000000000022"),
+        ],
+    );
 
     cargo_bin_cmd!("tvc")
         .env("HOME", temp.path())
@@ -235,8 +245,14 @@ fn login_delete_preserves_a_shared_yubikey_registry_entry() {
         .success();
 
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(!saved.contains("org-1"), "{saved}");
-    assert!(saved.contains("org-2"), "{saved}");
+    assert!(
+        !saved.contains("10000000-0000-4000-8000-000000000011"),
+        "{saved}"
+    );
+    assert!(
+        saved.contains("10000000-0000-4000-8000-000000000022"),
+        "{saved}"
+    );
     assert!(saved.contains("[[yubikeys]]"), "{saved}");
     assert!(saved.contains("serial = \"01c95c1f\""), "{saved}");
 }

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -168,8 +168,11 @@ fn login_help_shows_api_base_url_override() {
         .stdout(predicate::str::contains("TVC_API_BASE_URL"));
 }
 
+/// Deleting a profile with the legacy alias-keyed directory layout still
+/// removes that directory (TVC-55 changed the default to id-keyed, but the
+/// legacy layout remains recognized).
 #[test]
-fn login_delete_removes_default_registry_key_layout() {
+fn login_delete_removes_legacy_alias_keyed_layout() {
     let temp = TempDir::new().unwrap();
     let org_dir = temp.path().join(".config/turnkey/orgs/test");
     let api_key_path = org_dir.join("api_key.json");
@@ -197,6 +200,94 @@ fn login_delete_removes_default_registry_key_layout() {
     assert!(!saved.contains(ORG_TEST));
     assert!(!saved.contains("app-1"));
     assert!(!saved.contains("operator-1"));
+}
+
+/// Deleting a profile with the id-keyed directory layout (what login creates
+/// since TVC-55) removes that directory.
+#[test]
+fn login_delete_removes_id_keyed_layout() {
+    let temp = TempDir::new().unwrap();
+    let org_dir = temp.path().join(".config/turnkey/orgs").join(ORG_TEST);
+    let api_key_path = org_dir.join("api_key.json");
+    let operator_key_path = org_dir.join("operator.json");
+    fs::create_dir_all(&org_dir).unwrap();
+    fs::write(&api_key_path, "not needed for deletion").unwrap();
+    fs::write(&operator_key_path, "not needed for deletion").unwrap();
+    write_login_config(&temp, api_key_path, operator_key_path);
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("profile")
+        .arg("delete")
+        .arg("--org")
+        .arg("test")
+        .arg("--yes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed key directory"));
+
+    assert!(!org_dir.exists());
+    let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains(ORG_TEST));
+}
+
+/// A hand-edited config can point several profiles into one id-keyed
+/// directory; deleting one profile must not take the survivor's keys with it.
+#[test]
+fn profile_delete_keeps_directory_shared_with_another_profile() {
+    let temp = TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config/turnkey");
+    let org_dir = turnkey_dir.join("orgs").join(ORG_DUP);
+    fs::create_dir_all(&org_dir).unwrap();
+    fs::write(org_dir.join("api_key.json"), "shared api key").unwrap();
+    fs::write(org_dir.join("operator.json"), "shared operator key").unwrap();
+
+    let shared_profile = || OrgConfig {
+        id: ORG_DUP.parse().unwrap(),
+        api_key_path: org_dir.join("api_key.json"),
+        api_base_url: "https://api.turnkey.com".to_string(),
+        default_operator_kind: OperatorKind::Local,
+        operators: vec![OperatorRecord::local(org_dir.join("operator.json"))],
+        extra: toml::Table::new(),
+    };
+    let config = Config {
+        active_org: Some("alias-b".to_string()),
+        orgs: IndexMap::from([
+            ("alias-a".to_string(), shared_profile()),
+            ("alias-b".to_string(), shared_profile()),
+        ]),
+        yubikeys: Default::default(),
+        last_created_app_id: HashMap::new(),
+        last_operator_ids: HashMap::new(),
+        extra: toml::Table::new(),
+    };
+    fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("profile")
+        .arg("delete")
+        .arg("--org")
+        .arg("alias-a")
+        .arg("--yes")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "is still used by another profile and was NOT deleted",
+        ));
+
+    assert!(org_dir.join("api_key.json").exists());
+    assert!(org_dir.join("operator.json").exists());
+
+    let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(saved.contains("alias-b"));
+    assert!(!saved.contains("alias-a"));
 }
 
 /// Deleting a yubikey-default profile removes the org but never the device:

--- a/tvc/tests/login.rs
+++ b/tvc/tests/login.rs
@@ -11,6 +11,7 @@ use tvc::config::turnkey::{Config, OperatorKind, OperatorRecord, OrgConfig};
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
 
 const ORG_DUP: &str = "11111111-2222-4333-8444-555555555555";
+const ORG_SOLO: &str = "55555555-5555-4555-8555-555555555555";
 const ORG_TEST: &str = "33333333-3333-4333-8333-333333333333";
 
 fn write_login_config(
@@ -155,6 +156,39 @@ fn profile_delete_warns_and_keeps_custom_key_paths() {
 
     let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(!saved.contains(ORG_TEST));
+}
+
+/// Non-interactive login never touches the filesystem layout: legacy
+/// alias-keyed directories and the paths pointing at them stay put.
+#[test]
+fn login_non_interactive_leaves_legacy_layout_alone() {
+    let temp = TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_SOLO)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+
+    // Exits nonzero at the dead-port whoami; the layout must be untouched.
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("login")
+        .arg("--org")
+        .arg("alias-a")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Moved key directory").not());
+
+    assert!(legacy_dir.join("api_key.json").exists());
+    assert!(
+        !temp
+            .path()
+            .join(".config/turnkey/orgs")
+            .join(ORG_SOLO)
+            .exists()
+    );
+
+    let saved = fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(saved.contains("orgs/alias-a/api_key.json"));
 }
 
 #[test]

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -7,6 +7,7 @@
 //! Commands join this fence as they gain prompting behavior.
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use indexmap::IndexMap;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
@@ -39,10 +40,10 @@ fn write_config(
 
     let config = Config {
         active_org: Some("test".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "test".to_string(),
             OrgConfig {
-                id: "org-test".to_string(),
+                id: "10000000-0000-4000-8000-000000000001".parse().unwrap(),
                 api_key_path,
                 api_base_url: LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Local,

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -7,9 +7,7 @@
 //! Commands join this fence as they gain prompting behavior.
 
 use assert_cmd::cargo::cargo_bin_cmd;
-use indexmap::IndexMap;
 use predicates::prelude::*;
-use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};
@@ -17,6 +15,7 @@ use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use tvc::config::turnkey::{
     Config, KeyCurve, OperatorKind, OperatorRecord, OrgConfig, StoredApiKey,
 };
+use uuid::Uuid;
 
 const NON_INTERACTIVE_ENV: &str = "TVC_NON_INTERACTIVE";
 const LOCAL_API_BASE_URL: &str = "http://127.0.0.1:1";
@@ -38,28 +37,25 @@ fn write_config(
     let turnkey_dir = home.path().join(".config").join("turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
 
-    let config = Config {
-        active_org: Some("test".to_string()),
-        orgs: IndexMap::from([(
-            "test".to_string(),
-            OrgConfig {
-                id: "10000000-0000-4000-8000-000000000001".parse().unwrap(),
-                api_key_path,
-                api_base_url: LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Local,
-                operators: vec![OperatorRecord::local(operator_key_path)],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::from([("test".to_string(), last_operator_ids)]),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = "10000000-0000-4000-8000-000000000001".parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path,
+            api_base_url: LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Local,
+            operators: vec![OperatorRecord::local(operator_key_path)],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("test".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
+    config.last_operator_ids.insert(org_id, last_operator_ids);
 
     fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 }

--- a/tvc/tests/non_interactive.rs
+++ b/tvc/tests/non_interactive.rs
@@ -32,7 +32,7 @@ fn write_config(
     home: &TempDir,
     api_key_path: std::path::PathBuf,
     operator_key_path: std::path::PathBuf,
-    last_operator_ids: Vec<String>,
+    last_operator_ids: Vec<Uuid>,
 ) {
     let turnkey_dir = home.path().join(".config").join("turnkey");
     fs::create_dir_all(&turnkey_dir).unwrap();
@@ -245,8 +245,8 @@ fn app_init_interactive_conflicts_with_non_interactive_env() {
         ));
 }
 
-/// `deploy create` with no config file and no required fields can't prompt for
-/// the missing values, so it bails naming every field the user still has to set.
+/// `deploy create` with no config file requires --app-id up front; with it
+/// but nothing else, it bails naming every field the user still has to set.
 #[test]
 fn deploy_create_without_required_fields_bails_naming_each_field() {
     let temp = TempDir::new().unwrap();
@@ -258,7 +258,17 @@ fn deploy_create_without_required_fields_bails_naming_each_field() {
         .arg("create")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("app_id"))
+        .stderr(predicate::str::contains("--app-id is a required argument"));
+
+    cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .env(NON_INTERACTIVE_ENV, "1")
+        .arg("deploy")
+        .arg("create")
+        .arg("--app-id")
+        .arg("11111111-1111-4111-8111-111111111111")
+        .assert()
+        .failure()
         .stderr(predicate::str::contains("pivot_container_image_url"))
         .stderr(predicate::str::contains("pivot_path"))
         .stderr(predicate::str::contains("expected_pivot_digest"));
@@ -276,7 +286,7 @@ fn deploy_create_pull_secret_placeholder_bails_when_non_interactive() {
     // init-time sentinel that the user must resolve to null (public) or a real
     // encrypted secret (private).
     let config = r#"{
-        "appId": "file-app-id",
+        "appId": "33333333-3333-4333-8333-333333333333",
         "qosVersion": "file-qos",
         "pivotContainerImageUrl": "file-image",
         "pivotPath": "file-path",
@@ -344,8 +354,8 @@ fn approve_explicit_seed_does_not_inherit_a_saved_operator_id() {
         api_key_path.clone(),
         operator_key_path,
         vec![
-            "11111111-1111-4111-8111-111111111111".to_string(),
-            "22222222-2222-4222-8222-222222222222".to_string(),
+            "11111111-1111-4111-8111-111111111111".parse().unwrap(),
+            "22222222-2222-4222-8222-222222222222".parse().unwrap(),
         ],
     );
     write_api_key(&api_key_path);

--- a/tvc/tests/operator_create.rs
+++ b/tvc/tests/operator_create.rs
@@ -217,7 +217,7 @@ serial = "01c95c1f"
 public_key = "{key}"
 
 [orgs.default]
-id = "org-123"
+id = "11111111-1111-4111-8111-111111111111"
 api_key_path = "/keys/api.json"
 
 [[orgs.default.operators]]
@@ -277,7 +277,11 @@ fn a_registered_serial_is_added_non_interactively_without_a_device() {
 fn a_failed_hosted_default_save_reports_the_record_and_default_kind() {
     let temp = tempfile::TempDir::new().unwrap();
     let (api_base_url, server) = spawn_create_operator_server();
-    common::write_profiles_config(temp.path(), &[("default", "org-123")], Some("default"));
+    common::write_profiles_config(
+        temp.path(),
+        &[("default", "11111111-1111-4111-8111-111111111111")],
+        Some("default"),
+    );
     common::write_profile_key_files(temp.path(), "default");
 
     let config_path = temp.path().join(".config/turnkey/tvc.config.toml");

--- a/tvc/tests/operator_create.rs
+++ b/tvc/tests/operator_create.rs
@@ -201,7 +201,7 @@ fn an_unregistered_serial_points_at_external_setup() {
         ));
 }
 
-/// Write a v1 config with an active local-default org and one registered
+/// Write a v2 config with an active local-default org and one registered
 /// YubiKey the org does not reference yet.
 fn write_local_org_with_registered_yubikey(home: &Path) {
     let dir = home.join(".config/turnkey");
@@ -209,18 +209,20 @@ fn write_local_org_with_registered_yubikey(home: &Path) {
     std::fs::write(
         dir.join("tvc.config.toml"),
         format!(
-            r#"version = 1
-active_org = "default"
+            r#"version = 2
+active_org = "11111111-1111-4111-8111-111111111111"
+
+[aliases]
+default = "11111111-1111-4111-8111-111111111111"
 
 [[yubikeys]]
 serial = "01c95c1f"
 public_key = "{key}"
 
-[orgs.default]
-id = "11111111-1111-4111-8111-111111111111"
+[orgs.11111111-1111-4111-8111-111111111111]
 api_key_path = "/keys/api.json"
 
-[[orgs.default.operators]]
+[[orgs.11111111-1111-4111-8111-111111111111.operators]]
 name = "default"
 kind = "local"
 key_path = "/keys/operator.json"
@@ -301,7 +303,9 @@ fn a_failed_hosted_default_save_reports_the_record_and_default_kind() {
         .stderr(predicate::str::contains(
             "hosted operator 11111111-1111-4111-8111-111111111111 was created remotely",
         ))
-        .stderr(predicate::str::contains(r#"[[orgs."default".operators]]"#))
+        .stderr(predicate::str::contains(
+            r#"[[orgs."11111111-1111-4111-8111-111111111111".operators]]"#,
+        ))
         .stderr(predicate::str::contains("kind = \"hosted\""))
         .stderr(predicate::str::contains(
             "default_operator_kind = \"hosted\"",
@@ -330,7 +334,9 @@ fn a_failed_save_reports_the_recovery_record() {
         .stderr(predicate::str::contains(
             "the YubiKey operator could not be saved",
         ))
-        .stderr(predicate::str::contains(r#"[[orgs."default".operators]]"#))
+        .stderr(predicate::str::contains(
+            r#"[[orgs."11111111-1111-4111-8111-111111111111".operators]]"#,
+        ))
         .stderr(predicate::str::contains("kind = \"yubikey\""))
         .stderr(predicate::str::contains("default_operator_kind"));
 }

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -290,7 +290,9 @@ fn login_consolidates_duplicate_profiles_interactively() {
         .exp_string("IMPORTANT: The API key may still be registered")
         .unwrap();
 
-    // Login proceeds against the consolidated config.
+    // The keeper's legacy directory is migrated to the id-keyed layout, then
+    // login proceeds against the consolidated config.
+    session.exp_string("Moved key directory").unwrap();
     session.exp_string("Select organization").unwrap();
     session.send_line("alias-a").unwrap();
     exp_wrapped(&mut session, &format!("Selected org: alias-a ({ORG_DUP})"));
@@ -299,7 +301,14 @@ fn login_consolidates_duplicate_profiles_interactively() {
     session.exp_eof().unwrap();
 
     assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
-    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
+    assert!(!temp.path().join(".config/turnkey/orgs/alias-a").exists());
+    assert!(
+        temp.path()
+            .join(".config/turnkey/orgs")
+            .join(ORG_DUP)
+            .join("api_key.json")
+            .exists()
+    );
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
@@ -485,6 +494,69 @@ fn keys_backup_operator_key_prompts_for_destination() {
     assert!(destination.exists());
 }
 
+/// TVC-55: interactive login migrates a legacy alias-keyed key directory to
+/// the id-keyed layout — directory renamed, config paths rewritten, login
+/// succeeds — and a second login finds nothing left to migrate.
+#[test]
+fn login_migrates_legacy_key_directory() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_dir.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Using existing API key.").unwrap();
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(!legacy_dir.exists());
+    assert!(id_dir.join("api_key.json").exists());
+    assert!(id_dir.join("operator.json").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    let org = table["orgs"]["alias-a"].as_table().unwrap();
+    assert_eq!(
+        org["api_key_path"].as_str().unwrap(),
+        id_dir.join("api_key.json").to_str().unwrap()
+    );
+    assert_eq!(
+        org["operators"].as_array().unwrap()[0]["key_path"]
+            .as_str()
+            .unwrap(),
+        id_dir.join("operator.json").to_str().unwrap()
+    );
+
+    // Idempotent: a second login has nothing to move and succeeds silently.
+    let (api_base_url, server) = spawn_whoami_server();
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+    let output = session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(output.contains("Successfully logged in!"), "{output}");
+    assert!(!output.contains("Moved key directory"), "{output}");
+}
+
 /// TVC-53: generating a fresh operator key during login offers a backup;
 /// accepting prompts for a destination, writes the copy, and login still
 /// succeeds. The mock whoami server carries login past its network step.
@@ -521,11 +593,15 @@ fn login_fresh_operator_key_offers_backup() {
     session.exp_eof().unwrap();
     server.join().unwrap();
 
+    // The legacy directory was migrated on the way in, so the freshly
+    // generated key lives in the id-keyed layout.
     assert_eq!(
         std::fs::read(&destination).unwrap(),
         std::fs::read(
             temp.path()
-                .join(".config/turnkey/orgs/alias-a/operator.json")
+                .join(".config/turnkey/orgs")
+                .join(ORG_E2E)
+                .join("operator.json")
         )
         .unwrap()
     );

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -10,10 +10,8 @@
 
 mod common;
 
-use indexmap::IndexMap;
 use qos_p256::P256Pair;
 use rexpect::session::PtySession;
-use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
@@ -25,6 +23,7 @@ use tvc::config::turnkey::{
     Config, HostedOperatorRecord, KeyCurve, OperatorKind, OperatorRecord, OperatorRecordKind,
     OrgConfig, StoredApiKey, YubiKeyOperatorRecord, YubiKeySerial,
 };
+use uuid::Uuid;
 
 /// Default per-step timeout. Generous enough for CI-runner cold cargo builds
 /// of the binary; tight enough to fail fast if an `exp_string` mismatches.
@@ -252,140 +251,49 @@ fn login_with_empty_org_id_bails() {
     session.exp_eof().unwrap();
 }
 
-/// TVC-159: interactive `tvc login` folds duplicate profiles down to one per
-/// organization before proceeding: prompt for the keeper, one confirmation,
-/// full profile-delete cleanup for the losers, and active-profile repair onto
-/// the keeper. Duplicate profiles can no longer be created through the CLI,
-/// so this seeds the legacy on-disk state directly.
+/// Organization IDs are UUIDs; anything else is rejected at the prompt
+/// boundary before any profile is created.
 #[test]
-fn login_consolidates_duplicate_profiles_interactively() {
+fn login_with_non_uuid_org_id_bails() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(
-        temp.path(),
-        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
-        Some("alias-b"),
-    );
-    common::write_profile_key_files(temp.path(), "alias-a");
-    common::write_profile_key_files(temp.path(), "alias-b");
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
-    exp_wrapped(
-        &mut session,
-        &format!("Select the profile to keep for organization '{ORG_DUP}'"),
-    );
-    session.send_line("alias-a").unwrap();
-
+    session.exp_string("Organization ID").unwrap();
+    session.send_line("not-a-uuid").unwrap();
     session
-        .exp_string("Permanently delete 'alias-b' and the key files on disk?")
+        .exp_string("Organization ID must be a UUID")
         .unwrap();
-    session.send_line("y").unwrap();
-
-    exp_wrapped(
-        &mut session,
-        &format!("Deleted login profile 'alias-b' ({ORG_DUP})."),
-    );
-    session.exp_string("Removed key directory").unwrap();
-    session
-        .exp_string("IMPORTANT: The API key may still be registered")
-        .unwrap();
-
-    // The keeper's legacy directory is migrated to the id-keyed layout, then
-    // login proceeds against the consolidated config.
-    session.exp_string("Moved key directory").unwrap();
-    session.exp_string("Select organization").unwrap();
-    session.send_line("alias-a").unwrap();
-    exp_wrapped(&mut session, &format!("Selected org: alias-a ({ORG_DUP})"));
-    session.exp_string("Using existing API key.").unwrap();
-    session.exp_string("Verifying credentials...").unwrap();
     session.exp_eof().unwrap();
-
-    assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
-    assert!(!temp.path().join(".config/turnkey/orgs/alias-a").exists());
-    assert!(
-        temp.path()
-            .join(".config/turnkey/orgs")
-            .join(ORG_DUP)
-            .join("api_key.json")
-            .exists()
-    );
-
-    let saved =
-        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(!saved.contains("alias-b"));
-    assert!(saved.contains(r#"active_org = "alias-a""#));
 }
 
-/// Declining the consolidation confirmation cancels login and leaves both
-/// profiles and their key files untouched (nothing is mutated before the
-/// single consent point).
+/// `profile delete` without --org prompts with the organization picker and
+/// deletes only the chosen organization.
 #[test]
-fn login_consolidation_decline_cancels_login() {
+fn profile_delete_without_query_prompts_with_picker() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
-        Some("alias-b"),
-    );
-    common::write_profile_key_files(temp.path(), "alias-a");
-    common::write_profile_key_files(temp.path(), "alias-b");
-
-    let mut session = spawn_with_home(temp.path(), &["login"]);
-
-    exp_wrapped(
-        &mut session,
-        &format!("Select the profile to keep for organization '{ORG_DUP}'"),
-    );
-    session.send_line("alias-a").unwrap();
-
-    session
-        .exp_string("Permanently delete 'alias-b' and the key files on disk?")
-        .unwrap();
-    session.send_line("n").unwrap();
-
-    session
-        .exp_string("operation cancelled by user: profile consolidation")
-        .unwrap();
-    session.exp_eof().unwrap();
-
-    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
-    assert!(temp.path().join(".config/turnkey/orgs/alias-b").exists());
-
-    let saved =
-        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(saved.contains("alias-a"));
-    assert!(saved.contains("alias-b"));
-}
-
-/// `profile delete --org <org-id>` with several profiles registered for that
-/// organization ID prompts for which profile to delete instead of deleting an
-/// arbitrary one (TVC-159), and only the chosen profile is removed.
-#[test]
-fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
-    let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(
-        temp.path(),
-        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_OTHER)],
         Some("alias-a"),
     );
     common::write_profile_key_files(temp.path(), "alias-a");
     common::write_profile_key_files(temp.path(), "alias-b");
 
-    let mut session = spawn_with_home(temp.path(), &["profile", "delete", "--org", ORG_DUP]);
+    let mut session = spawn_with_home(temp.path(), &["profile", "delete"]);
 
-    session.exp_string("Select profile to delete").unwrap();
+    session.exp_string("Select organization to delete").unwrap();
     session.send_line("alias-b").unwrap();
 
     exp_wrapped(
         &mut session,
-        &format!("Permanently delete profile 'alias-b' ({ORG_DUP})"),
+        &format!("Permanently delete 'alias-b' ({ORG_OTHER})"),
     );
     session.send_line("y").unwrap();
 
-    exp_wrapped(
-        &mut session,
-        &format!("Deleted login profile 'alias-b' ({ORG_DUP})."),
-    );
+    session
+        .exp_string("Deleted the login for organization")
+        .unwrap();
     session.exp_eof().unwrap();
 
     assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
@@ -407,8 +315,11 @@ fn login_creates_first_profile_and_persists_it() {
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(saved.contains("[orgs.solo]"));
-    assert!(saved.contains(&format!(r#"id = "{ORG_SOLO}""#)));
+    assert!(saved.contains(&format!("[orgs.{ORG_SOLO}]")), "{saved}");
+    assert!(
+        saved.contains(&format!(r#"solo = "{ORG_SOLO}""#)),
+        "{saved}"
+    );
 
     let org_dir = temp.path().join(".config/turnkey/orgs").join(ORG_SOLO);
     assert!(org_dir.join("api_key.json").exists());
@@ -433,16 +344,23 @@ fn login_new_org_refuses_already_configured_org_id() {
 
     exp_wrapped(
         &mut session,
-        &format!("Organization '{ORG_DUP}' is already configured as profile 'alias-a'."),
+        &format!("Organization '{ORG_DUP}' is already configured as 'alias-a'."),
     );
     session
         .exp_string("tvc profile delete --org alias-a")
         .unwrap();
     session.exp_eof().unwrap();
 
+    // Refused before any mutation: still exactly one configured org and one
+    // alias.
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert_eq!(saved.matches(&format!(r#"id = "{ORG_DUP}""#)).count(), 1);
+    // "\n[orgs." matches the org table header but not "[[orgs.<id>.operators]]".
+    assert_eq!(saved.matches("\n[orgs.").count(), 1, "{saved}");
+    assert!(
+        saved.contains(&format!(r#"alias-a = "{ORG_DUP}""#)),
+        "{saved}"
+    );
 }
 
 /// Reusing an existing profile alias for a different organization refuses
@@ -464,13 +382,13 @@ fn login_new_org_refuses_alias_already_in_use() {
 
     exp_wrapped(
         &mut session,
-        &format!("Profile alias 'alias-a' is already in use for organization '{ORG_OTHER}'."),
+        &format!("Alias 'alias-a' already names organization '{ORG_OTHER}'."),
     );
     session.exp_eof().unwrap();
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(saved.contains(&format!(r#"id = "{ORG_OTHER}""#)));
+    assert!(saved.contains(&format!("[orgs.{ORG_OTHER}]")), "{saved}");
     assert!(!saved.contains(ORG_SOLO));
 }
 
@@ -532,7 +450,7 @@ fn login_migrates_legacy_key_directory() {
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     let table: toml::Table = toml::from_str(&saved).unwrap();
-    let org = table["orgs"]["alias-a"].as_table().unwrap();
+    let org = table["orgs"][ORG_E2E].as_table().unwrap();
     assert_eq!(
         org["api_key_path"].as_str().unwrap(),
         id_dir.join("api_key.json").to_str().unwrap()
@@ -769,30 +687,27 @@ fn write_hosted_org_config(home: &Path, saved_operator_ids: &[&str]) -> String {
             }),
     );
 
-    let config = Config {
-        active_org: Some("hosted-org".to_string()),
-        orgs: IndexMap::from([(
-            "hosted-org".to_string(),
-            OrgConfig {
-                id: ORG_HOSTED.parse().unwrap(),
-                api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
-                api_base_url: common::LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Hosted,
-                operators,
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::from([(
-            "hosted-org".to_string(),
-            saved_operator_ids.iter().map(|id| id.to_string()).collect(),
-        )]),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = ORG_HOSTED.parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
+            api_base_url: common::LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Hosted,
+            operators,
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("hosted-org".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
+    config.last_operator_ids.insert(
+        org_id,
+        saved_operator_ids.iter().map(|id| id.to_string()).collect(),
+    );
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 
@@ -1000,7 +915,7 @@ fn write_registry_only_config(home: &Path) -> String {
         .register(YubiKeySerial::from(0x01c9_5c1f), composite.parse().unwrap());
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 
@@ -1097,27 +1012,23 @@ fn login_selects_among_multiple_yubikey_operators() {
             .parse()
             .unwrap()
     };
-    let mut config = Config {
-        active_org: Some("yk-org".to_string()),
-        orgs: IndexMap::from([(
-            "yk-org".to_string(),
-            OrgConfig {
-                id: ORG_E2E.parse().unwrap(),
-                api_key_path: turnkey_dir.join("orgs/yk-org/api_key.json"),
-                api_base_url: common::LOCAL_API_BASE_URL.to_string(),
-                default_operator_kind: OperatorKind::Yubikey,
-                operators: vec![
-                    yubikey_record("first", 0x01c9_5c1f),
-                    yubikey_record("second", 0xdead_beef),
-                ],
-                extra: toml::Table::new(),
-            },
-        )]),
-        yubikeys: Default::default(),
-        last_created_app_id: HashMap::new(),
-        last_operator_ids: HashMap::new(),
-        extra: toml::Table::new(),
-    };
+    let org_id: Uuid = ORG_E2E.parse().unwrap();
+    let mut config = Config::default();
+    config.orgs.insert(
+        org_id,
+        OrgConfig {
+            api_key_path: turnkey_dir.join("orgs/yk-org/api_key.json"),
+            api_base_url: common::LOCAL_API_BASE_URL.to_string(),
+            default_operator_kind: OperatorKind::Yubikey,
+            operators: vec![
+                yubikey_record("first", 0x01c9_5c1f),
+                yubikey_record("second", 0xdead_beef),
+            ],
+            extra: toml::Table::new(),
+        },
+    );
+    config.aliases.bind("yk-org".to_string(), org_id);
+    config.set_active_org(org_id).unwrap();
     config
         .yubikeys
         .register(YubiKeySerial::from(0x01c9_5c1f), registry_key());
@@ -1126,7 +1037,7 @@ fn login_selects_among_multiple_yubikey_operators() {
         .register(YubiKeySerial::from(0xdead_beef), registry_key());
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),
-        format!("version = 1\n{}", toml::to_string_pretty(&config).unwrap()),
+        format!("version = 2\n{}", toml::to_string_pretty(&config).unwrap()),
     )
     .unwrap();
 

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -12,7 +12,7 @@ mod common;
 
 use qos_p256::P256Pair;
 use rexpect::session::PtySession;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
@@ -253,61 +253,67 @@ fn login_with_empty_org_id_bails() {
     session.exp_eof().unwrap();
 }
 
-/// TVC-159: when one organization ID is registered under multiple aliases,
-/// `login --org <org-id>` resolves to an arbitrary alias, because resolution
-/// falls back to `HashMap` iteration order, which is randomized per process.
-///
-/// The duplicate state is created through the CLI itself (two logins to the
-/// same organization under different aliases), then resolution runs in fresh
-/// processes until both aliases have been observed. With the bug present the
-/// expected number of attempts is 2-3; all 40 agreeing has probability 2⁻³⁹.
+/// TVC-159: `login --org <org-id>` with several profiles registered for that
+/// organization ID prompts for which profile to use instead of resolving to
+/// an arbitrary one. The duplicate state is created through the CLI itself,
+/// proving the fix handles profiles that predate it.
 #[test]
-fn login_with_duplicate_org_id_selects_alias_nondeterministically() {
+fn login_with_duplicate_org_id_prompts_for_profile() {
     let temp = tempfile::TempDir::new().unwrap();
     pty_create_profile(temp.path(), "org-dup-test", "alias-a", false);
     pty_create_profile(temp.path(), "org-dup-test", "alias-b", true);
 
-    let bin = env!("CARGO_BIN_EXE_tvc");
-    let mut seen = BTreeSet::new();
+    let mut session = spawn_with_home(temp.path(), &["login", "--org", "org-dup-test"]);
 
-    for _ in 0..40 {
-        let output = Command::new(bin)
-            .args(["login", "--org", "org-dup-test"])
-            .env("HOME", temp.path())
-            .env("TVC_NON_INTERACTIVE", "1")
-            .env_remove("TVC_ORG")
-            .env_remove("TVC_API_BASE_URL")
-            .env_remove("TVC_ORG_ID")
-            .env_remove("TVC_API_KEY_PUBLIC")
-            .env_remove("TVC_API_KEY_PRIVATE")
-            .output()
-            .unwrap();
+    session
+        .exp_string("Select profile for organization 'org-dup-test'")
+        .unwrap();
+    session.send_line("alias-a").unwrap();
 
-        // Selection happens (and the config is saved) before the whoami
-        // request, which fails against the dead-port base URL on the profile.
-        assert!(!output.status.success());
+    session
+        .exp_string("Selected org: alias-a (org-dup-test)")
+        .unwrap();
+    session.exp_string("Using existing API key.").unwrap();
+    session.exp_string("Verifying credentials...").unwrap();
+    session.exp_eof().unwrap();
+}
 
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        let alias = stdout
-            .lines()
-            .find_map(|line| line.strip_prefix("Selected org: "))
-            .and_then(|rest| rest.strip_suffix(" (org-dup-test)"))
-            .unwrap_or_else(|| panic!("no selected-org line in output:\n{stdout}"));
-        seen.insert(alias.to_string());
-
-        if seen.len() == 2 {
-            break;
-        }
-    }
-
-    let expected = ["alias-a", "alias-b"]
-        .into_iter()
-        .map(String::from)
-        .collect::<BTreeSet<_>>();
-    assert_eq!(
-        seen, expected,
-        "resolution by org ID should be nondeterministic across processes (TVC-159)"
+/// `profile delete --org <org-id>` with several profiles registered for that
+/// organization ID prompts for which profile to delete instead of deleting an
+/// arbitrary one (TVC-159), and only the chosen profile is removed.
+#[test]
+fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        Some("alias-a"),
     );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+
+    let mut session = spawn_with_home(temp.path(), &["profile", "delete", "--org", "org-dup-test"]);
+
+    session.exp_string("Select profile to delete").unwrap();
+    session.send_line("alias-b").unwrap();
+
+    session
+        .exp_string("Permanently delete profile 'alias-b' (org-dup-test)")
+        .unwrap();
+    session.send_line("y").unwrap();
+
+    session
+        .exp_string("Deleted login profile 'alias-b' (org-dup-test).")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
+    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains("alias-b"));
+    assert!(saved.contains("alias-a"));
 }
 
 /// Interactive `keys backup-operator-key` prompts for the destination and

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -78,22 +78,13 @@ fn spawn_with_home(home: &Path, args: &[&str]) -> PtySession {
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {bin} {}", args.join(" ")))
 }
 
-/// Drive `tvc login` through the interactive new-org flow against a dead-port
-/// API base URL. Login persists the profile and its generated API key before
-/// the final whoami request, so the profile exists on disk even though the
-/// command exits nonzero when that request fails.
-///
-/// `pick_new_in_selector` is required once profiles exist: login then opens an
-/// org selector first, and typing "new" filters it down to the
-/// "[new] Add a new organization" entry (no fixture string here contains
-/// "new") which Enter selects.
-fn pty_create_profile(home: &Path, org_id: &str, alias: &str, pick_new_in_selector: bool) {
+/// Drive `tvc login` through the interactive new-org flow (empty config, so
+/// no org selector appears) against a dead-port API base URL. Login persists
+/// the profile and its generated API key before the final whoami request, so
+/// the profile exists on disk even though the command exits nonzero when that
+/// request fails.
+fn pty_create_profile(home: &Path, org_id: &str, alias: &str) {
     let mut session = spawn_with_home(home, &["login", "--api-base-url", "http://127.0.0.1:1"]);
-
-    if pick_new_in_selector {
-        session.exp_string("Select organization").unwrap();
-        session.send_line("new").unwrap();
-    }
 
     session.exp_string("Organization ID").unwrap();
     session.send_line(org_id).unwrap();
@@ -255,13 +246,18 @@ fn login_with_empty_org_id_bails() {
 
 /// TVC-159: `login --org <org-id>` with several profiles registered for that
 /// organization ID prompts for which profile to use instead of resolving to
-/// an arbitrary one. The duplicate state is created through the CLI itself,
-/// proving the fix handles profiles that predate it.
+/// an arbitrary one. Duplicate profiles can no longer be created through the
+/// CLI, so this seeds the legacy on-disk state directly.
 #[test]
 fn login_with_duplicate_org_id_prompts_for_profile() {
     let temp = tempfile::TempDir::new().unwrap();
-    pty_create_profile(temp.path(), "org-dup-test", "alias-a", false);
-    pty_create_profile(temp.path(), "org-dup-test", "alias-b", true);
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        Some("alias-b"),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
 
     let mut session = spawn_with_home(temp.path(), &["login", "--org", "org-dup-test"]);
 
@@ -314,6 +310,77 @@ fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(!saved.contains("alias-b"));
     assert!(saved.contains("alias-a"));
+}
+
+/// The interactive new-org flow (the only way to create a profile) works end
+/// to end and persists the profile even though the final whoami request fails
+/// against the dead-port URL.
+#[test]
+fn login_creates_first_profile_and_persists_it() {
+    let temp = tempfile::TempDir::new().unwrap();
+    pty_create_profile(temp.path(), "org-solo-test", "solo");
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(saved.contains("[orgs.solo]"));
+    assert!(saved.contains(r#"id = "org-solo-test""#));
+}
+
+/// Entering an organization ID that is already configured refuses to create a
+/// second profile for it (one profile per organization, TVC-159) and names
+/// the existing alias.
+#[test]
+fn login_new_org_refuses_already_configured_org_id() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", "org-dup-test")], Some("alias-a"));
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session.exp_string("Select organization").unwrap();
+    session.send_line("new").unwrap();
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line("org-dup-test").unwrap();
+
+    session
+        .exp_string("Organization 'org-dup-test' is already configured as profile 'alias-a'.")
+        .unwrap();
+    session
+        .exp_string("tvc profile delete --org alias-a")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert_eq!(saved.matches(r#"id = "org-dup-test""#).count(), 1);
+}
+
+/// Reusing an existing profile alias for a different organization refuses
+/// instead of silently overwriting the profile.
+#[test]
+fn login_new_org_refuses_alias_already_in_use() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", "org-other-id")], Some("alias-a"));
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session.exp_string("Select organization").unwrap();
+    session.send_line("new").unwrap();
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line("org-fresh-id").unwrap();
+    session.exp_string("Organization alias").unwrap();
+    session.send_line("alias-a").unwrap();
+
+    session
+        .exp_string("Profile alias 'alias-a' is already in use for organization 'org-other-id'.")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(saved.contains(r#"id = "org-other-id""#));
+    assert!(!saved.contains("org-fresh-id"));
 }
 
 /// Interactive `keys backup-operator-key` prompts for the destination and

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -326,13 +326,14 @@ fn login_creates_first_profile_and_persists_it() {
     assert!(!temp.path().join(".config/turnkey/orgs/solo").exists());
 }
 
-/// Entering an organization ID that is already configured refuses to create a
-/// second profile for it (one profile per organization, TVC-159) and names
-/// the existing alias.
+/// Entering an organization ID that is already configured offers to bind an
+/// extra alias to the existing entry; accepting binds the name and logs into
+/// the same organization without reconfiguring it.
 #[test]
-fn login_new_org_refuses_already_configured_org_id() {
+fn login_new_org_binds_an_extra_alias_after_confirmation() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(temp.path(), &[("alias-a", ORG_DUP)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
@@ -347,12 +348,18 @@ fn login_new_org_refuses_already_configured_org_id() {
         &format!("Organization '{ORG_DUP}' is already configured as 'alias-a'."),
     );
     session
-        .exp_string("tvc profile delete --org alias-a")
+        .exp_string("Bind another alias to 'alias-a' and log in to it?")
         .unwrap();
+    session.send_line("y").unwrap();
+
+    session.exp_string("Organization alias").unwrap();
+    session.send_line("alias-b").unwrap();
+
+    exp_wrapped(&mut session, &format!("Selected org: alias-b ({ORG_DUP})"));
+    session.exp_string("Using existing API key.").unwrap();
     session.exp_eof().unwrap();
 
-    // Refused before any mutation: still exactly one configured org and one
-    // alias.
+    // One organization, two names; the existing entry was not reconfigured.
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     // "\n[orgs." matches the org table header but not "[[orgs.<id>.operators]]".
@@ -361,12 +368,71 @@ fn login_new_org_refuses_already_configured_org_id() {
         saved.contains(&format!(r#"alias-a = "{ORG_DUP}""#)),
         "{saved}"
     );
+    assert!(
+        saved.contains(&format!(r#"alias-b = "{ORG_DUP}""#)),
+        "{saved}"
+    );
 }
 
-/// Reusing an existing profile alias for a different organization refuses
-/// instead of silently overwriting the profile.
+/// Declining the extra-alias confirmation cancels login before anything is
+/// bound or written.
 #[test]
-fn login_new_org_refuses_alias_already_in_use() {
+fn login_extra_alias_decline_cancels_login() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_DUP)], Some("alias-a"));
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session.exp_string("Select organization").unwrap();
+    session.send_line("new").unwrap();
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line(ORG_DUP).unwrap();
+
+    session
+        .exp_string("Bind another alias to 'alias-a' and log in to it?")
+        .unwrap();
+    session.send_line("n").unwrap();
+
+    session
+        .exp_string("operation cancelled by user: alias binding")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains("alias-b"), "{saved}");
+}
+
+/// UUID-shaped aliases are refused at binding: org queries parse UUID-shaped
+/// input as an organization ID, so such a name could never be looked up.
+#[test]
+fn login_new_org_refuses_uuid_shaped_alias() {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line(ORG_SOLO).unwrap();
+    session.exp_string("Organization alias").unwrap();
+    session.send_line(ORG_OTHER).unwrap();
+
+    exp_wrapped(&mut session, &format!("Alias '{ORG_OTHER}' is UUID-shaped"));
+    session.exp_eof().unwrap();
+
+    // Refused before any mutation: neither the organization nor the alias
+    // reached the config.
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains(ORG_SOLO), "{saved}");
+    assert!(!saved.contains(ORG_OTHER), "{saved}");
+}
+
+/// Reusing an existing alias for a different organization re-points it after
+/// an explicit confirmation; the old organization keeps its entry, only the
+/// name moves.
+#[test]
+fn login_repoints_an_alias_after_confirmation() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(temp.path(), &[("alias-a", ORG_OTHER)], Some("alias-a"));
 
@@ -382,13 +448,68 @@ fn login_new_org_refuses_alias_already_in_use() {
 
     exp_wrapped(
         &mut session,
-        &format!("Alias 'alias-a' already names organization '{ORG_OTHER}'."),
+        &format!("Alias 'alias-a' currently names organization '{ORG_OTHER}'."),
     );
+    exp_wrapped(
+        &mut session,
+        &format!("Re-point alias 'alias-a' to organization '{ORG_SOLO}'?"),
+    );
+    session.send_line("y").unwrap();
+
+    // Enter accepts the highlighted "Local key file" entry.
+    session.exp_string("Operator key type").unwrap();
+    session.send_line("").unwrap();
+
+    exp_wrapped(&mut session, &format!("Selected org: alias-a ({ORG_SOLO})"));
+    session.exp_string("API Key Generated!").unwrap();
+    session.exp_string("Press Enter when done...").unwrap();
+    session.send_line("").unwrap();
+    session.exp_string("Verifying credentials...").unwrap();
     session.exp_eof().unwrap();
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(
+        saved.contains(&format!(r#"alias-a = "{ORG_SOLO}""#)),
+        "{saved}"
+    );
+    // The old organization keeps its entry; only the name moved.
     assert!(saved.contains(&format!("[orgs.{ORG_OTHER}]")), "{saved}");
+}
+
+/// Declining the re-point confirmation cancels login with nothing changed.
+#[test]
+fn login_repoint_decline_cancels_login() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_OTHER)], Some("alias-a"));
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session.exp_string("Select organization").unwrap();
+    session.send_line("new").unwrap();
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line(ORG_SOLO).unwrap();
+    session.exp_string("Organization alias").unwrap();
+    session.send_line("alias-a").unwrap();
+
+    exp_wrapped(
+        &mut session,
+        &format!("Re-point alias 'alias-a' to organization '{ORG_SOLO}'?"),
+    );
+    session.send_line("n").unwrap();
+
+    session
+        .exp_string("operation cancelled by user: alias re-pointing")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(
+        saved.contains(&format!(r#"alias-a = "{ORG_OTHER}""#)),
+        "{saved}"
+    );
     assert!(!saved.contains(ORG_SOLO));
 }
 

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -244,12 +244,13 @@ fn login_with_empty_org_id_bails() {
     session.exp_eof().unwrap();
 }
 
-/// TVC-159: `login --org <org-id>` with several profiles registered for that
-/// organization ID prompts for which profile to use instead of resolving to
-/// an arbitrary one. Duplicate profiles can no longer be created through the
-/// CLI, so this seeds the legacy on-disk state directly.
+/// TVC-159: interactive `tvc login` folds duplicate profiles down to one per
+/// organization before proceeding: prompt for the keeper, one confirmation,
+/// full profile-delete cleanup for the losers, and active-profile repair onto
+/// the keeper. Duplicate profiles can no longer be created through the CLI,
+/// so this seeds the legacy on-disk state directly.
 #[test]
-fn login_with_duplicate_org_id_prompts_for_profile() {
+fn login_consolidates_duplicate_profiles_interactively() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
@@ -259,19 +260,83 @@ fn login_with_duplicate_org_id_prompts_for_profile() {
     common::write_profile_key_files(temp.path(), "alias-a");
     common::write_profile_key_files(temp.path(), "alias-b");
 
-    let mut session = spawn_with_home(temp.path(), &["login", "--org", "org-dup-test"]);
+    let mut session = spawn_with_home(temp.path(), &["login"]);
 
     session
-        .exp_string("Select profile for organization 'org-dup-test'")
+        .exp_string("Select the profile to keep for organization 'org-dup-test'")
         .unwrap();
     session.send_line("alias-a").unwrap();
 
+    session
+        .exp_string("Permanently delete profile 'alias-b' and the key files on disk?")
+        .unwrap();
+    session.send_line("y").unwrap();
+
+    session
+        .exp_string("Deleted login profile 'alias-b' (org-dup-test).")
+        .unwrap();
+    session.exp_string("Removed key directory").unwrap();
+    session
+        .exp_string("IMPORTANT: The API key may still be registered")
+        .unwrap();
+
+    // Login proceeds against the consolidated config.
+    session.exp_string("Select organization").unwrap();
+    session.send_line("alias-a").unwrap();
     session
         .exp_string("Selected org: alias-a (org-dup-test)")
         .unwrap();
     session.exp_string("Using existing API key.").unwrap();
     session.exp_string("Verifying credentials...").unwrap();
     session.exp_eof().unwrap();
+
+    assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
+    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(!saved.contains("alias-b"));
+    assert!(saved.contains(r#"active_org = "alias-a""#));
+}
+
+/// Declining the consolidation confirmation cancels login and leaves both
+/// profiles and their key files untouched (nothing is mutated before the
+/// single consent point).
+#[test]
+fn login_consolidation_decline_cancels_login() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        Some("alias-b"),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+
+    let mut session = spawn_with_home(temp.path(), &["login"]);
+
+    session
+        .exp_string("Select the profile to keep for organization 'org-dup-test'")
+        .unwrap();
+    session.send_line("alias-a").unwrap();
+
+    session
+        .exp_string("Permanently delete profile 'alias-b' and the key files on disk?")
+        .unwrap();
+    session.send_line("n").unwrap();
+
+    session
+        .exp_string("operation cancelled by user: profile consolidation")
+        .unwrap();
+    session.exp_eof().unwrap();
+
+    assert!(temp.path().join(".config/turnkey/orgs/alias-a").exists());
+    assert!(temp.path().join(".config/turnkey/orgs/alias-b").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    assert!(saved.contains("alias-a"));
+    assert!(saved.contains("alias-b"));
 }
 
 /// `profile delete --org <org-id>` with several profiles registered for that

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -703,7 +703,10 @@ fn write_hosted_org_config(home: &Path, saved_operator_ids: &[&str]) -> String {
     config.set_active_org(org_id).unwrap();
     config.last_operator_ids.insert(
         org_id,
-        saved_operator_ids.iter().map(|id| id.to_string()).collect(),
+        saved_operator_ids
+            .iter()
+            .map(|id| id.parse().expect("saved operator ids must be UUIDs"))
+            .collect(),
     );
     std::fs::write(
         turnkey_dir.join("tvc.config.toml"),

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -10,6 +10,7 @@
 
 mod common;
 
+use indexmap::IndexMap;
 use qos_p256::P256Pair;
 use rexpect::session::PtySession;
 use std::collections::HashMap;
@@ -29,6 +30,11 @@ use tvc::config::turnkey::{
 /// of the binary; tight enough to fail fast if an `exp_string` mismatches.
 const TIMEOUT_MS: u64 = 10_000;
 
+const ORG_DUP: &str = "11111111-2222-4333-8444-555555555555";
+const ORG_E2E: &str = "44444444-4444-4444-8444-444444444444";
+const ORG_SOLO: &str = "55555555-5555-4555-8555-555555555555";
+const ORG_BACKUP: &str = "66666666-6666-4666-8666-666666666666";
+const ORG_OTHER: &str = "77777777-7777-4777-8777-777777777777";
 const ORG_HOSTED: &str = "88888888-8888-4888-8888-888888888888";
 
 fn spawn(args: &str) -> PtySession {
@@ -144,7 +150,9 @@ fn spawn_whoami_server() -> (String, JoinHandle<()>) {
         reader.read_exact(&mut request_body).unwrap();
         drop(reader);
 
-        let body = r#"{"organizationId":"org-e2e","organizationName":"E2E Org","userId":"user-1","username":"e2e"}"#;
+        let body = format!(
+            r#"{{"organizationId":"{ORG_E2E}","organizationName":"E2E Org","userId":"user-1","username":"e2e"}}"#
+        );
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()
@@ -254,7 +262,7 @@ fn login_consolidates_duplicate_profiles_interactively() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
         Some("alias-b"),
     );
     common::write_profile_key_files(temp.path(), "alias-a");
@@ -262,19 +270,21 @@ fn login_consolidates_duplicate_profiles_interactively() {
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
-    session
-        .exp_string("Select the profile to keep for organization 'org-dup-test'")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Select the profile to keep for organization '{ORG_DUP}'"),
+    );
     session.send_line("alias-a").unwrap();
 
     session
-        .exp_string("Permanently delete profile 'alias-b' and the key files on disk?")
+        .exp_string("Permanently delete 'alias-b' and the key files on disk?")
         .unwrap();
     session.send_line("y").unwrap();
 
-    session
-        .exp_string("Deleted login profile 'alias-b' (org-dup-test).")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Deleted login profile 'alias-b' ({ORG_DUP})."),
+    );
     session.exp_string("Removed key directory").unwrap();
     session
         .exp_string("IMPORTANT: The API key may still be registered")
@@ -283,9 +293,7 @@ fn login_consolidates_duplicate_profiles_interactively() {
     // Login proceeds against the consolidated config.
     session.exp_string("Select organization").unwrap();
     session.send_line("alias-a").unwrap();
-    session
-        .exp_string("Selected org: alias-a (org-dup-test)")
-        .unwrap();
+    exp_wrapped(&mut session, &format!("Selected org: alias-a ({ORG_DUP})"));
     session.exp_string("Using existing API key.").unwrap();
     session.exp_string("Verifying credentials...").unwrap();
     session.exp_eof().unwrap();
@@ -307,7 +315,7 @@ fn login_consolidation_decline_cancels_login() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
         Some("alias-b"),
     );
     common::write_profile_key_files(temp.path(), "alias-a");
@@ -315,13 +323,14 @@ fn login_consolidation_decline_cancels_login() {
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
-    session
-        .exp_string("Select the profile to keep for organization 'org-dup-test'")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Select the profile to keep for organization '{ORG_DUP}'"),
+    );
     session.send_line("alias-a").unwrap();
 
     session
-        .exp_string("Permanently delete profile 'alias-b' and the key files on disk?")
+        .exp_string("Permanently delete 'alias-b' and the key files on disk?")
         .unwrap();
     session.send_line("n").unwrap();
 
@@ -347,25 +356,27 @@ fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
     let temp = tempfile::TempDir::new().unwrap();
     common::write_profiles_config(
         temp.path(),
-        &[("alias-a", "org-dup-test"), ("alias-b", "org-dup-test")],
+        &[("alias-a", ORG_DUP), ("alias-b", ORG_DUP)],
         Some("alias-a"),
     );
     common::write_profile_key_files(temp.path(), "alias-a");
     common::write_profile_key_files(temp.path(), "alias-b");
 
-    let mut session = spawn_with_home(temp.path(), &["profile", "delete", "--org", "org-dup-test"]);
+    let mut session = spawn_with_home(temp.path(), &["profile", "delete", "--org", ORG_DUP]);
 
     session.exp_string("Select profile to delete").unwrap();
     session.send_line("alias-b").unwrap();
 
-    session
-        .exp_string("Permanently delete profile 'alias-b' (org-dup-test)")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Permanently delete profile 'alias-b' ({ORG_DUP})"),
+    );
     session.send_line("y").unwrap();
 
-    session
-        .exp_string("Deleted login profile 'alias-b' (org-dup-test).")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Deleted login profile 'alias-b' ({ORG_DUP})."),
+    );
     session.exp_eof().unwrap();
 
     assert!(!temp.path().join(".config/turnkey/orgs/alias-b").exists());
@@ -383,12 +394,12 @@ fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
 #[test]
 fn login_creates_first_profile_and_persists_it() {
     let temp = tempfile::TempDir::new().unwrap();
-    pty_create_profile(temp.path(), "org-solo-test", "solo");
+    pty_create_profile(temp.path(), ORG_SOLO, "solo");
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(saved.contains("[orgs.solo]"));
-    assert!(saved.contains(r#"id = "org-solo-test""#));
+    assert!(saved.contains(&format!(r#"id = "{ORG_SOLO}""#)));
 }
 
 /// Entering an organization ID that is already configured refuses to create a
@@ -397,7 +408,7 @@ fn login_creates_first_profile_and_persists_it() {
 #[test]
 fn login_new_org_refuses_already_configured_org_id() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-dup-test")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_DUP)], Some("alias-a"));
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
@@ -405,11 +416,12 @@ fn login_new_org_refuses_already_configured_org_id() {
     session.send_line("new").unwrap();
 
     session.exp_string("Organization ID").unwrap();
-    session.send_line("org-dup-test").unwrap();
+    session.send_line(ORG_DUP).unwrap();
 
-    session
-        .exp_string("Organization 'org-dup-test' is already configured as profile 'alias-a'.")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Organization '{ORG_DUP}' is already configured as profile 'alias-a'."),
+    );
     session
         .exp_string("tvc profile delete --org alias-a")
         .unwrap();
@@ -417,7 +429,7 @@ fn login_new_org_refuses_already_configured_org_id() {
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert_eq!(saved.matches(r#"id = "org-dup-test""#).count(), 1);
+    assert_eq!(saved.matches(&format!(r#"id = "{ORG_DUP}""#)).count(), 1);
 }
 
 /// Reusing an existing profile alias for a different organization refuses
@@ -425,7 +437,7 @@ fn login_new_org_refuses_already_configured_org_id() {
 #[test]
 fn login_new_org_refuses_alias_already_in_use() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-other-id")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_OTHER)], Some("alias-a"));
 
     let mut session = spawn_with_home(temp.path(), &["login"]);
 
@@ -433,19 +445,20 @@ fn login_new_org_refuses_alias_already_in_use() {
     session.send_line("new").unwrap();
 
     session.exp_string("Organization ID").unwrap();
-    session.send_line("org-fresh-id").unwrap();
+    session.send_line(ORG_SOLO).unwrap();
     session.exp_string("Organization alias").unwrap();
     session.send_line("alias-a").unwrap();
 
-    session
-        .exp_string("Profile alias 'alias-a' is already in use for organization 'org-other-id'.")
-        .unwrap();
+    exp_wrapped(
+        &mut session,
+        &format!("Profile alias 'alias-a' is already in use for organization '{ORG_OTHER}'."),
+    );
     session.exp_eof().unwrap();
 
     let saved =
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
-    assert!(saved.contains(r#"id = "org-other-id""#));
-    assert!(!saved.contains("org-fresh-id"));
+    assert!(saved.contains(&format!(r#"id = "{ORG_OTHER}""#)));
+    assert!(!saved.contains(ORG_SOLO));
 }
 
 /// Interactive `keys backup-operator-key` prompts for the destination and
@@ -453,7 +466,7 @@ fn login_new_org_refuses_alias_already_in_use() {
 #[test]
 fn keys_backup_operator_key_prompts_for_destination() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-backup")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_BACKUP)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     let destination = temp.path().join("operator-backup.json");
 
@@ -474,7 +487,7 @@ fn keys_backup_operator_key_prompts_for_destination() {
 #[test]
 fn login_fresh_operator_key_offers_backup() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     std::fs::remove_file(
         temp.path()
@@ -519,7 +532,7 @@ fn login_fresh_operator_key_offers_backup() {
 #[test]
 fn login_backup_decline_points_at_command() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     std::fs::remove_file(
         temp.path()
@@ -553,7 +566,7 @@ fn login_backup_decline_points_at_command() {
 #[test]
 fn login_backup_confirm_cancel_still_succeeds() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     std::fs::remove_file(
         temp.path()
@@ -584,7 +597,7 @@ fn login_backup_confirm_cancel_still_succeeds() {
 #[test]
 fn login_backup_destination_cancel_still_succeeds() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
     std::fs::remove_file(
         temp.path()
@@ -617,7 +630,7 @@ fn login_backup_destination_cancel_still_succeeds() {
 #[test]
 fn login_existing_operator_key_prints_backup_tip() {
     let temp = tempfile::TempDir::new().unwrap();
-    common::write_profiles_config(temp.path(), &[("alias-a", "org-e2e")], Some("alias-a"));
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
     common::write_profile_key_files(temp.path(), "alias-a");
 
     let (api_base_url, server) = spawn_whoami_server();
@@ -678,10 +691,10 @@ fn write_hosted_org_config(home: &Path, saved_operator_ids: &[&str]) -> String {
 
     let config = Config {
         active_org: Some("hosted-org".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "hosted-org".to_string(),
             OrgConfig {
-                id: ORG_HOSTED.to_string(),
+                id: ORG_HOSTED.parse().unwrap(),
                 api_key_path: turnkey_dir.join("orgs/hosted-org/api_key.json"),
                 api_base_url: common::LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Hosted,
@@ -937,7 +950,7 @@ fn login_creates_a_new_org_with_the_explicit_registered_yubikey() {
 
     session.exp_string("No organization configured.").unwrap();
     session.exp_string("Organization ID").unwrap();
-    session.send_line("org-e2e").unwrap();
+    session.send_line(ORG_E2E).unwrap();
     session.exp_string("Organization alias").unwrap();
     session.send_line("").unwrap();
 
@@ -1006,10 +1019,10 @@ fn login_selects_among_multiple_yubikey_operators() {
     };
     let mut config = Config {
         active_org: Some("yk-org".to_string()),
-        orgs: HashMap::from([(
+        orgs: IndexMap::from([(
             "yk-org".to_string(),
             OrgConfig {
-                id: "org-e2e".to_string(),
+                id: ORG_E2E.parse().unwrap(),
                 api_key_path: turnkey_dir.join("orgs/yk-org/api_key.json"),
                 api_base_url: common::LOCAL_API_BASE_URL.to_string(),
                 default_operator_kind: OperatorKind::Yubikey,

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -12,7 +12,7 @@ mod common;
 
 use qos_p256::P256Pair;
 use rexpect::session::PtySession;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::path::Path;
@@ -76,6 +76,43 @@ fn spawn_with_home(home: &Path, args: &[&str]) -> PtySession {
 
     rexpect::session::spawn_command(cmd, Some(TIMEOUT_MS))
         .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {bin} {}", args.join(" ")))
+}
+
+/// Drive `tvc login` through the interactive new-org flow against a dead-port
+/// API base URL. Login persists the profile and its generated API key before
+/// the final whoami request, so the profile exists on disk even though the
+/// command exits nonzero when that request fails.
+///
+/// `pick_new_in_selector` is required once profiles exist: login then opens an
+/// org selector first, and typing "new" filters it down to the
+/// "[new] Add a new organization" entry (no fixture string here contains
+/// "new") which Enter selects.
+fn pty_create_profile(home: &Path, org_id: &str, alias: &str, pick_new_in_selector: bool) {
+    let mut session = spawn_with_home(home, &["login", "--api-base-url", "http://127.0.0.1:1"]);
+
+    if pick_new_in_selector {
+        session.exp_string("Select organization").unwrap();
+        session.send_line("new").unwrap();
+    }
+
+    session.exp_string("Organization ID").unwrap();
+    session.send_line(org_id).unwrap();
+    session.exp_string("Organization alias").unwrap();
+    session.send_line(alias).unwrap();
+
+    // Enter accepts the highlighted "Local key file" entry.
+    session.exp_string("Operator key type").unwrap();
+    session.send_line("").unwrap();
+
+    session
+        .exp_string(&format!("Selected org: {alias} ({org_id})"))
+        .unwrap();
+    session.exp_string("API Key Generated!").unwrap();
+    session.exp_string("Press Enter when done...").unwrap();
+    session.send_line("").unwrap();
+
+    session.exp_string("Verifying credentials...").unwrap();
+    session.exp_eof().unwrap();
 }
 
 /// One-shot mock Turnkey API that answers the whoami query, enough to carry
@@ -208,23 +245,69 @@ fn approve_bails_when_user_rejects_pivot() {
 fn login_with_empty_org_id_bails() {
     let temp = tempfile::TempDir::new().unwrap();
 
-    let bin = env!("CARGO_BIN_EXE_tvc");
-    let cmd = format!("{bin} login");
-
-    let mut session = rexpect::session::spawn_command(
-        {
-            let mut c = std::process::Command::new(bin);
-            c.arg("login").env("HOME", temp.path());
-            c
-        },
-        Some(TIMEOUT_MS),
-    )
-    .unwrap_or_else(|e| panic!("spawn failed: {e}\n  cmd: {cmd}"));
+    let mut session = spawn_with_home(temp.path(), &["login"]);
 
     session.exp_string("Organization ID").unwrap();
     session.send_line("").unwrap();
     session.exp_string("Organization ID is required").unwrap();
     session.exp_eof().unwrap();
+}
+
+/// TVC-159: when one organization ID is registered under multiple aliases,
+/// `login --org <org-id>` resolves to an arbitrary alias, because resolution
+/// falls back to `HashMap` iteration order, which is randomized per process.
+///
+/// The duplicate state is created through the CLI itself (two logins to the
+/// same organization under different aliases), then resolution runs in fresh
+/// processes until both aliases have been observed. With the bug present the
+/// expected number of attempts is 2-3; all 40 agreeing has probability 2⁻³⁹.
+#[test]
+fn login_with_duplicate_org_id_selects_alias_nondeterministically() {
+    let temp = tempfile::TempDir::new().unwrap();
+    pty_create_profile(temp.path(), "org-dup-test", "alias-a", false);
+    pty_create_profile(temp.path(), "org-dup-test", "alias-b", true);
+
+    let bin = env!("CARGO_BIN_EXE_tvc");
+    let mut seen = BTreeSet::new();
+
+    for _ in 0..40 {
+        let output = Command::new(bin)
+            .args(["login", "--org", "org-dup-test"])
+            .env("HOME", temp.path())
+            .env("TVC_NON_INTERACTIVE", "1")
+            .env_remove("TVC_ORG")
+            .env_remove("TVC_API_BASE_URL")
+            .env_remove("TVC_ORG_ID")
+            .env_remove("TVC_API_KEY_PUBLIC")
+            .env_remove("TVC_API_KEY_PRIVATE")
+            .output()
+            .unwrap();
+
+        // Selection happens (and the config is saved) before the whoami
+        // request, which fails against the dead-port base URL on the profile.
+        assert!(!output.status.success());
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let alias = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("Selected org: "))
+            .and_then(|rest| rest.strip_suffix(" (org-dup-test)"))
+            .unwrap_or_else(|| panic!("no selected-org line in output:\n{stdout}"));
+        seen.insert(alias.to_string());
+
+        if seen.len() == 2 {
+            break;
+        }
+    }
+
+    let expected = ["alias-a", "alias-b"]
+        .into_iter()
+        .map(String::from)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        seen, expected,
+        "resolution by org ID should be nondeterministic across processes (TVC-159)"
+    );
 }
 
 /// Interactive `keys backup-operator-key` prompts for the destination and

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -1255,10 +1255,10 @@ fn login_reports_the_hosted_operator_for_a_hosted_default_org() {
     assert!(output.contains("Hosted operator:"), "{output}");
 }
 
-/// A crash between the directory rename and the config save leaves the files
-/// moved but the config still pointing at the legacy paths. The next
-/// interactive login heals: it treats the move as done and rewrites the
-/// config.
+/// A directory whose files already moved (an older tvc's rename-based
+/// migration crashing before its save) leaves the config pointing at the
+/// legacy paths. The next interactive login heals: it treats the copy as
+/// done and rewrites the config.
 #[test]
 fn login_heals_a_crash_between_directory_move_and_config_save() {
     let temp = tempfile::TempDir::new().unwrap();
@@ -1361,6 +1361,75 @@ fn login_finishes_a_partially_migrated_config_in_one_pass() {
     assert_eq!(
         table["orgs"][ORG_OTHER]["api_key_path"].as_str().unwrap(),
         id_b.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// The copy-verify-delete window: a crash after the copy but before the save
+/// leaves both directories populated and the config on the legacy paths —
+/// which non-interactive commands can still use, since nothing was deleted.
+/// The next interactive login resumes the identical copy, saves, and only
+/// then removes the legacy directory.
+#[test]
+fn login_finishes_a_crash_between_copy_and_config_save() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    // Recreate the crash window: the copy happened, the save did not.
+    std::fs::create_dir_all(&id_dir).unwrap();
+
+    for name in ["api_key.json", "operator.json"] {
+        std::fs::copy(legacy_dir.join(name), id_dir.join(name)).unwrap();
+    }
+
+    // Mid-window, non-interactive commands still work off the legacy paths.
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_tvc"));
+    cmd.args(["keys", "backup-operator-key", "--output"])
+        .arg(temp.path().join("mid-window-backup.json"))
+        .env("HOME", temp.path())
+        .env("TVC_NON_INTERACTIVE", "1")
+        .env_remove("TVC_ORG")
+        .env_remove("TVC_API_BASE_URL")
+        .env_remove("TVC_ORG_ID")
+        .env_remove("TVC_API_KEY_PUBLIC")
+        .env_remove("TVC_API_KEY_PRIVATE");
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_dir.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(!legacy_dir.exists());
+    assert!(id_dir.join("operator.json").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        id_dir.join("api_key.json").to_str().unwrap()
     );
 }
 

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -1133,3 +1133,229 @@ fn login_reports_the_hosted_operator_for_a_hosted_default_org() {
     assert!(!output.contains("Generating operator key"), "{output}");
     assert!(output.contains("Hosted operator:"), "{output}");
 }
+
+/// A crash between the directory rename and the config save leaves the files
+/// moved but the config still pointing at the legacy paths. The next
+/// interactive login heals: it treats the move as done and rewrites the
+/// config.
+#[test]
+fn login_heals_a_crash_between_directory_move_and_config_save() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    // Recreate the crash window: the rename happened, the save did not.
+    std::fs::rename(&legacy_dir, &id_dir).unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_dir.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        id_dir.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// A crash mid-loop strands at most one organization (the migration saves
+/// after each): the next interactive login finishes the job in one pass,
+/// healing the moved-but-unsaved org and moving the untouched one.
+#[test]
+fn login_finishes_a_partially_migrated_config_in_one_pass() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(
+        temp.path(),
+        &[("alias-a", ORG_E2E), ("alias-b", ORG_OTHER)],
+        Some("alias-a"),
+    );
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+    let legacy_a = temp.path().join(".config/turnkey/orgs/alias-a");
+    let legacy_b = temp.path().join(".config/turnkey/orgs/alias-b");
+    let id_a = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+    let id_b = temp.path().join(".config/turnkey/orgs").join(ORG_OTHER);
+
+    // Org A crashed between rename and save; org B was never reached.
+    std::fs::rename(&legacy_a, &id_a).unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_a.display(),
+            id_a.display()
+        ),
+    );
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_b.display(),
+            id_b.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    assert!(!legacy_a.exists());
+    assert!(!legacy_b.exists());
+    assert!(id_a.join("operator.json").exists());
+    assert!(id_b.join("operator.json").exists());
+
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        id_a.join("api_key.json").to_str().unwrap()
+    );
+    assert_eq!(
+        table["orgs"][ORG_OTHER]["api_key_path"].as_str().unwrap(),
+        id_b.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// An occupied target directory fails the move: the migration warns, keeps
+/// the organization on its legacy paths, and login still succeeds — nothing
+/// is deleted or overwritten.
+#[test]
+fn login_skips_migration_when_the_target_directory_is_occupied() {
+    let temp = tempfile::TempDir::new().unwrap();
+    common::write_profiles_config(temp.path(), &[("alias-a", ORG_E2E)], Some("alias-a"));
+    common::write_profile_key_files(temp.path(), "alias-a");
+    let legacy_dir = temp.path().join(".config/turnkey/orgs/alias-a");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+
+    // Someone (or something) already owns the target directory.
+    std::fs::create_dir_all(&id_dir).unwrap();
+    std::fs::write(id_dir.join("unrelated.txt"), "not ours").unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(&mut session, "WARNING: could not move key directory");
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    // Both directories intact; the config still points at the legacy paths.
+    assert!(legacy_dir.join("operator.json").exists());
+    assert_eq!(
+        std::fs::read_to_string(id_dir.join("unrelated.txt")).unwrap(),
+        "not ours"
+    );
+    let saved =
+        std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
+    let table: toml::Table = toml::from_str(&saved).unwrap();
+    assert_eq!(
+        table["orgs"][ORG_E2E]["api_key_path"].as_str().unwrap(),
+        legacy_dir.join("api_key.json").to_str().unwrap()
+    );
+}
+
+/// Merging v1 duplicate profiles keeps one registration per organization;
+/// the losing alias's directory is deliberately orphaned on disk (reported
+/// in the migration note), and only the kept profile's directory migrates.
+#[test]
+fn duplicate_alias_merge_leaves_the_losing_directory_orphaned() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let turnkey_dir = temp.path().join(".config/turnkey");
+    std::fs::create_dir_all(&turnkey_dir).unwrap();
+    common::write_profile_key_files(temp.path(), "alias-a");
+    common::write_profile_key_files(temp.path(), "alias-b");
+    let legacy_a = temp.path().join(".config/turnkey/orgs/alias-a");
+    let legacy_b = temp.path().join(".config/turnkey/orgs/alias-b");
+    let id_dir = temp.path().join(".config/turnkey/orgs").join(ORG_E2E);
+    std::fs::write(
+        turnkey_dir.join("tvc.config.toml"),
+        format!(
+            r#"version = 1
+active_org = "alias-a"
+
+[orgs.alias-a]
+id = "{ORG_E2E}"
+api_key_path = "{a}/api_key.json"
+api_base_url = "{url}"
+
+[[orgs.alias-a.operators]]
+name = "default"
+kind = "local"
+key_path = "{a}/operator.json"
+
+[orgs.alias-b]
+id = "{ORG_E2E}"
+api_key_path = "{b}/api_key.json"
+api_base_url = "{url}"
+
+[[orgs.alias-b.operators]]
+name = "default"
+kind = "local"
+key_path = "{b}/operator.json"
+"#,
+            a = legacy_a.display(),
+            b = legacy_b.display(),
+            url = common::LOCAL_API_BASE_URL,
+        ),
+    )
+    .unwrap();
+
+    let (api_base_url, server) = spawn_whoami_server();
+
+    let mut session = spawn_with_home(
+        temp.path(),
+        &["login", "--org", "alias-a", "--api-base-url", &api_base_url],
+    );
+
+    exp_wrapped(
+        &mut session,
+        "config migration: merged duplicate profile 'alias-b'",
+    );
+    exp_wrapped(
+        &mut session,
+        &format!(
+            "Moved key directory: {} -> {}",
+            legacy_a.display(),
+            id_dir.display()
+        ),
+    );
+    session.exp_string("Successfully logged in!").unwrap();
+    session.exp_eof().unwrap();
+    server.join().unwrap();
+
+    // The loser's files stay on disk, untouched and unregistered.
+    assert!(legacy_b.join("operator.json").exists());
+    assert!(!legacy_a.exists());
+    assert!(id_dir.join("operator.json").exists());
+}

--- a/tvc/tests/pty.rs
+++ b/tvc/tests/pty.rs
@@ -389,8 +389,8 @@ fn profile_delete_with_duplicate_org_id_prompts_for_profile() {
 }
 
 /// The interactive new-org flow (the only way to create a profile) works end
-/// to end and persists the profile even though the final whoami request fails
-/// against the dead-port URL.
+/// to end, keys its directory by org ID (TVC-55), and persists the profile
+/// even though the final whoami request fails against the dead-port URL.
 #[test]
 fn login_creates_first_profile_and_persists_it() {
     let temp = tempfile::TempDir::new().unwrap();
@@ -400,6 +400,10 @@ fn login_creates_first_profile_and_persists_it() {
         std::fs::read_to_string(temp.path().join(".config/turnkey/tvc.config.toml")).unwrap();
     assert!(saved.contains("[orgs.solo]"));
     assert!(saved.contains(&format!(r#"id = "{ORG_SOLO}""#)));
+
+    let org_dir = temp.path().join(".config/turnkey/orgs").join(ORG_SOLO);
+    assert!(org_dir.join("api_key.json").exists());
+    assert!(!temp.path().join(".config/turnkey/orgs/solo").exists());
 }
 
 /// Entering an organization ID that is already configured refuses to create a


### PR DESCRIPTION
Semantic replay of #224's un-merged remainder onto current main, one reviewable commit at a time, plus the two alias-plan follow-ups that were never written on the template branch. Supersedes #241 (stale after its base stack #236/#237/#239 merged with review-time rebases and main moved ~84 commits). #224 stays open as the frozen reference until this lands, then both close.

## TVC-159 — one profile per organization
- Config disk v2: `orgs` keyed by organization ID, human names in an edge-only `[aliases]` map — duplicate registrations are unrepresentable
- Older configs migrate eagerly behind a backup fence (`tvc.config.toml.backup`): v0/v1 load in one hop, duplicates merge to the first profile in file order (every alias survives; lossy decisions reported once on stderr), and a leftover backup blocks every command with recovery instructions
- `--org` parses into ID-vs-alias at the clap boundary (`OrgQuery`); resolution never guesses, and output echoes what you typed (alias in → alias out, ID in → ID out)
- Alias binding policy: logging in with an already-configured org ID offers to bind an extra name (confirmed); reusing an alias re-points it after an explicit confirmation; UUID-shaped aliases are refused (they would always resolve as IDs). Non-interactive runs cannot bind at all
- Org/app/operator IDs are `Uuid` end to end; app configs get typed `<FILL_IN>` placeholders

## TVC-55 — id-keyed key directories
- New logins store keys under `orgs/<org-id>/`; legacy `orgs/<alias>/` stays readable — paths are data, not schema
- Interactive login migrates legacy directories by **copy → verify → rewrite config → save → delete**, so every crash window leaves the config pointing at files that exist (no `fs::rename`; mid-migration non-interactive commands keep working); failures warn and keep the legacy paths
- `profile delete` recognizes and cleans up either layout, and refuses to delete a directory another organization still points into

## Migration test hardening (from #240)
- The fence lifecycle, version chain, v0→v2 single hop, both manual recovery paths, and the key-directory migration's crash windows (copy-done-unsaved resume, old rename-crash heal, one-pass finish, occupied target, orphaned duplicate) are pinned by unit, real-binary, and PTY tests

Vs #241: the `default_alias` marker world (marker, `profile set-default-alias`, load-time repair) is collapsed away — the v2 schema makes it unnecessary — everything is adapted to main's YubiKey series and Config-method refactors, and the alias binding policy + copy-verify-delete migration land here instead of as follow-ups.

Closes TVC-159. Closes TVC-55.