### PR TITLE
tvc: add instance size as deployment option

### DIFF
--- a/client/src/generated/external.data.v1.rs
+++ b/client/src/generated/external.data.v1.rs
@@ -751,6 +751,10 @@ pub struct TvcContainerSpec {
     pub health_check_port: u32,
     #[serde(default)]
     pub public_ingress_port: u32,
+    #[serde(default)]
+    pub instance_size_cpus: u32,
+    #[serde(default)]
+    pub instance_size_ram: u32,
 }
 #[derive(Debug)]
 #[serde_with::serde_as]

--- a/client/src/generated/immutable.activity.v1.rs
+++ b/client/src/generated/immutable.activity.v1.rs
@@ -2528,6 +2528,10 @@ pub struct CreateTvcDeploymentIntent {
     pub public_ingress_port: u32,
     #[serde(default)]
     pub replicas: ::core::option::Option<u32>,
+    #[serde(default)]
+    pub instance_size_cpus: ::core::option::Option<u32>,
+    #[serde(default)]
+    pub instance_size_ram: ::core::option::Option<u32>,
 }
 #[derive(Debug)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]

--- a/proto/external/data/v1/tvc.proto
+++ b/proto/external/data/v1/tvc.proto
@@ -131,6 +131,14 @@ message TvcContainerSpec {
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The port to use for public ingress to this executable."}
   ];
+  uint32 instance_size_cpus = 8 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The instance cpu count for this enclave."}
+  ];
+  uint32 instance_size_ram = 9 [
+    (google.api.field_behavior) = REQUIRED,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The instance memory size in GiB for this enclave."}
+  ];
 }
 
 message TvcOperatorApproval {

--- a/proto/immutable/activity/v1/activity.proto
+++ b/proto/immutable/activity/v1/activity.proto
@@ -5012,6 +5012,14 @@ message CreateTvcDeploymentIntent {
     (google.api.field_behavior) = OPTIONAL,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional desired replica count for this deployment."}
   ];
+  optional uint32 instance_size_cpus = 18 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional desired instance cpu count."}
+  ];
+  optional uint32 instance_size_ram = 19 [
+    (google.api.field_behavior) = OPTIONAL,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Optional desired instance memory size in GiB."}
+  ];
 }
 
 message CreateTvcManifestApprovalsIntent {

--- a/proto/immutable/common/v1/common.proto
+++ b/proto/immutable/common/v1/common.proto
@@ -342,3 +342,4 @@ enum AuthenticationType {
   AUTHENTICATION_TYPE_OAUTH = 5;
   AUTHENTICATION_TYPE_SESSION = 6;
 }
+

--- a/tvc/src/commands/deploy/create.rs
+++ b/tvc/src/commands/deploy/create.rs
@@ -380,6 +380,8 @@ fn build_create_intent(
         health_check_port: deploy_config.health_check_port as u32,
         public_ingress_port: deploy_config.public_ingress_port as u32,
         replicas: deploy_config.replicas,
+        instance_size_cpus: deploy_config.instance_size_cpus,
+        instance_size_ram: deploy_config.instance_size_ram,
     }
 }
 
@@ -557,6 +559,8 @@ mod tests {
         c.pivot_container_encrypted_pull_secret = None;
         c.health_check_port = 4000;
         c.public_ingress_port = 5000;
+        c.instance_size_cpus = None;
+        c.instance_size_ram = None;
         c
     }
 
@@ -844,6 +848,28 @@ mod tests {
         cfg.replicas = None;
         let json = serde_json::to_value(&cfg).unwrap();
         assert_eq!(json.get("replicas"), None);
+    }
+
+    /// Defaults to instance size `small`
+    /// `deploy init` templates stay clean and round-trips don't add noise.
+    #[test]
+    fn defaults_to_instance_size_small() {
+        let cfg = file_config();
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(json.get("instanceSizeCpus"), None);
+        assert_eq!(json.get("instanceSizeRam"), None);
+    }
+
+    /// Defaults to instance size `small`
+    /// `deploy init` templates stay clean and round-trips don't add noise.
+    #[test]
+    fn serializes_instance_size_correctly() {
+        let mut cfg = file_config();
+        cfg.instance_size_cpus = Some(14);
+        cfg.instance_size_ram = Some(64);
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(json.get("instanceSizeCpus").unwrap().as_u64().unwrap(), 14);
+        assert_eq!(json.get("instanceSizeRam").unwrap().as_u64().unwrap(), 64);
     }
 
     /// Exercises every deploy-create flag via clap parsing so flag renames or

--- a/tvc/src/config/deploy.rs
+++ b/tvc/src/config/deploy.rs
@@ -48,6 +48,12 @@ pub struct DeployConfig {
     /// choice to the backend default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replicas: Option<u32>,
+    /// Enclave instance size CPU cound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_size_cpus: Option<u32>,
+    /// Enclave instance size RAM in Gi.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_size_ram: Option<u32>,
 }
 
 /// Build a config seeded from an existing deployment, for use as a template.
@@ -92,6 +98,8 @@ impl TryFrom<TvcDeployment> for DeployConfig {
             health_check_type,
             health_check_port,
             public_ingress_port,
+            instance_size_cpus,
+            instance_size_ram,
         } = pivot_container
             .ok_or_else(|| anyhow!("deployment {id} has no pivot container spec"))?;
 
@@ -114,6 +122,8 @@ impl TryFrom<TvcDeployment> for DeployConfig {
             health_check_port,
             public_ingress_port,
             replicas: None,
+            instance_size_cpus: Some(instance_size_cpus),
+            instance_size_ram: Some(instance_size_ram),
         })
     }
 }
@@ -135,6 +145,8 @@ impl DeployConfig {
             health_check_port: 3000,
             public_ingress_port: 3000,
             replicas: None,
+            instance_size_cpus: None,
+            instance_size_ram: None,
         }
     }
 
@@ -256,8 +268,21 @@ impl DeployConfig {
                 placeholder: PULL_SECRET_PLACEHOLDER.to_string(),
             });
         }
+        if !valid_instance_size(self.instance_size_cpus, self.instance_size_ram) {
+            errors.push(DeployConfigValidationError::InvalidInstanceSize)
+        }
 
         DeployConfigValidationErrors::ok_or_errors(errors)
+    }
+}
+
+fn valid_instance_size(cpus: Option<u32>, ram: Option<u32>) -> bool {
+    match (cpus, ram) {
+        (None, None) => true,         // defaults
+        (Some(2), Some(1)) => true,   // small
+        (Some(6), Some(24)) => true,  // medium
+        (Some(14), Some(48)) => true, // large
+        (_, _) => false,
     }
 }
 
@@ -275,6 +300,10 @@ pub enum DeployConfigValidationError {
          --pivot-pull-secret <PATH> or remove pivotContainerEncryptedPullSecret for public images"
     )]
     PullSecretPlaceholder { placeholder: String },
+    #[error(
+        "instance_size_cpu and instance_size_ram need to be empty or one of\n\tinstanceSizeCPU: 2, instanceSizeRam: 1\n\tinstanceSizeCPU: 6, instanceSizeRam: 24\n\tinstanceSizeCPU: 14, instanceSizeRam: 48"
+    )]
+    InvalidInstanceSize,
 }
 
 impl DeployConfigValidationError {
@@ -363,6 +392,8 @@ mod tests {
                 health_check_type: TvcHealthCheckType::Http,
                 health_check_port: 8080,
                 public_ingress_port: 9090,
+                instance_size_cpus: 2,
+                instance_size_ram: 8,
             }),
             created_at: None,
             updated_at: None,


### PR DESCRIPTION
Adds `instance_size_cpus` and `instance_size_ram` fields to the `deploy` config so users can request larger enclaves. We currently only support enumerated values of:
```
CPU: 2, RAM: 1Gi
CPU: 6, RAM: 24Gi
CPU: 14, RAM: 48Gi
```

Example deploy config:
```json
{
  "appId": "71606b3f-6bc0-43e4-b4c2-f831a1821b54",
  "qosVersion": "0.12.1",
  "pivotContainerImageUrl": "ghcr.io/anchorageoss/parser_app:latest@sha256:ff50383cc5bc5e80ef40430a6f58b80e511d2a50065b4b76699168b724eb3d9c",
  "pivotPath": "/parser_app",
  "pivotArgs": [],
  "expectedPivotDigest": "fb606155b55356a785a4b1350c1862516d07977b3a92512c9b1dffb96f395498",
  "dangerousDeployDebugMode": false,
  "healthCheckType": "TVC_HEALTH_CHECK_TYPE_HTTP",
  "healthCheckPort": 3000,
  "publicIngressPort": 3000,
  "instanceSizeCpus": 6,
  "instanceSizeRam": 24
}
```

Depends on https://github.com/tkhq/mono/pull/7966 but should be backwards compatible as the new intents values are all optional.