### PR TITLE
feat: add unified tk CLI preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,6 +4198,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
+ "getrandom 0.3.3",
  "serde",
 ]
 

--- a/docs/tk-local-preview.md
+++ b/docs/tk-local-preview.md
@@ -1,0 +1,96 @@
+# Local unified CLI preview
+
+This preview provides a locally testable `tk` CLI in the existing `tvc`
+package. It is an implementation preview, not a production release or a complete
+replacement for `tkcli`. No live organization acceptance run has been performed.
+
+Build the two entry points with `cargo build -p tvc --bins`. The existing `tvc`
+entry point keeps its command grammar and configuration. Cloud operations are
+also available through `tk tvc app|deploy|operator|keys`.
+
+## Shared identity setup
+
+Generate a credential file without contacting Turnkey:
+
+```sh
+tk api-key generate --output ./agent-key.json
+```
+
+The output contains only the public key and destination. Register the public
+key with Turnkey before using it to authenticate; generating a file does not
+register remote access. Existing registered credentials use the same JSON
+shape as TVC: `public_key`, `private_key`, and `curve: "p256"`.
+
+Save and select an existing registered identity:
+
+```sh
+tk login --profile admin --organization-id ORG_UUID --api-key-file ./admin-key.json
+tk --profile admin auth status
+tk --profile admin whoami --message-format json
+```
+
+Login verifies the credential with `whoami` before saving the registry. It does
+not create an operator, wallet, or remote user. The current login requires an
+existing credential file; browser onboarding is not implemented.
+
+The new registry is `~/.config/turnkey/tk.config.toml`. Profiles identify users
+or credentials, so admin and agent profiles can share one organization. Use
+`tk profile import --help` for explicit TVC and experimental-tk migration.
+Imports preserve their sources and do not automatically select the new profile.
+`profile delete` removes a registry entry only; logout clears selection only.
+
+For CI, supply the complete `TURNKEY_ORGANIZATION_ID`, `TURNKEY_API_PUBLIC_KEY`,
+and `TURNKEY_API_PRIVATE_KEY` bundle. Environment-only calls need no HOME or
+registry. Explicit `--profile` selection overrides ambient credentials. Partial,
+empty, or mixed canonical/legacy bundles fail rather than falling back to a
+saved admin identity.
+
+Shared identity selectors are currently rejected on `tk tvc`; those commands
+continue using the existing TVC identity environment and configuration.
+
+## Implemented command families
+
+```text
+tk auth login|status|whoami|logout
+tk profile list|show|use|import|delete
+tk api-key generate|register|list|delete
+tk user list|get|create|update|delete|tag
+tk policy list|get|create|create-batch|update|delete|evaluations
+tk wallet list|get|create|update|account
+tk sign payload|transaction
+tk request
+tk activity list|get|approve|reject|wait
+```
+
+Resource mutations and signing accept `--input-json` or `--input-file` with a
+parameters object matching the generated API type. `--input-file -` reads stdin.
+Local input parsing occurs before credential resolution. See
+[resource input examples](tk-resource-commands.md) and each command's help.
+
+`tk request` takes an API-relative `--path` and either `--body` or `--body-file`
+(`-` reads stdin). It preserves original body bytes and requires an organization
+matching the selected identity. `--stamp-only` produces signed metadata without
+posting. Signing and raw submission do not imply transaction broadcasting.
+
+## Automation and recovery
+
+Use `--message-format json` for newline-delimited records. Shared results carry
+`schemaVersion`, `reason`, `command`, `status`, `data`, and activity metadata when
+available. Accepted pending submissions exit successfully with `status: pending`;
+that is not a completed action. Resume with `tk activity wait ACTIVITY_ID`, whose
+positive `--timeout` defaults to 60 seconds. Activity inspection can succeed when
+the inspected activity is rejected; waiting for that activity exits with failure.
+
+Uncertain mutation outcomes retain recovery information where available. Do not
+resubmit solely because a transport response was lost; inspect activities first.
+The CLI emits failures with a nonzero exit status, including structured
+operation failures. Output-write failure also produces a nonzero exit status.
+
+## Remaining release work
+
+Outstanding acceptance includes live
+agent lifecycle verification in an authorized test organization, TVC identity
+injection, complete profile/readiness UX and browser onboarding, pagination
+completion, managed transaction delivery, import/export cryptography, remaining
+legacy curves, distribution, and SSH/Git consolidation. Machine contracts and
+skill examples must be validated against this preview before release claims.

--- a/docs/tk-resource-commands.md
+++ b/docs/tk-resource-commands.md
@@ -1,0 +1,86 @@
+# Shared user, policy, and API-key commands
+
+These commands operate on the organization and credentials selected by shared auth. They do not initialize TVC operator keys. Query output retains the API's named resource arrays/objects; mutations retain the complete activity, including its ID, status, and any result IDs.
+
+## Structured inputs
+
+Create/update/register commands require exactly one of `--input-json JSON` or `--input-file PATH`. Use `--input-file -` for stdin. Supply the **parameters object**, without organization ID, timestamp, or activity envelope. Inputs are parsed before credential resolution. Unsupported fields, malformed JSON, invalid resource UUIDs, and empty create batches are rejected locally; the server remains authoritative for policy language and authorization.
+
+Policy expressions are passed through unchanged. Policy creation uses `effect`, `condition`, `consensus`, and `notes`; policy updates use `policyEffect`, `policyCondition`, `policyConsensus`, and `policyNotes`. Using a create field in an update is an error rather than silently dropping the field.
+
+```sh
+tk user list
+tk user get 11111111-1111-4111-8111-111111111111
+tk user create --input-file users.json
+tk user update --input-file user-update.json
+tk user delete 11111111-1111-4111-8111-111111111111
+
+tk user tag list
+tk user tag create --input-file tag.json
+tk user tag update --input-file tag-update.json
+tk user tag delete 22222222-2222-4222-8222-222222222222
+
+tk policy list
+tk policy get 33333333-3333-4333-8333-333333333333
+tk policy create --input-file policy.json
+tk policy create-batch --input-file policies.json
+tk policy update --input-file policy-update.json
+tk policy delete 33333333-3333-4333-8333-333333333333
+tk policy evaluations 44444444-4444-4444-8444-444444444444
+
+tk api-key list --user-id 11111111-1111-4111-8111-111111111111
+tk api-key register --input-file public-keys.json
+tk api-key delete --user-id 11111111-1111-4111-8111-111111111111 55555555-5555-4555-8555-555555555555
+```
+
+Delete commands accept multiple positional resource UUIDs. API-key list without a user filter follows the API's default scope. List endpoints here expose no cursor parameters; no unsupported pagination flags are added.
+
+## Example parameters
+
+`users.json` creates a tagged non-root user; root quorum membership is a separate operation.
+
+```json
+{
+  "users": [{
+    "userName": "agent",
+    "userTags": ["22222222-2222-4222-8222-222222222222"],
+    "apiKeys": [{
+      "apiKeyName": "agent-key",
+      "publicKey": "REPLACE_WITH_PUBLIC_KEY_HEX",
+      "curveType": "API_KEY_CURVE_P256"
+    }]
+  }]
+}
+```
+
+`tag-update.json` adds/removes tag members explicitly:
+
+```json
+{
+  "userTagId": "22222222-2222-4222-8222-222222222222",
+  "addUserIds": ["11111111-1111-4111-8111-111111111111"],
+  "removeUserIds": []
+}
+```
+
+`policy.json` contains the exact policy expression to submit. This is a shape example; choose the intended resource scope before creating it.
+
+```json
+{
+  "policyName": "agent signing",
+  "effect": "EFFECT_ALLOW",
+  "condition": "activity.action == 'SIGN'",
+  "consensus": "approvers.any(user, user.id == '11111111-1111-4111-8111-111111111111')",
+  "notes": "Replace condition with the intended wallet scope before use"
+}
+```
+
+Batch creation wraps those objects in `{"policies": [...]}`. `public-keys.json` uses `{"userId": "...", "apiKeys": [...]}` with public keys only. Local credential generation is separate from remote registration.
+
+## Activity and rotation behavior
+
+Each mutation submits once. Pending, consensus-needed, failed, and rejected activities are returned intact to the shared output boundary. Follow pending work with `tk activity get/wait`; resuming an activity must not repeat resource creation. If a transport error makes the outcome uncertain, inspect activity history before retrying a mutation.
+
+For rotation, register the replacement public key, verify the replacement through `tk whoami` using its explicit credentials/profile, and then revoke the old key. Registration does not select the replacement profile or delete local credentials. The CLI supplies execution; skills retain workflow judgment and already-authorized approval decisions.
+
+This module implements remote API-key management. Contract-interface upload/list/delete remain request recipes; wallet/signing commands and local key generation use their own command families. Tests use a loopback mock server and synthetic keys, with no live organization calls.

--- a/tvc/Cargo.toml
+++ b/tvc/Cargo.toml
@@ -11,6 +11,12 @@ documentation = "https://docs.rs/tvc"
 keywords = ["turnkey", "tvc", "enclaves", "cli"]
 categories = ["command-line-utilities", "cryptography"]
 
+default-run = "tvc"
+
+[[bin]]
+name = "tk"
+path = "src/bin/tk.rs"
+
 [dependencies]
 qos_core = { workspace = true }
 qos_crypto = { workspace = true }
@@ -36,7 +42,7 @@ serde_with = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util"] }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tvc/src/bin/tk.rs
+++ b/tvc/src/bin/tk.rs
@@ -1,0 +1,19 @@
+// Keep synchronized with the corresponding lint policy in the other TVC crate root.
+// TVC has separate library and binary crates, so this attribute must appear in both.
+#![deny(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "direct print macros bypass TVC's output protocol; use shell_println!, shell_print!, or shell_eprintln! for presentation output, Shell::emit for structured output, and tracing for diagnostics"
+)]
+
+use std::process::ExitCode;
+use tracing::debug;
+use tvc::cli::TkCli;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tvc::logging::init();
+    debug!(version = env!("CARGO_PKG_VERSION"), "starting tk");
+
+    TkCli::run().await
+}

--- a/tvc/src/cli.rs
+++ b/tvc/src/cli.rs
@@ -6,7 +6,7 @@ use crate::errors::strip_ansi;
 use crate::outcome::Outcome;
 use crate::output::{ColorChoice, Ctx, ErrorMessage, MessageFormat, Shell, StdCtx};
 use anyhow::Context;
-use clap::{ArgAction, Parser, Subcommand, builder::BoolishValueParser, error::ErrorKind};
+use clap::{ArgAction, Args, Parser, Subcommand, builder::BoolishValueParser, error::ErrorKind};
 use std::ffi::OsString;
 use std::io::Write;
 use std::path::PathBuf;
@@ -68,6 +68,16 @@ Output format:
 #[derive(Debug, Parser)]
 #[command(about = "CLI for building with Turnkey Verifiable Cloud", long_about = LONG_ABOUT)]
 pub struct Cli {
+    #[command(flatten)]
+    output: OutputOptions,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+/// Presentation settings shared by both command entry points.
+#[derive(Debug, Args)]
+struct OutputOptions {
     /// Disable interactive prompts and fail fast when required values are missing.
     #[arg(
         long,
@@ -85,9 +95,287 @@ pub struct Cli {
     /// Control ANSI color in user-facing output.
     #[arg(long, global = true, value_enum, default_value_t = ColorChoice::Auto)]
     color: ColorChoice,
+}
 
+async fn run_resource(
+    prepared: anyhow::Result<crate::shared_resources::PreparedResource>,
+    options: &crate::shared_auth::AuthOptions,
+) -> anyhow::Result<crate::shared_operations::OperationOutput> {
+    let prepared = prepared?;
+    let auth = crate::shared_auth::resolve(options).await?;
+    prepared.run(auth).await
+}
+
+impl OutputOptions {
+    fn emit_operation(
+        self,
+        result: anyhow::Result<crate::shared_operations::OperationOutput>,
+    ) -> ExitCode {
+        let failed = result.as_ref().is_ok_and(|result| result.failed());
+        let emitted = self.emit_shared(result);
+        if failed { ExitCode::FAILURE } else { emitted }
+    }
+
+    fn emit_shared<M: serde::Serialize + std::fmt::Display>(
+        self,
+        result: anyhow::Result<M>,
+    ) -> ExitCode {
+        let mut shell = Shell::standard(self.message_format, self.color);
+        match result {
+            Ok(message) => {
+                if shell.emit(&message).is_ok() {
+                    ExitCode::SUCCESS
+                } else {
+                    ExitCode::FAILURE
+                }
+            }
+            Err(error) => {
+                if shell.message_format().is_json() {
+                    #[derive(serde::Serialize)]
+                    struct SharedError {
+                        #[serde(rename = "schemaVersion")]
+                        schema_version: u32,
+                        #[serde(flatten)]
+                        error: ErrorMessage,
+                    }
+                    impl std::fmt::Display for SharedError {
+                        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                            std::fmt::Display::fmt(&self.error, f)
+                        }
+                    }
+                    let _ = shell.emit(&SharedError {
+                        schema_version: 1,
+                        error: ErrorMessage::from_error(&error),
+                    });
+                } else {
+                    let _ = shell.human().error(&error);
+                }
+                ExitCode::FAILURE
+            }
+        }
+    }
+}
+
+/// Unified Turnkey CLI entry point.
+#[derive(Debug, Parser)]
+#[command(name = "tk", about = "CLI for building with Turnkey")]
+pub struct TkCli {
+    #[command(flatten)]
+    auth: crate::shared_auth::AuthOptions,
+    #[command(flatten)]
+    output: OutputOptions,
     #[command(subcommand)]
-    command: Commands,
+    command: TkCommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum TkCommands {
+    /// Send an arbitrary signed API request.
+    Request(crate::shared_operations::RequestArgs),
+    /// Inspect, approve, reject, and wait for activities.
+    Activity {
+        #[command(subcommand)]
+        command: crate::shared_operations::ActivityCommand,
+    },
+    /// Manage users and user tags.
+    User(crate::shared_resources::UserArgs),
+    /// Manage policies and inspect evaluations.
+    Policy(crate::shared_resources::PolicyArgs),
+    /// Manage registered API credentials.
+    ApiKey {
+        #[command(subcommand)]
+        command: SharedApiKeyCommand,
+    },
+    /// Manage wallets and accounts.
+    Wallet {
+        #[command(subcommand)]
+        command: crate::shared_wallets::WalletCommand,
+    },
+    /// Sign payloads and serialized transactions.
+    Sign {
+        #[command(subcommand)]
+        command: crate::shared_wallets::SignCommand,
+    },
+    /// Authenticate using an existing API credential.
+    Login(crate::shared_auth::LoginArgs),
+    /// Verify the selected identity remotely.
+    Whoami,
+    /// Manage shared API authentication.
+    Auth {
+        #[command(subcommand)]
+        command: crate::shared_auth::AuthCommand,
+    },
+    /// Manage named API identities.
+    Profile {
+        #[command(subcommand)]
+        command: crate::shared_auth::ProfileCommand,
+    },
+    /// Build with Turnkey Verifiable Cloud.
+    Tvc {
+        #[command(subcommand)]
+        command: CloudCommands,
+    },
+    /// Print the CLI version.
+    Version,
+}
+
+#[derive(Debug, Subcommand)]
+enum SharedApiKeyCommand {
+    /// Generate a protected local credential file without registration.
+    Generate(crate::shared_key_generation::GenerateArgs),
+    #[command(flatten)]
+    Remote(crate::shared_resources::ApiKeyCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum CloudCommands {
+    /// Manage hosted TVC operators.
+    Operator {
+        #[command(subcommand)]
+        command: OperatorCommands,
+    },
+    /// Manage deployments.
+    Deploy {
+        #[command(subcommand)]
+        command: DeployCommands,
+    },
+    /// Manage applications.
+    App {
+        #[command(subcommand)]
+        command: AppCommands,
+    },
+    /// Manage TVC operator and quorum keys.
+    Keys {
+        #[command(subcommand)]
+        command: KeysCommands,
+    },
+}
+
+impl TkCli {
+    /// Parse and execute a unified command using the shared runtime.
+    pub async fn run() -> ExitCode {
+        let args = match Self::try_parse() {
+            Ok(args) => args,
+            Err(error) => return handle_parse_error(error),
+        };
+        let command = match args.command {
+            TkCommands::Request(request) => {
+                let prepared = match request.prepare() {
+                    Ok(prepared) => prepared,
+                    Err(error) => return args.output.emit_operation(Ok(error)),
+                };
+                let result = async {
+                    let auth = crate::shared_auth::resolve(&args.auth).await?;
+                    Ok(prepared
+                        .run(&auth.org_id, &auth.api_base_url, &auth.stamper)
+                        .await)
+                }
+                .await;
+                return args.output.emit_operation(result);
+            }
+            TkCommands::Activity { command } => {
+                let result = async {
+                    let auth = crate::shared_auth::resolve(&args.auth).await?;
+                    Ok(crate::shared_operations::run_activity(
+                        command,
+                        &auth.org_id,
+                        &auth.api_base_url,
+                        &auth.stamper,
+                    )
+                    .await)
+                }
+                .await;
+                return args.output.emit_operation(result);
+            }
+            TkCommands::User(user) => {
+                return args
+                    .output
+                    .emit_operation(run_resource(user.prepare(), &args.auth).await);
+            }
+            TkCommands::Policy(policy) => {
+                return args
+                    .output
+                    .emit_operation(run_resource(policy.prepare(), &args.auth).await);
+            }
+            TkCommands::ApiKey { command } => {
+                let result = match command {
+                    SharedApiKeyCommand::Generate(args) => args.run(),
+                    SharedApiKeyCommand::Remote(command) => {
+                        run_resource(
+                            crate::shared_resources::ApiKeyArgs::from(command).prepare(),
+                            &args.auth,
+                        )
+                        .await
+                    }
+                };
+                return args.output.emit_operation(result);
+            }
+            TkCommands::Wallet { command } => {
+                let result = async {
+                    let prepared = command.prepare()?;
+                    let auth = crate::shared_auth::resolve(&args.auth).await?;
+                    prepared.run(auth).await
+                }
+                .await;
+                return args.output.emit_operation(result);
+            }
+            TkCommands::Sign { command } => {
+                let result = async {
+                    let prepared = command.prepare()?;
+                    let auth = crate::shared_auth::resolve(&args.auth).await?;
+                    prepared.run(auth).await
+                }
+                .await;
+                return args.output.emit_operation(result);
+            }
+            TkCommands::Login(login) => {
+                return args.output.emit_shared(
+                    crate::shared_auth::run_auth(
+                        crate::shared_auth::AuthCommand::Login(login),
+                        &args.auth,
+                    )
+                    .await,
+                );
+            }
+            TkCommands::Whoami => {
+                return args.output.emit_shared(
+                    crate::shared_auth::run_auth(
+                        crate::shared_auth::AuthCommand::Whoami,
+                        &args.auth,
+                    )
+                    .await,
+                );
+            }
+            TkCommands::Auth { command } => {
+                return args
+                    .output
+                    .emit_shared(crate::shared_auth::run_auth(command, &args.auth).await);
+            }
+            TkCommands::Profile { command } => {
+                return args
+                    .output
+                    .emit_shared(crate::shared_auth::run_profile(command, &args.auth).await);
+            }
+            TkCommands::Tvc { command } => {
+                if args.auth.has_selection() {
+                    return args.output.emit_shared::<crate::shared_auth::AuthOutput>(Err(crate::shared_auth::InvalidAuthInput("shared identity selectors are not yet supported by tk tvc; use the existing TVC environment/configuration".into()).into()));
+                }
+                match command {
+                    CloudCommands::Operator { command } => Commands::Operator { command },
+                    CloudCommands::Deploy { command } => Commands::Deploy { command },
+                    CloudCommands::App { command } => Commands::App { command },
+                    CloudCommands::Keys { command } => Commands::Keys { command },
+                }
+            }
+            TkCommands::Version => Commands::Version,
+        };
+        Cli {
+            output: args.output,
+            command,
+        }
+        .run_parsed()
+        .await
+    }
 }
 
 impl Cli {
@@ -97,16 +385,21 @@ impl Cli {
             Ok(args) => args,
             Err(error) => return handle_parse_error(error),
         };
+        args.run_parsed().await
+    }
+
+    async fn run_parsed(self) -> ExitCode {
+        let args = self;
         debug!(
             command = args.command.name(),
-            non_interactive = args.non_interactive,
-            message_format = ?args.message_format,
-            color = ?args.color,
+            non_interactive = args.output.non_interactive,
+            message_format = ?args.output.message_format,
+            color = ?args.output.color,
             "dispatching"
         );
 
-        let shell = Shell::standard(args.message_format, args.color);
-        let mut ctx = Ctx::new(shell, args.non_interactive);
+        let shell = Shell::standard(args.output.message_format, args.output.color);
+        let mut ctx = Ctx::new(shell, args.output.non_interactive);
         let result = args.command.run(&mut ctx).await;
         match result {
             Ok(outcome) => {

--- a/tvc/src/errors.rs
+++ b/tvc/src/errors.rs
@@ -92,6 +92,12 @@ impl Classification {
 /// status; callers still render the complete original chain.
 pub fn classify(error: &anyhow::Error) -> Classification {
     for cause in error.chain() {
+        if cause
+            .downcast_ref::<crate::shared_auth::InvalidAuthInput>()
+            .is_some()
+        {
+            return Classification::new(ErrorCode::InvalidInput, None);
+        }
         if cause.downcast_ref::<MissingResource>().is_some() {
             return Classification::new(ErrorCode::NotFound, None);
         }

--- a/tvc/src/lib.rs
+++ b/tvc/src/lib.rs
@@ -23,4 +23,10 @@ pub mod prompts;
 pub(crate) mod provisioning;
 pub mod pull_secret;
 pub(crate) mod quorum_key_metadata;
+pub mod shared_resources;
 pub mod util;
+
+pub mod shared_auth;
+pub mod shared_key_generation;
+pub mod shared_operations;
+pub mod shared_wallets;

--- a/tvc/src/shared_auth.rs
+++ b/tvc/src/shared_auth.rs
@@ -1,0 +1,589 @@
+//! Shared identity selection independent of TVC operator configuration.
+
+use crate::{
+    client::{AuthenticatedClient, build_turnkey_client},
+    config::turnkey::{Config, KeyCurve, StoredApiKey},
+};
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::GetWhoamiRequest;
+use uuid::Uuid;
+
+const DEFAULT_URL: &str = "https://api.turnkey.com";
+
+/// Global identity selectors. Credential secrets are never command-line arguments.
+#[derive(Debug, Default, Args)]
+pub struct AuthOptions {
+    #[arg(long, global = true, env = "TK_CONFIG")]
+    config: Option<PathBuf>,
+    #[arg(long, global = true, env = "TK_PROFILE")]
+    profile: Option<String>,
+    #[arg(long, global = true)]
+    organization_id: Option<Uuid>,
+    #[arg(long, global = true)]
+    api_base_url: Option<String>,
+}
+
+impl AuthOptions {
+    pub(crate) fn has_selection(&self) -> bool {
+        self.config.is_some()
+            || self.profile.is_some()
+            || self.organization_id.is_some()
+            || self.api_base_url.is_some()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub(crate) struct InvalidAuthInput(pub String);
+
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Save and select an existing API credential after verifying it remotely.
+    Login(LoginArgs),
+    /// Inspect local credential readiness without contacting the server.
+    Status,
+    /// Verify the selected identity with Turnkey.
+    Whoami,
+    /// Clear the saved profile selection; keep credentials and remote access intact.
+    Logout,
+}
+
+#[derive(Debug, Args)]
+pub struct LoginArgs {
+    /// Existing P256 credential JSON file (public_key, private_key, curve).
+    #[arg(long)]
+    api_key_file: PathBuf,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProfileCommand {
+    List,
+    Show { name: String },
+    Use { name: String },
+    Delete { name: String },
+    Import(ImportArgs),
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+enum ImportSource {
+    Tvc,
+    ExperimentalTk,
+}
+
+#[derive(Debug, Args)]
+pub struct ImportArgs {
+    #[arg(long, value_enum)]
+    from: ImportSource,
+    #[arg(long)]
+    name: String,
+    #[arg(long)]
+    source: Option<PathBuf>,
+    #[arg(long)]
+    source_profile: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Registry {
+    version: u32,
+    active_profile: Option<String>,
+    #[serde(default)]
+    profiles: BTreeMap<String, Profile>,
+}
+impl Default for Registry {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            active_profile: None,
+            profiles: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Profile {
+    organization_id: Uuid,
+    api_base_url: String,
+    api_key_file: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ssh_signing_key_id: Option<String>,
+}
+
+/// Resolved identity; intentionally does not implement Debug or Serialize.
+pub struct ResolvedAuth {
+    pub org_id: String,
+    pub api_base_url: String,
+    pub stamper: TurnkeyP256ApiKey,
+    source: &'static str,
+    profile: Option<String>,
+}
+impl ResolvedAuth {
+    pub fn into_client(self) -> Result<AuthenticatedClient> {
+        Ok(AuthenticatedClient {
+            client: build_turnkey_client(self.stamper, &self.api_base_url)?,
+            org_id: self.org_id,
+            api_base_url: self.api_base_url,
+        })
+    }
+}
+
+/// A shared command result, emitted by the common presentation boundary.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthOutput {
+    schema_version: u32,
+    reason: &'static str,
+    command: &'static str,
+    status: &'static str,
+    data: Value,
+}
+impl Display for AuthOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.data)
+    }
+}
+fn result(command: &'static str, data: Value) -> AuthOutput {
+    AuthOutput {
+        schema_version: 1,
+        reason: "command_result",
+        command,
+        status: "completed",
+        data,
+    }
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+fn home() -> Result<PathBuf> {
+    env("HOME")
+        .map(PathBuf::from)
+        .context("HOME is required when no explicit configuration path is supplied")
+}
+fn registry_path(options: &AuthOptions) -> Result<PathBuf> {
+    options
+        .config
+        .clone()
+        .map(Ok)
+        .unwrap_or_else(|| Ok(home()?.join(".config/turnkey/tk.config.toml")))
+}
+fn load(path: &Path) -> Result<Registry> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Registry::default()),
+        Err(e) => return Err(e).with_context(|| format!("read registry {}", path.display())),
+    };
+    // Avoid including source lines, which could contain accidentally pasted secrets.
+    let registry: Registry = toml::from_str(&text).map_err(|_| {
+        anyhow::Error::from(InvalidAuthInput(format!(
+            "invalid identity registry {}",
+            path.display()
+        )))
+    })?;
+    if registry.version != 1 {
+        bail!(
+            "unsupported registry version {} in {}",
+            registry.version,
+            path.display()
+        );
+    }
+    Ok(registry)
+}
+// Serialize registry mutations so concurrent agents cannot silently lose profiles.
+struct RegistryLock(PathBuf);
+impl RegistryLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let lock = path.with_extension("lock");
+        secure_create(&lock, std::process::id().to_string().as_bytes())
+            .context("identity registry is locked; retry after the other writer completes")?;
+        Ok(Self(lock))
+    }
+}
+impl Drop for RegistryLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn save(path: &Path, registry: &Registry) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temporary = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
+    let content = toml::to_string_pretty(registry)?;
+    secure_create(&temporary, content.as_bytes())?;
+    if let Err(error) = fs::rename(&temporary, path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error).context("replace identity registry");
+    }
+    Ok(())
+}
+fn secure_create(path: &Path, contents: &[u8]) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).with_context(|| {
+        format!(
+            "create {} without overwriting existing files",
+            path.display()
+        )
+    })?;
+    if let Err(error) = file.write_all(contents).and_then(|_| file.sync_all()) {
+        let _ = fs::remove_file(path);
+        return Err(error).context("write protected file");
+    }
+    Ok(())
+}
+fn parse_key(private: &str, public: &str) -> Result<TurnkeyP256ApiKey> {
+    let bytes = hex::decode(private).context("private credential must be hexadecimal")?;
+    if bytes.len() != 32 {
+        bail!("P256 private credentials must contain exactly 32 bytes");
+    }
+    TurnkeyP256ApiKey::from_strings(private, Some(public)).context("invalid P256 credential pair")
+}
+
+fn read_key(path: &Path) -> Result<TurnkeyP256ApiKey> {
+    let text =
+        fs::read_to_string(path).with_context(|| format!("read credential {}", path.display()))?;
+    let key: StoredApiKey = serde_json::from_str(&text)
+        .map_err(|_| anyhow::anyhow!("invalid credential JSON in {}", path.display()))?;
+    if !matches!(key.curve, KeyCurve::P256) {
+        bail!("shared authentication supports only P256 credentials");
+    }
+    parse_key(&key.private_key, &key.public_key)
+}
+fn endpoint(options: &AuthOptions, fallback: String) -> Result<String> {
+    let endpoint = options
+        .api_base_url
+        .clone()
+        .or_else(|| env("TURNKEY_API_BASE_URL"))
+        .unwrap_or(fallback);
+    parse_endpoint(endpoint)
+}
+fn parse_endpoint(endpoint: String) -> Result<String> {
+    let url = reqwest::Url::parse(&endpoint).context("invalid API base URL")?;
+    if !matches!(url.scheme(), "https" | "http")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        bail!("API base URL must be an HTTP(S) URL without credentials, query or fragment");
+    }
+    Ok(endpoint)
+}
+
+/// Resolve a complete identity without mixing credentials across sources.
+pub async fn resolve(options: &AuthOptions) -> Result<ResolvedAuth> {
+    if options.profile.is_none() {
+        let canonical = [
+            "TURNKEY_ORGANIZATION_ID",
+            "TURNKEY_API_PUBLIC_KEY",
+            "TURNKEY_API_PRIVATE_KEY",
+        ]
+        .map(std::env::var_os);
+        let legacy =
+            ["TVC_ORG_ID", "TVC_API_KEY_PUBLIC", "TVC_API_KEY_PRIVATE"].map(std::env::var_os);
+        let has_canonical = canonical.iter().any(Option::is_some);
+        let has_legacy = legacy.iter().any(Option::is_some);
+        if has_canonical && has_legacy {
+            bail!(
+                "conflicting TURNKEY and TVC credential bundles; select --profile or supply only one bundle"
+            );
+        }
+        if has_canonical || has_legacy {
+            let [org, public, private] = if has_canonical { canonical } else { legacy };
+            let (Some(org), Some(public), Some(private)) = (org, public, private) else {
+                bail!(
+                    "partial credential environment: organization ID, public key, and private key are all required"
+                );
+            };
+            let org = org.into_string().map_err(|_| {
+                InvalidAuthInput("organization environment value is not valid Unicode".into())
+            })?;
+            let public = public.into_string().map_err(|_| {
+                InvalidAuthInput("public key environment value is not valid Unicode".into())
+            })?;
+            let private = private.into_string().map_err(|_| {
+                InvalidAuthInput("private key environment value is not valid Unicode".into())
+            })?;
+            if org.is_empty() || public.is_empty() || private.is_empty() {
+                return Err(InvalidAuthInput(
+                    "credential environment fields must not be empty".into(),
+                )
+                .into());
+            }
+            let org = match options.organization_id {
+                Some(org) => org,
+                None => Uuid::parse_str(&org).context("invalid environment organization ID")?,
+            };
+            return Ok(ResolvedAuth {
+                org_id: org.to_string(),
+                api_base_url: endpoint(
+                    options,
+                    if has_legacy {
+                        env("TVC_API_BASE_URL").unwrap_or_else(|| DEFAULT_URL.into())
+                    } else {
+                        DEFAULT_URL.into()
+                    },
+                )?,
+                stamper: parse_key(&private, &public)?,
+                source: if has_canonical {
+                    "environment"
+                } else {
+                    "legacy_environment"
+                },
+                profile: None,
+            });
+        }
+    }
+    let path = registry_path(options)?;
+    let registry = load(&path)?;
+    let name = options
+        .profile
+        .as_ref()
+        .or(registry.active_profile.as_ref())
+        .context("no selected identity; use --profile or tk login")?;
+    let profile = registry
+        .profiles
+        .get(name)
+        .with_context(|| format!("profile {name} does not exist in {}", path.display()))?;
+    Ok(ResolvedAuth {
+        org_id: options
+            .organization_id
+            .unwrap_or(profile.organization_id)
+            .to_string(),
+        api_base_url: endpoint(options, profile.api_base_url.clone())?,
+        stamper: read_key(&profile.api_key_file)?,
+        source: "profile",
+        profile: Some(name.clone()),
+    })
+}
+
+pub async fn run_auth(command: AuthCommand, options: &AuthOptions) -> Result<AuthOutput> {
+    match command {
+        AuthCommand::Status => {
+            let auth = resolve(options).await?;
+            Ok(result(
+                "auth.status",
+                json!({"ready": true, "profile": auth.profile, "organizationId": auth.org_id, "apiBaseUrl": auth.api_base_url, "publicKey": hex::encode(auth.stamper.compressed_public_key()), "credentialSource": auth.source}),
+            ))
+        }
+        AuthCommand::Whoami => {
+            let auth = resolve(options).await?.into_client()?;
+            let identity = auth
+                .client
+                .get_whoami(GetWhoamiRequest {
+                    organization_id: auth.org_id,
+                })
+                .await?;
+            Ok(result("auth.whoami", serde_json::to_value(identity)?))
+        }
+        AuthCommand::Logout => {
+            let path = registry_path(options)?;
+            let _lock = RegistryLock::acquire(&path)?;
+            let mut registry = load(&path)?;
+            registry.active_profile = None;
+            save(&path, &registry)?;
+            Ok(result(
+                "auth.logout",
+                json!({"activeProfile": null, "environmentCredentialsPresent": (["TURNKEY_ORGANIZATION_ID", "TURNKEY_API_PUBLIC_KEY", "TURNKEY_API_PRIVATE_KEY", "TVC_ORG_ID", "TVC_API_KEY_PUBLIC", "TVC_API_KEY_PRIVATE"].iter().any(|name| env(name).is_some()))}),
+            ))
+        }
+        AuthCommand::Login(args) => {
+            let name = options
+                .profile
+                .as_ref()
+                .context("login requires --profile NAME")?;
+            let org = options
+                .organization_id
+                .context("login requires --organization-id")?;
+            let path = registry_path(options)?;
+            let _lock = RegistryLock::acquire(&path)?;
+            let mut registry = load(&path)?;
+            if registry.profiles.contains_key(name) {
+                bail!("profile {name} already exists; use profile use to select it");
+            }
+            let key_path =
+                fs::canonicalize(args.api_key_file).context("resolve credential path")?;
+            let base_url = endpoint(options, DEFAULT_URL.into())?;
+            let client = build_turnkey_client(read_key(&key_path)?, &base_url)?;
+            let identity = client
+                .get_whoami(GetWhoamiRequest {
+                    organization_id: org.to_string(),
+                })
+                .await?;
+            registry.profiles.insert(
+                name.clone(),
+                Profile {
+                    organization_id: org,
+                    api_base_url: base_url,
+                    api_key_file: key_path,
+                    ssh_signing_key_id: None,
+                },
+            );
+            registry.active_profile = Some(name.clone());
+            save(&path, &registry)?;
+            Ok(result(
+                "auth.login",
+                json!({"profile": name, "identity": identity}),
+            ))
+        }
+    }
+}
+
+pub async fn run_profile(command: ProfileCommand, options: &AuthOptions) -> Result<AuthOutput> {
+    let path = registry_path(options)?;
+    let _lock = if matches!(&command, ProfileCommand::List | ProfileCommand::Show { .. }) {
+        None
+    } else {
+        Some(RegistryLock::acquire(&path)?)
+    };
+    let mut registry = load(&path)?;
+    match command {
+        ProfileCommand::List => Ok(result(
+            "profile.list",
+            json!({"activeProfile": registry.active_profile, "profiles": registry.profiles}),
+        )),
+        ProfileCommand::Show { name } => Ok(result(
+            "profile.show",
+            json!({"name": name, "profile": registry.profiles.get(&name).context("profile does not exist")?}),
+        )),
+        ProfileCommand::Use { name } => {
+            let profile = registry
+                .profiles
+                .get(&name)
+                .context("profile does not exist")?;
+            read_key(&profile.api_key_file)?;
+            registry.active_profile = Some(name.clone());
+            save(&path, &registry)?;
+            Ok(result("profile.use", json!({"activeProfile": name})))
+        }
+        ProfileCommand::Delete { name } => {
+            registry
+                .profiles
+                .remove(&name)
+                .context("profile does not exist")?;
+            if registry.active_profile.as_ref() == Some(&name) {
+                registry.active_profile = None;
+            }
+            save(&path, &registry)?;
+            Ok(result(
+                "profile.delete",
+                json!({"name": name, "credentialFilesDeleted": false}),
+            ))
+        }
+        ProfileCommand::Import(args) => {
+            if registry.profiles.contains_key(&args.name) {
+                bail!("profile {} already exists", args.name);
+            }
+            let source = match args.source {
+                Some(path) => path,
+                None => home()?.join(match args.from {
+                    ImportSource::Tvc => ".config/turnkey/tvc.config.toml",
+                    ImportSource::ExperimentalTk => ".config/turnkey/tk/tk.toml",
+                }),
+            };
+            let text = fs::read_to_string(&source)
+                .with_context(|| format!("read import source {}", source.display()))?;
+            let profile = match args.from {
+                ImportSource::Tvc => {
+                    let config = Config::from_toml(&text).map_err(|_| {
+                        InvalidAuthInput(format!(
+                            "invalid TVC import configuration {}",
+                            source.display()
+                        ))
+                    })?;
+                    let org = match args.source_profile {
+                        Some(name) => config
+                            .orgs
+                            .get(&name)
+                            .context("source profile does not exist")?,
+                        None if config.orgs.len() == 1 => {
+                            config.orgs.values().next().context("no source profile")?
+                        }
+                        None => bail!(
+                            "select --source-profile when importing a registry with multiple organizations"
+                        ),
+                    };
+                    read_key(&org.api_key_path)?;
+                    Profile {
+                        organization_id: Uuid::parse_str(&org.id)?,
+                        api_base_url: org.api_base_url.clone(),
+                        api_key_file: fs::canonicalize(&org.api_key_path)?,
+                        ssh_signing_key_id: None,
+                    }
+                }
+                ImportSource::ExperimentalTk => {
+                    if args.source_profile.is_some() {
+                        bail!("--source-profile is only supported for TVC imports");
+                    }
+                    #[derive(Deserialize)]
+                    struct Legacy {
+                        turnkey: LegacyIdentity,
+                    }
+                    #[derive(Deserialize)]
+                    #[serde(rename_all = "camelCase")]
+                    struct LegacyIdentity {
+                        organization_id: Uuid,
+                        api_public_key: String,
+                        api_private_key: String,
+                        #[serde(default)]
+                        api_base_url: Option<String>,
+                        private_key_id: Option<String>,
+                    }
+                    let legacy: Legacy = toml::from_str(&text)
+                        .map_err(|_| anyhow::anyhow!("invalid experimental tk configuration"))?;
+                    let key = legacy.turnkey;
+                    parse_key(&key.api_private_key, &key.api_public_key)?;
+                    let api_base_url =
+                        parse_endpoint(key.api_base_url.unwrap_or_else(|| DEFAULT_URL.into()))?;
+                    let directory = path
+                        .parent()
+                        .context("registry needs a parent directory")?
+                        .join("credentials");
+                    fs::create_dir_all(&directory)?;
+                    let key_path = directory.join(format!("{}.json", Uuid::new_v4()));
+                    let stored = StoredApiKey {
+                        public_key: key.api_public_key,
+                        private_key: key.api_private_key,
+                        curve: KeyCurve::P256,
+                    };
+                    secure_create(&key_path, &serde_json::to_vec(&stored)?)?;
+                    Profile {
+                        organization_id: key.organization_id,
+                        api_base_url,
+                        api_key_file: fs::canonicalize(key_path)?,
+                        ssh_signing_key_id: key.private_key_id,
+                    }
+                }
+            };
+            registry.profiles.insert(args.name.clone(), profile);
+            save(&path, &registry)?;
+            Ok(result(
+                "profile.import",
+                json!({"name": args.name, "selected": false}),
+            ))
+        }
+    }
+}

--- a/tvc/src/shared_key_generation.rs
+++ b/tvc/src/shared_key_generation.rs
@@ -1,0 +1,116 @@
+//! Offline credential creation with an explicit private-key destination.
+use crate::{
+    config::turnkey::{KeyCurve, StoredApiKey},
+    shared_operations::OperationOutput,
+};
+use anyhow::{Context, Result};
+use clap::Args;
+use serde_json::json;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::PathBuf,
+};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use zeroize::Zeroizing;
+
+#[derive(Debug, Args)]
+pub struct GenerateArgs {
+    /// New credential JSON path. Existing files are never overwritten.
+    #[arg(long)]
+    output: PathBuf,
+}
+impl GenerateArgs {
+    pub fn run(self) -> Result<OperationOutput> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&self.output)
+            .with_context(|| format!("create credential destination {}", self.output.display()))?;
+        let result = (|| -> Result<_> {
+            let key = TurnkeyP256ApiKey::generate();
+            let public_key = hex::encode(key.compressed_public_key());
+            let mut stored = StoredApiKey {
+                public_key: public_key.clone(),
+                private_key: hex::encode(key.private_key()),
+                curve: KeyCurve::P256,
+            };
+            let encoded = serde_json::to_vec(&stored);
+            use zeroize::Zeroize;
+            stored.private_key.zeroize();
+            let encoded = Zeroizing::new(encoded?);
+            file.write_all(&encoded)
+                .context("write private credential")?;
+            file.sync_all().context("persist private credential")?;
+            Ok(public_key)
+        })();
+        drop(file);
+        match result {
+            Ok(public_key) => Ok(OperationOutput::result(
+                "api-key.generate",
+                json!({"publicKey": public_key, "curve": "p256", "path": self.output}),
+            )),
+            Err(error) => {
+                fs::remove_file(&self.output).context("remove incomplete credential file")?;
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn generated_credentials_are_valid_private_and_not_in_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key.json");
+        let output = GenerateArgs {
+            output: path.clone(),
+        }
+        .run()
+        .unwrap();
+        let stored: StoredApiKey = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        TurnkeyP256ApiKey::from_strings(&stored.private_key, Some(&stored.public_key)).unwrap();
+        let result = serde_json::to_value(output).unwrap();
+        assert_eq!(result["data"]["publicKey"], stored.public_key);
+        assert!(!result.to_string().contains(&stored.private_key));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+    #[test]
+    fn existing_destination_is_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key.json");
+        fs::write(&path, b"existing").unwrap();
+        assert!(
+            GenerateArgs {
+                output: path.clone()
+            }
+            .run()
+            .is_err()
+        );
+        assert_eq!(fs::read(path).unwrap(), b"existing");
+    }
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_is_not_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let path = dir.path().join("link");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+        assert!(GenerateArgs { output: path }.run().is_err());
+        assert!(!target.exists());
+    }
+}

--- a/tvc/src/shared_operations.rs
+++ b/tvc/src/shared_operations.rs
@@ -1,0 +1,1173 @@
+//! Signed requests and resumable activity operations for shared CLI identities.
+use std::fmt::{self, Display, Formatter};
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use clap::{Args, Subcommand};
+use reqwest::{Client, Url, redirect::Policy};
+use serde::Serialize;
+use serde_json::{Value, json};
+use turnkey_api_key_stamper::{Stamp, TurnkeyP256ApiKey};
+use turnkey_client::generated::{
+    GetActivitiesRequest, GetActivityRequest,
+    external::{
+        activity::v1::{ApproveActivityRequest, RejectActivityRequest},
+        options::v1::Pagination,
+    },
+    immutable::activity::v1::{ApproveActivityIntent, RejectActivityIntent},
+};
+
+#[derive(Debug, Args)]
+pub struct RequestArgs {
+    #[arg(long, value_parser = request_path)]
+    path: String,
+    #[arg(
+        long,
+        required_unless_present = "body_file",
+        conflicts_with = "body_file"
+    )]
+    body: Option<String>,
+    /// Read exact UTF-8 request bytes from a file, or - for stdin.
+    #[arg(long, required_unless_present = "body", conflicts_with = "body")]
+    body_file: Option<PathBuf>,
+    /// Produce a stamp without submitting the request.
+    #[arg(long)]
+    stamp_only: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ActivityCommand {
+    List {
+        #[arg(long, default_value_t = 50, value_parser = clap::value_parser!(u32).range(1..))]
+        limit: u32,
+        /// API after cursor (activity ID); pagination is explicitly caller-driven.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+    Get {
+        id: String,
+    },
+    Approve {
+        id: String,
+    },
+    Reject {
+        id: String,
+    },
+    Wait {
+        id: String,
+        #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(1..))]
+        timeout: u64,
+    },
+}
+
+/// A terminal command record. A nonzero exit reflects operation failure, not an
+/// inspected resource's state; successfully inspecting a rejected activity works.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationOutput {
+    schema_version: u8,
+    reason: &'static str,
+    command: &'static str,
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Box<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activity: Option<Box<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    http_status: Option<u16>,
+}
+
+impl OperationOutput {
+    pub fn failed(&self) -> bool {
+        self.code.is_some()
+    }
+    pub fn result(command: &'static str, data: Value) -> Self {
+        let activity = data
+            .get("activity")
+            .filter(|v| v.is_object())
+            .map(|v| json!({"id":v.get("id"),"status":v.get("status")}));
+        let status = activity
+            .as_ref()
+            .map(activity_status)
+            .unwrap_or("completed");
+        Self {
+            schema_version: 1,
+            reason: "command_result",
+            command,
+            status,
+            data: Some(Box::new(data)),
+            activity: activity.map(Box::new),
+            code: None,
+            message: None,
+            http_status: None,
+        }
+    }
+    pub fn error(command: &'static str, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            schema_version: 1,
+            reason: "command_error",
+            command,
+            status: if code == "submission_unknown" {
+                "unknown"
+            } else {
+                "failed"
+            },
+            data: None,
+            activity: None,
+            code: Some(code),
+            message: Some(message.into()),
+            http_status: None,
+        }
+    }
+    fn fail(mut self, code: &'static str, message: &str) -> Self {
+        self.reason = "command_error";
+        self.code = Some(code);
+        self.message = Some(message.to_owned());
+        self
+    }
+}
+impl Display for OperationOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string_pretty(self).map_err(|_| fmt::Error)?
+        )
+    }
+}
+
+fn activity_status(activity: &Value) -> &'static str {
+    match activity.get("status").and_then(Value::as_str) {
+        Some("ACTIVITY_STATUS_COMPLETED") => "completed",
+        Some("ACTIVITY_STATUS_REJECTED") => "rejected",
+        Some("ACTIVITY_STATUS_FAILED") => "failed",
+        Some(
+            "ACTIVITY_STATUS_CREATED"
+            | "ACTIVITY_STATUS_PENDING"
+            | "ACTIVITY_STATUS_CONSENSUS_NEEDED"
+            | "ACTIVITY_STATUS_AUTHENTICATORS_NEEDED",
+        ) => "pending",
+        _ => "unknown",
+    }
+}
+fn request_path(value: &str) -> Result<String, String> {
+    if !value.starts_with("/public/v1/")
+        || value.contains(['?', '#', '\\', '%'])
+        || value.split('/').any(|s| s == ".." || s == ".")
+    {
+        return Err(
+            "path must be an absolute /public/v1/ API path without query, fragment, or traversal"
+                .into(),
+        );
+    }
+    Ok(value.into())
+}
+fn url(base: &str, path: &str) -> Result<Url, &'static str> {
+    let base = Url::parse(base).map_err(|_| "invalid API base URL")?;
+    if !matches!(base.scheme(), "https" | "http")
+        || !base.username().is_empty()
+        || base.password().is_some()
+        || base.query().is_some()
+        || base.fragment().is_some()
+    {
+        return Err("API base URL must be HTTP(S) without credentials, query, or fragment");
+    }
+    base.join(path).map_err(|_| "invalid request URL")
+}
+fn client() -> Result<Client, reqwest::Error> {
+    Client::builder()
+        .redirect(Policy::none())
+        .timeout(Duration::from_secs(30))
+        .build()
+}
+async fn post(
+    command: &'static str,
+    http: &Client,
+    endpoint: Url,
+    body: String,
+    stamper: &TurnkeyP256ApiKey,
+    mutation: bool,
+) -> Result<Value, OperationOutput> {
+    let stamp = stamper
+        .stamp(body.as_bytes())
+        .map_err(|_| OperationOutput::error(command, "invalid_input", "could not stamp request"))?;
+    let response = http
+        .post(endpoint)
+        .header(stamp.name, stamp.value)
+        .header("Content-Type", "application/json")
+        .header("X-TVC-CLIENT-VERSION", env!("CARGO_PKG_VERSION"))
+        .body(body)
+        .send()
+        .await
+        .map_err(|_| {
+            OperationOutput::error(
+                command,
+                if mutation {
+                    "submission_unknown"
+                } else {
+                    "network_error"
+                },
+                if mutation {
+                    "request outcome is unknown; inspect activities before resubmitting"
+                } else {
+                    "API request failed"
+                },
+            )
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let code = match status.as_u16() {
+            401 | 403 => "unauthorized",
+            404 => "not_found",
+            _ => "api_error",
+        };
+        let mut output = OperationOutput::error(
+            command,
+            code,
+            format!("API returned HTTP {}", status.as_u16()),
+        );
+        output.http_status = Some(status.as_u16());
+        return Err(output);
+    }
+    response.json().await.map_err(|_| {
+        OperationOutput::error(
+            command,
+            if mutation {
+                "submission_unknown"
+            } else {
+                "api_error"
+            },
+            "API returned an unreadable response",
+        )
+    })
+}
+fn encode<T: Serialize>(command: &'static str, value: &T) -> Result<String, OperationOutput> {
+    serde_json::to_string(value)
+        .map_err(|_| OperationOutput::error(command, "invalid_input", "could not encode request"))
+}
+fn validate_body(body: &str, org: &str) -> Result<(), &'static str> {
+    let value: Value = serde_json::from_str(body).map_err(|_| "body must be valid JSON")?;
+    if !value.is_object() {
+        return Err("body must be a JSON object");
+    }
+    if value.get("organizationId").and_then(Value::as_str) != Some(org) {
+        return Err("body organizationId must match selected organization");
+    }
+    Ok(())
+}
+
+/// A raw request whose local body has been read and parsed before authentication.
+pub struct PreparedRequest {
+    path: String,
+    body: String,
+    stamp_only: bool,
+}
+
+impl RequestArgs {
+    pub fn prepare(self) -> Result<PreparedRequest, OperationOutput> {
+        let command = "request";
+        let body = match (self.body, self.body_file) {
+            (Some(body), None) => Ok(body),
+            (None, Some(path)) if path.as_os_str() == "-" => {
+                let mut body = String::new();
+                std::io::stdin().read_to_string(&mut body).map(|_| body)
+            }
+            (None, Some(path)) => std::fs::read_to_string(path),
+            _ => {
+                return Err(OperationOutput::error(
+                    command,
+                    "invalid_input",
+                    "provide exactly one request body source",
+                ));
+            }
+        };
+        let body = match body {
+            Ok(body) => body,
+            Err(_) => {
+                return Err(OperationOutput::error(
+                    command,
+                    "invalid_input",
+                    "could not read UTF-8 request body",
+                ));
+            }
+        };
+        let value: Value = serde_json::from_str(&body).map_err(|_| {
+            OperationOutput::error("request", "invalid_input", "body must be valid JSON")
+        })?;
+        if !value.is_object() {
+            return Err(OperationOutput::error(
+                "request",
+                "invalid_input",
+                "body must be a JSON object",
+            ));
+        }
+        Ok(PreparedRequest {
+            path: self.path,
+            body,
+            stamp_only: self.stamp_only,
+        })
+    }
+}
+
+pub async fn run_request(
+    args: RequestArgs,
+    org_id: &str,
+    api_base_url: &str,
+    stamper: &TurnkeyP256ApiKey,
+) -> OperationOutput {
+    match args.prepare() {
+        Ok(prepared) => prepared.run(org_id, api_base_url, stamper).await,
+        Err(error) => error,
+    }
+}
+
+impl PreparedRequest {
+    pub async fn run(
+        self,
+        org_id: &str,
+        api_base_url: &str,
+        stamper: &TurnkeyP256ApiKey,
+    ) -> OperationOutput {
+        let command = "request";
+        let body = self.body;
+        if let Err(message) = validate_body(&body, org_id) {
+            return OperationOutput::error(command, "invalid_input", message);
+        }
+        let endpoint = match url(api_base_url, &self.path) {
+            Ok(url) => url,
+            Err(message) => return OperationOutput::error(command, "invalid_input", message),
+        };
+        if self.stamp_only {
+            return match stamper.stamp(body.as_bytes()) {
+                Ok(stamp) => OperationOutput::result(
+                    command,
+                    json!({"url":endpoint.as_str(),"method":"POST","header":{"name":stamp.name,"value":stamp.value},"body":body}),
+                ),
+                Err(_) => {
+                    OperationOutput::error(command, "invalid_input", "could not stamp request")
+                }
+            };
+        }
+        let http = match client() {
+            Ok(http) => http,
+            Err(_) => {
+                return OperationOutput::error(
+                    command,
+                    "command_error",
+                    "could not initialize HTTP client",
+                );
+            }
+        };
+        match post(
+            command,
+            &http,
+            endpoint,
+            body,
+            stamper,
+            !self.path.starts_with("/public/v1/query/"),
+        )
+        .await
+        {
+            Ok(value) if self.path.starts_with("/public/v1/query/") => {
+                OperationOutput::result(command, value)
+            }
+            Ok(value) => submission_result(command, value),
+            Err(error) => error,
+        }
+    }
+}
+
+fn submission_result(command: &'static str, data: Value) -> OperationOutput {
+    if data
+        .pointer("/activity/id")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        return OperationOutput::error(
+            command,
+            "submission_unknown",
+            "response omitted activity identity; inspect activities before resubmitting",
+        );
+    }
+    terminal_submission(OperationOutput::result(command, data))
+}
+
+fn terminal_submission(output: OperationOutput) -> OperationOutput {
+    match output.status {
+        "rejected" => output.fail("api_error", "activity rejected"),
+        "failed" => output.fail("api_error", "activity failed"),
+        "unknown" => output.fail(
+            "submission_unknown",
+            "unknown activity status; inspect activity before resubmitting",
+        ),
+        _ => output,
+    }
+}
+
+async fn query_activity(
+    command: &'static str,
+    http: &Client,
+    base: &str,
+    org: &str,
+    id: &str,
+    stamper: &TurnkeyP256ApiKey,
+) -> Result<Value, OperationOutput> {
+    let body = encode(
+        command,
+        &GetActivityRequest {
+            organization_id: org.into(),
+            activity_id: id.into(),
+        },
+    )?;
+    let endpoint = url(base, "/public/v1/query/get_activity")
+        .map_err(|message| OperationOutput::error(command, "invalid_input", message))?;
+    let value = post(command, http, endpoint, body, stamper, false).await?;
+    if value.pointer("/activity/id").and_then(Value::as_str) != Some(id) {
+        return Err(OperationOutput::error(
+            command,
+            "api_error",
+            "response omitted or mismatched requested activity",
+        ));
+    }
+    Ok(value)
+}
+
+pub async fn run_activity(
+    args: ActivityCommand,
+    org_id: &str,
+    api_base_url: &str,
+    stamper: &TurnkeyP256ApiKey,
+) -> OperationOutput {
+    let command = match &args {
+        ActivityCommand::List { .. } => "activity.list",
+        ActivityCommand::Get { .. } => "activity.get",
+        ActivityCommand::Approve { .. } => "activity.approve",
+        ActivityCommand::Reject { .. } => "activity.reject",
+        ActivityCommand::Wait { .. } => "activity.wait",
+    };
+    let http = match client() {
+        Ok(http) => http,
+        Err(_) => {
+            return OperationOutput::error(
+                command,
+                "command_error",
+                "could not initialize HTTP client",
+            );
+        }
+    };
+    match activity_inner(command, args, org_id, api_base_url, stamper, &http).await {
+        Ok(output) | Err(output) => output,
+    }
+}
+async fn activity_inner(
+    command: &'static str,
+    args: ActivityCommand,
+    org: &str,
+    base: &str,
+    stamper: &TurnkeyP256ApiKey,
+    http: &Client,
+) -> Result<OperationOutput, OperationOutput> {
+    if let ActivityCommand::List { limit, cursor } = args {
+        let request = GetActivitiesRequest {
+            organization_id: org.into(),
+            filter_by_status: vec![],
+            filter_by_type: vec![],
+            pagination_options: Some(Pagination {
+                limit: limit.to_string(),
+                before: String::new(),
+                after: cursor.unwrap_or_default(),
+            }),
+        };
+        let endpoint = url(base, "/public/v1/query/list_activities")
+            .map_err(|message| OperationOutput::error(command, "invalid_input", message))?;
+        let response = post(
+            command,
+            http,
+            endpoint,
+            encode(command, &request)?,
+            stamper,
+            false,
+        )
+        .await?;
+        let items = response
+            .get("activities")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                OperationOutput::error(command, "api_error", "response omitted activities")
+            })?;
+        // The API exposes no hasNextPage. Return a continuation candidate rather
+        // than claim a full page proves more results exist.
+        let next = if items.len() == limit as usize {
+            items.last().and_then(|item| item.get("id")).cloned()
+        } else {
+            None
+        };
+        return Ok(OperationOutput::result(
+            command,
+            json!({"items":items,"nextCursor":next}),
+        ));
+    }
+    let (id, timeout, vote) = match args {
+        ActivityCommand::Get { id } => (id, None, None),
+        ActivityCommand::Wait { id, timeout } => (id, Some(timeout), None),
+        ActivityCommand::Approve { id } => (id, None, Some(true)),
+        ActivityCommand::Reject { id } => (id, None, Some(false)),
+        ActivityCommand::List { .. } => {
+            return Err(OperationOutput::error(
+                command,
+                "invalid_input",
+                "invalid activity operation",
+            ));
+        }
+    };
+    if let Some(seconds) = timeout {
+        let mut last = None;
+        let result = tokio::time::timeout(Duration::from_secs(seconds), async {
+            loop {
+                let value = query_activity(command, http, base, org, &id, stamper).await?;
+                let output = OperationOutput::result(command, value);
+                if output.status != "pending" {
+                    return Ok::<_, OperationOutput>(terminal_submission(output));
+                }
+                last = output.activity;
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await;
+        return match result {
+            Ok(Ok(output)) => Ok(output),
+            Ok(Err(mut output)) => {
+                output.activity =
+                    Some(last.unwrap_or_else(|| Box::new(json!({"id": id, "status": null}))));
+                Err(output)
+            }
+            Err(_) => {
+                let mut output = OperationOutput::error(
+                    command,
+                    "wait_timeout",
+                    "wait timed out; resume with activity wait and the same ID",
+                );
+                output.status = "pending";
+                output.activity =
+                    Some(last.unwrap_or_else(|| Box::new(json!({"id":id,"status":null}))));
+                Ok(output)
+            }
+        };
+    }
+    let value = query_activity(command, http, base, org, &id, stamper).await?;
+    let Some(approve) = vote else {
+        return Ok(OperationOutput::result(command, value));
+    };
+    let target = Box::new(json!({"id": id, "status": value.pointer("/activity/status")}));
+    let submitted = async {
+        let fingerprint = value
+            .pointer("/activity/fingerprint")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                OperationOutput::error(command, "api_error", "activity omitted fingerprint")
+            })?
+            .to_owned();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| {
+                OperationOutput::error(command, "command_error", "system clock precedes Unix epoch")
+            })?
+            .as_millis()
+            .to_string();
+        let (path, body) = if approve {
+            (
+                "/public/v1/submit/approve_activity",
+                encode(
+                    command,
+                    &ApproveActivityRequest {
+                        r#type: "ACTIVITY_TYPE_APPROVE_ACTIVITY".into(),
+                        timestamp_ms: timestamp,
+                        organization_id: org.into(),
+                        parameters: Some(ApproveActivityIntent { fingerprint }),
+                        generate_app_proofs: None,
+                    },
+                )?,
+            )
+        } else {
+            (
+                "/public/v1/submit/reject_activity",
+                encode(
+                    command,
+                    &RejectActivityRequest {
+                        r#type: "ACTIVITY_TYPE_REJECT_ACTIVITY".into(),
+                        timestamp_ms: timestamp,
+                        organization_id: org.into(),
+                        parameters: Some(RejectActivityIntent { fingerprint }),
+                        generate_app_proofs: None,
+                    },
+                )?,
+            )
+        };
+        let endpoint = url(base, path)
+            .map_err(|message| OperationOutput::error(command, "invalid_input", message))?;
+        let response = post(command, http, endpoint, body, stamper, true).await?;
+        if response
+            .pointer("/activity/id")
+            .and_then(Value::as_str)
+            .is_none_or(str::is_empty)
+        {
+            return Err(OperationOutput::error(
+                command,
+                "submission_unknown",
+                "response omitted activity; inspect activity before resubmitting",
+            ));
+        }
+        let output = OperationOutput::result(command, response);
+        // A rejected target is the successful outcome of an explicit rejection.
+        Ok::<_, OperationOutput>(if !approve && output.status == "rejected" {
+            output
+        } else {
+            terminal_submission(output)
+        })
+    }
+    .await;
+    match submitted {
+        Ok(mut output) => {
+            if output.failed() {
+                output.activity = Some(target);
+            }
+            Ok(output)
+        }
+        Err(mut output) => {
+            // This is the last observed target state, not proof of the vote's
+            // outcome. Preserve submission_unknown and give callers an ID to inspect.
+            output.activity = Some(target);
+            Err(output)
+        }
+    }
+}
+
+/// Convert a decoded SDK activity without requiring its result to be complete.
+pub fn from_activity(
+    command: &'static str,
+    activity: turnkey_client::generated::external::activity::v1::Activity,
+) -> OperationOutput {
+    match serde_json::to_value(activity) {
+        Ok(value) => submission_result(command, json!({"activity": value})),
+        Err(_) => {
+            OperationOutput::error(command, "command_error", "could not encode activity output")
+        }
+    }
+}
+
+/// Submit one typed activity envelope without implicit retries or result unwrapping.
+pub async fn submit<T: Serialize>(
+    command: &'static str,
+    path: &str,
+    request: &T,
+    api_base_url: &str,
+    stamper: &TurnkeyP256ApiKey,
+) -> OperationOutput {
+    let body = match encode(command, request) {
+        Ok(body) => body,
+        Err(error) => return error,
+    };
+    let endpoint = match url(api_base_url, path) {
+        Ok(endpoint) => endpoint,
+        Err(message) => return OperationOutput::error(command, "invalid_input", message),
+    };
+    let http = match client() {
+        Ok(http) => http,
+        Err(_) => {
+            return OperationOutput::error(
+                command,
+                "command_error",
+                "could not initialize HTTP client",
+            );
+        }
+    };
+    match post(command, &http, endpoint, body, stamper, true).await {
+        Ok(value) => submission_result(command, value),
+        Err(error) => error,
+    }
+}
+
+/// Query with the same bounded transport and without activity completion checks.
+pub async fn query<T: Serialize>(
+    command: &'static str,
+    path: &str,
+    request: &T,
+    api_base_url: &str,
+    stamper: &TurnkeyP256ApiKey,
+) -> OperationOutput {
+    let body = match encode(command, request) {
+        Ok(body) => body,
+        Err(error) => return error,
+    };
+    let endpoint = match url(api_base_url, path) {
+        Ok(endpoint) => endpoint,
+        Err(message) => return OperationOutput::error(command, "invalid_input", message),
+    };
+    let http = match client() {
+        Ok(http) => http,
+        Err(_) => {
+            return OperationOutput::error(
+                command,
+                "command_error",
+                "could not initialize HTTP client",
+            );
+        }
+    };
+    match post(command, &http, endpoint, body, stamper, false).await {
+        Ok(value) => OperationOutput::result(command, value),
+        Err(error) => error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_string, header_exists, method, path},
+    };
+    #[derive(Parser)]
+    struct RequestCli {
+        #[command(flatten)]
+        request: RequestArgs,
+    }
+    #[derive(Parser)]
+    struct ActivityCli {
+        #[command(subcommand)]
+        activity: ActivityCommand,
+    }
+    fn activity(id: &str, status: &str) -> Value {
+        json!({"activity":{"id":id,"status":status,"fingerprint":"sha256:example"}})
+    }
+    #[test]
+    fn decoded_sdk_activities_require_identity_for_completed_and_pending_results() {
+        for status in [
+            "ACTIVITY_STATUS_COMPLETED",
+            "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+        ] {
+            let decoded = serde_json::from_value(json!({
+                "id": "", "organizationId": "org", "status": status,
+                "type": "ACTIVITY_TYPE_APPROVE_ACTIVITY", "fingerprint": "sha256:example"
+            }))
+            .unwrap();
+            let output = from_activity("test", decoded);
+            assert_eq!(output.code, Some("submission_unknown"));
+            assert_eq!(output.status, "unknown");
+            assert!(output.failed());
+        }
+    }
+    #[test]
+    fn result_serialization_preserves_the_machine_contract() {
+        let data = json!({"activity":{"id":"a","status":"ACTIVITY_STATUS_COMPLETED"}});
+        let output = OperationOutput::result("test", data);
+        assert_eq!(
+            serde_json::to_value(output).unwrap(),
+            json!({
+                "schemaVersion":1,"reason":"command_result","command":"test","status":"completed",
+                "data":{"activity":{"id":"a","status":"ACTIVITY_STATUS_COMPLETED"}},
+                "activity":{"id":"a","status":"ACTIVITY_STATUS_COMPLETED"}
+            })
+        );
+    }
+    #[test]
+    fn submission_requires_recoverable_activity_identity() {
+        let output = submission_result(
+            "test",
+            json!({"activity":{"status":"ACTIVITY_STATUS_COMPLETED"}}),
+        );
+        assert_eq!(output.code, Some("submission_unknown"));
+        assert_eq!(output.status, "unknown");
+    }
+    #[test]
+    fn parser_enforces_body_source_and_safe_path() {
+        assert!(RequestCli::try_parse_from(["tk", "--path", "/public/v1/query/whoami"]).is_err());
+        assert!(
+            RequestCli::try_parse_from([
+                "tk",
+                "--path",
+                "/public/v1/query/whoami",
+                "--body",
+                "{}",
+                "--body-file",
+                "-"
+            ])
+            .is_err()
+        );
+        assert!(
+            RequestCli::try_parse_from(["tk", "--path", "https://other.test", "--body", "{}"])
+                .is_err()
+        );
+        assert!(ActivityCli::try_parse_from(["tk", "wait", "a", "--timeout", "0"]).is_err());
+    }
+    #[tokio::test]
+    async fn raw_request_preserves_signed_bytes() {
+        let server = MockServer::start().await;
+        let body = "{\n  \"organizationId\": \"org\"\n}\n";
+        let key = TurnkeyP256ApiKey::generate();
+        let stamp = key.stamp(body.as_bytes()).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/whoami"))
+            .and(body_string(body))
+            .and(wiremock::matchers::header(
+                stamp.name.as_str(),
+                stamp.value.as_str(),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"userId":"user"})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = run_request(
+            RequestArgs {
+                path: "/public/v1/query/whoami".into(),
+                body: Some(body.into()),
+                body_file: None,
+                stamp_only: false,
+            },
+            "org",
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert!(!output.failed());
+        assert_eq!(output.data.as_deref(), Some(&json!({"userId":"user"})));
+        server.verify().await;
+    }
+    #[tokio::test]
+    async fn stamp_only_and_mismatch_make_no_requests() {
+        let server = MockServer::start().await;
+        let key = TurnkeyP256ApiKey::generate();
+        let args = |org: &str| RequestArgs {
+            path: "/public/v1/query/whoami".into(),
+            body: Some(json!({"organizationId":org}).to_string()),
+            body_file: None,
+            stamp_only: true,
+        };
+        assert!(
+            !run_request(args("org"), "org", &server.uri(), &key)
+                .await
+                .failed()
+        );
+        assert_eq!(
+            run_request(args("other"), "org", &server.uri(), &key)
+                .await
+                .code,
+            Some("invalid_input")
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+    #[tokio::test]
+    async fn redirect_is_not_followed() {
+        let server = MockServer::start().await;
+        Mock::given(path("/public/v1/submit/test"))
+            .respond_with(ResponseTemplate::new(307).insert_header("Location", "/leaked"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let key = TurnkeyP256ApiKey::generate();
+        let output = submit(
+            "test",
+            "/public/v1/submit/test",
+            &json!({}),
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert_eq!(output.http_status, Some(307));
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+    #[tokio::test]
+    async fn pending_submission_retains_activity_without_retry() {
+        let server = MockServer::start().await;
+        Mock::given(path("/public/v1/submit/test"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(activity("a", "ACTIVITY_STATUS_CONSENSUS_NEEDED")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = submit(
+            "test",
+            "/public/v1/submit/test",
+            &json!({}),
+            &server.uri(),
+            &TurnkeyP256ApiKey::generate(),
+        )
+        .await;
+        assert_eq!(output.status, "pending");
+        assert_eq!(
+            output.activity.as_deref(),
+            Some(&json!({"id":"a","status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}))
+        );
+        assert!(!output.failed());
+        server.verify().await;
+    }
+    #[tokio::test]
+    async fn wait_timeout_retains_identity_and_get_rejection_is_success() {
+        let server = MockServer::start().await;
+        let key = TurnkeyP256ApiKey::generate();
+        Mock::given(path("/public/v1/query/get_activity"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(activity("a", "ACTIVITY_STATUS_CONSENSUS_NEEDED")),
+            )
+            .mount(&server)
+            .await;
+        let output = run_activity(
+            ActivityCommand::Wait {
+                id: "a".into(),
+                timeout: 1,
+            },
+            "org",
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert_eq!(output.code, Some("wait_timeout"));
+        assert_eq!(output.activity.unwrap()["id"], "a");
+        server.reset().await;
+        Mock::given(path("/public/v1/query/get_activity"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(activity("a", "ACTIVITY_STATUS_REJECTED")),
+            )
+            .mount(&server)
+            .await;
+        let output = run_activity(
+            ActivityCommand::Get { id: "a".into() },
+            "org",
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert!(!output.failed());
+        assert_eq!(output.status, "rejected");
+        let waited = run_activity(
+            ActivityCommand::Wait {
+                id: "a".into(),
+                timeout: 1,
+            },
+            "org",
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert!(waited.failed());
+    }
+    #[tokio::test]
+    async fn reject_success_and_malformed_submission_are_distinct() {
+        let server = MockServer::start().await;
+        let key = TurnkeyP256ApiKey::generate();
+        Mock::given(path("/public/v1/query/get_activity"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(activity("a", "ACTIVITY_STATUS_CONSENSUS_NEEDED")),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(path("/public/v1/submit/reject_activity"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(activity("a", "ACTIVITY_STATUS_REJECTED")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = run_activity(
+            ActivityCommand::Reject { id: "a".into() },
+            "org",
+            &server.uri(),
+            &key,
+        )
+        .await;
+        assert!(!output.failed());
+        assert_eq!(output.status, "rejected");
+        Mock::given(path("/public/v1/submit/test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        assert_eq!(
+            submit(
+                "test",
+                "/public/v1/submit/test",
+                &json!({}),
+                &server.uri(),
+                &key
+            )
+            .await
+            .code,
+            Some("submission_unknown")
+        );
+        server.verify().await;
+    }
+    #[tokio::test]
+    async fn list_preserves_api_cursor_and_does_not_fetch_extra_pages() {
+        let server = MockServer::start().await;
+        Mock::given(path("/public/v1/query/list_activities"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"activities":[{"id":"b"}]})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = run_activity(
+            ActivityCommand::List {
+                limit: 1,
+                cursor: Some("a".into()),
+            },
+            "org",
+            &server.uri(),
+            &TurnkeyP256ApiKey::generate(),
+        )
+        .await;
+        assert_eq!(
+            output.data.as_deref(),
+            Some(&json!({"items":[{"id":"b"}],"nextCursor":"b"}))
+        );
+        let requests = server.received_requests().await.unwrap();
+        let request: GetActivitiesRequest = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(
+            request.pagination_options,
+            Some(Pagination {
+                limit: "1".into(),
+                before: String::new(),
+                after: "a".into()
+            })
+        );
+        server.verify().await;
+    }
+    #[tokio::test]
+    async fn mutation_timeout_is_unknown_and_does_not_leak_body() {
+        let server = MockServer::start().await;
+        Mock::given(path("/public/v1/submit/test"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(100))
+                    .set_body_json(json!({})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let http = Client::builder()
+            .timeout(Duration::from_millis(10))
+            .build()
+            .unwrap();
+        let output = post(
+            "test",
+            &http,
+            url(&server.uri(), "/public/v1/submit/test").unwrap(),
+            "secret-marker".into(),
+            &TurnkeyP256ApiKey::generate(),
+            true,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(output.code, Some("submission_unknown"));
+        assert!(
+            !serde_json::to_string(&output)
+                .unwrap()
+                .contains("secret-marker")
+        );
+        server.verify().await;
+    }
+    #[tokio::test]
+    async fn vote_submission_failures_retain_last_observed_target() {
+        for approve in [true, false] {
+            for timeout in [true, false] {
+                let server = MockServer::start().await;
+                let key = TurnkeyP256ApiKey::generate();
+                Mock::given(path("/public/v1/query/get_activity"))
+                    .respond_with(
+                        ResponseTemplate::new(200)
+                            .set_body_json(activity("target", "ACTIVITY_STATUS_CONSENSUS_NEEDED")),
+                    )
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                let vote_path = if approve {
+                    "/public/v1/submit/approve_activity"
+                } else {
+                    "/public/v1/submit/reject_activity"
+                };
+                let response = ResponseTemplate::new(200).set_body_json(json!({}));
+                Mock::given(path(vote_path))
+                    .respond_with(if timeout {
+                        response.set_delay(Duration::from_millis(500))
+                    } else {
+                        response
+                    })
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                let http = Client::builder()
+                    .timeout(Duration::from_millis(100))
+                    .build()
+                    .unwrap();
+                let args = if approve {
+                    ActivityCommand::Approve {
+                        id: "target".into(),
+                    }
+                } else {
+                    ActivityCommand::Reject {
+                        id: "target".into(),
+                    }
+                };
+                let command = if approve {
+                    "activity.approve"
+                } else {
+                    "activity.reject"
+                };
+                let output = activity_inner(command, args, "org", &server.uri(), &key, &http)
+                    .await
+                    .unwrap_err();
+                assert_eq!(output.code, Some("submission_unknown"));
+                assert_eq!(output.status, "unknown");
+                assert_eq!(
+                    output.activity.as_deref(),
+                    Some(&json!({"id":"target", "status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}))
+                );
+                server.verify().await;
+            }
+        }
+    }
+    #[tokio::test]
+    async fn approve_fetches_fingerprint_then_submits_once() {
+        let server = MockServer::start().await;
+        Mock::given(path("/public/v1/query/get_activity"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(activity("a", "ACTIVITY_STATUS_CONSENSUS_NEEDED")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(path("/public/v1/submit/approve_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(activity("vote", "ACTIVITY_STATUS_COMPLETED")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = run_activity(
+            ActivityCommand::Approve { id: "a".into() },
+            "org",
+            &server.uri(),
+            &TurnkeyP256ApiKey::generate(),
+        )
+        .await;
+        assert!(!output.failed());
+        let requests = server.received_requests().await.unwrap();
+        let body: ApproveActivityRequest = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(body.parameters.unwrap().fingerprint, "sha256:example");
+        assert_eq!(body.organization_id, "org");
+        server.verify().await;
+    }
+}

--- a/tvc/src/shared_resources.rs
+++ b/tvc/src/shared_resources.rs
@@ -1,0 +1,952 @@
+//! Shared user, credential, and policy operations with typed request preparation.
+
+use std::{
+    io::{self, Read},
+    path::PathBuf,
+};
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::{
+    external::activity::v1 as activity, immutable::activity::v1 as intent,
+    services::coordinator::public::v1 as query,
+};
+use uuid::Uuid;
+
+use crate::{
+    errors::MissingResource,
+    shared_auth::ResolvedAuth,
+    shared_operations::{OperationOutput, submit},
+};
+
+/// User and user-tag commands.
+#[derive(Debug, Args)]
+pub struct UserArgs {
+    #[command(subcommand)]
+    command: UserCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum UserCommand {
+    List,
+    Get {
+        id: Uuid,
+    },
+    /// Create one or more users from a CreateUsersIntentV4 parameters object.
+    Create(BodyArgs),
+    /// Update user name, email, phone, or tag membership.
+    Update(BodyArgs),
+    Delete {
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<Uuid>,
+    },
+    Tag {
+        #[command(subcommand)]
+        command: TagCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum TagCommand {
+    List,
+    Create(BodyArgs),
+    Update(BodyArgs),
+    Delete {
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<Uuid>,
+    },
+}
+
+/// Policy management and server evaluation diagnostics.
+#[derive(Debug, Args)]
+pub struct PolicyArgs {
+    #[command(subcommand)]
+    command: PolicyCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum PolicyCommand {
+    List,
+    Get {
+        id: Uuid,
+    },
+    /// Create a policy from a CreatePolicyIntentV3 parameters object.
+    Create(BodyArgs),
+    /// Create multiple policies from a parameters object containing policies.
+    CreateBatch(BodyArgs),
+    /// Update with policyEffect/policyCondition/policyConsensus field names.
+    Update(BodyArgs),
+    Delete {
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<Uuid>,
+    },
+    Evaluations {
+        activity_id: Uuid,
+    },
+}
+
+/// Remote public API-key registration and revocation.
+#[derive(Debug, Args)]
+pub struct ApiKeyArgs {
+    #[command(subcommand)]
+    command: ApiKeyCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ApiKeyCommand {
+    List {
+        #[arg(long)]
+        user_id: Option<Uuid>,
+    },
+    /// Register public keys using CreateApiKeysIntentV2 parameters.
+    Register(BodyArgs),
+    Delete {
+        #[arg(long)]
+        user_id: Uuid,
+        #[arg(required = true, num_args = 1..)]
+        ids: Vec<Uuid>,
+    },
+}
+
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct BodyArgs {
+    /// Inline JSON parameters (no activity envelope).
+    #[arg(long)]
+    input_json: Option<String>,
+    /// Read JSON parameters from a file, or - for stdin.
+    #[arg(long)]
+    input_file: Option<PathBuf>,
+}
+
+/// A command whose local input has been parsed before loading credentials.
+pub struct PreparedResource {
+    operation: Operation,
+}
+
+enum Operation {
+    Users,
+    User(Uuid),
+    CreateUsers(intent::CreateUsersIntentV4),
+    UpdateUser(intent::UpdateUserIntent),
+    DeleteUsers(intent::DeleteUsersIntent),
+    Tags,
+    CreateTag(intent::CreateUserTagIntent),
+    UpdateTag(intent::UpdateUserTagIntent),
+    DeleteTags(intent::DeleteUserTagsIntent),
+    Policies,
+    Policy(Uuid),
+    CreatePolicy(intent::CreatePolicyIntentV3),
+    CreatePolicies(intent::CreatePoliciesIntent),
+    UpdatePolicy(intent::UpdatePolicyIntentV2),
+    DeletePolicy(intent::DeletePolicyIntent),
+    DeletePolicies(intent::DeletePoliciesIntent),
+    Evaluations(Uuid),
+    ApiKeys(Option<Uuid>),
+    RegisterKeys(intent::CreateApiKeysIntentV2),
+    DeleteKeys(intent::DeleteApiKeysIntent),
+}
+
+impl BodyArgs {
+    fn parse<T: DeserializeOwned + Serialize>(self) -> Result<T> {
+        let bytes = match (self.input_json, self.input_file) {
+            (Some(json), None) => json.into_bytes(),
+            (None, Some(path)) if path.as_os_str() == "-" => {
+                let mut bytes = Vec::new();
+                io::stdin()
+                    .read_to_end(&mut bytes)
+                    .context("read JSON parameters from stdin")?;
+                bytes
+            }
+            (None, Some(path)) => std::fs::read(&path)
+                .with_context(|| format!("read JSON parameters from {}", path.display()))?,
+            _ => bail!("provide exactly one of --input-json or --input-file"),
+        };
+        parse_parameters(&bytes)
+    }
+}
+
+fn parse_parameters<T: DeserializeOwned + Serialize>(bytes: &[u8]) -> Result<T> {
+    let mut value: Value = serde_json::from_slice(bytes).context("parse JSON parameters")?;
+    if !value.is_object() {
+        bail!("parameters must be a JSON object");
+    }
+    normalize_ids(&mut value)?;
+    let typed: T = serde_json::from_value(value.clone()).context("invalid operation parameters")?;
+    let normalized = serde_json::to_value(&typed)?;
+    reject_dropped_fields(&value, &normalized, "parameters")?;
+    Ok(typed)
+}
+
+// Known UUID fields in this resource surface are parsed and canonicalized once.
+fn normalize_ids(value: &mut Value) -> Result<()> {
+    match value {
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if matches!(key.as_str(), "userId" | "userTagId" | "policyId") {
+                    let id =
+                        Uuid::parse_str(value.as_str().context("resource ID must be a string")?)
+                            .with_context(|| format!("invalid UUID in {key}"))?;
+                    *value = Value::String(id.to_string());
+                } else if matches!(
+                    key.as_str(),
+                    "userIds"
+                        | "userTags"
+                        | "userTagIds"
+                        | "addUserIds"
+                        | "removeUserIds"
+                        | "apiKeyIds"
+                        | "policyIds"
+                ) {
+                    let ids = value
+                        .as_array_mut()
+                        .context("resource IDs must be an array")?;
+                    for value in ids {
+                        let id = Uuid::parse_str(
+                            value.as_str().context("resource ID must be a string")?,
+                        )
+                        .with_context(|| format!("invalid UUID in {key}"))?;
+                        *value = Value::String(id.to_string());
+                    }
+                } else {
+                    normalize_ids(value)?;
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                normalize_ids(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+// Generated structs accept unknown fields. Reject them before they can silently
+// disappear from a submitted policy or credential request.
+fn reject_dropped_fields(input: &Value, normalized: &Value, path: &str) -> Result<()> {
+    match (input, normalized) {
+        (Value::Object(input), Value::Object(normalized)) => {
+            for (key, value) in input {
+                let Some(known) = normalized.get(key) else {
+                    bail!("unsupported field {path}.{key}");
+                };
+                reject_dropped_fields(value, known, &format!("{path}.{key}"))?;
+            }
+        }
+        (Value::Array(input), Value::Array(normalized)) => {
+            for (i, (value, known)) in input.iter().zip(normalized).enumerate() {
+                reject_dropped_fields(value, known, &format!("{path}[{i}]"))?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+impl UserArgs {
+    pub fn prepare(self) -> Result<PreparedResource> {
+        let operation = match self.command {
+            UserCommand::List => Operation::Users,
+            UserCommand::Get { id } => Operation::User(id),
+            UserCommand::Create(body) => {
+                let params: intent::CreateUsersIntentV4 = body.parse()?;
+                if params.users.is_empty() {
+                    bail!("users must contain at least one user");
+                }
+                Operation::CreateUsers(params)
+            }
+            UserCommand::Update(body) => Operation::UpdateUser(body.parse()?),
+            UserCommand::Delete { ids } => Operation::DeleteUsers(intent::DeleteUsersIntent {
+                user_ids: ids.into_iter().map(|id| id.to_string()).collect(),
+            }),
+            UserCommand::Tag { command } => match command {
+                TagCommand::List => Operation::Tags,
+                TagCommand::Create(body) => Operation::CreateTag(body.parse()?),
+                TagCommand::Update(body) => Operation::UpdateTag(body.parse()?),
+                TagCommand::Delete { ids } => Operation::DeleteTags(intent::DeleteUserTagsIntent {
+                    user_tag_ids: ids.into_iter().map(|id| id.to_string()).collect(),
+                }),
+            },
+        };
+        Ok(PreparedResource { operation })
+    }
+}
+
+impl PolicyArgs {
+    pub fn prepare(self) -> Result<PreparedResource> {
+        let operation = match self.command {
+            PolicyCommand::List => Operation::Policies,
+            PolicyCommand::Get { id } => Operation::Policy(id),
+            PolicyCommand::Create(body) => Operation::CreatePolicy(body.parse()?),
+            PolicyCommand::CreateBatch(body) => {
+                let params: intent::CreatePoliciesIntent = body.parse()?;
+                if params.policies.is_empty() {
+                    bail!("policies must contain at least one policy");
+                }
+                Operation::CreatePolicies(params)
+            }
+            PolicyCommand::Update(body) => Operation::UpdatePolicy(body.parse()?),
+            PolicyCommand::Delete { ids } => {
+                let mut ids = ids.into_iter().map(|id| id.to_string());
+                let first = ids.next().context("at least one policy ID is required")?;
+                let remaining: Vec<_> = ids.collect();
+                if remaining.is_empty() {
+                    Operation::DeletePolicy(intent::DeletePolicyIntent { policy_id: first })
+                } else {
+                    Operation::DeletePolicies(intent::DeletePoliciesIntent {
+                        policy_ids: std::iter::once(first).chain(remaining).collect(),
+                    })
+                }
+            }
+            PolicyCommand::Evaluations { activity_id } => Operation::Evaluations(activity_id),
+        };
+        Ok(PreparedResource { operation })
+    }
+}
+
+impl From<ApiKeyCommand> for ApiKeyArgs {
+    fn from(command: ApiKeyCommand) -> Self {
+        Self { command }
+    }
+}
+
+impl ApiKeyArgs {
+    pub fn prepare(self) -> Result<PreparedResource> {
+        let operation = match self.command {
+            ApiKeyCommand::List { user_id } => Operation::ApiKeys(user_id),
+            ApiKeyCommand::Register(body) => {
+                let params: intent::CreateApiKeysIntentV2 = body.parse()?;
+                if params.api_keys.is_empty() {
+                    bail!("apiKeys must contain at least one public key");
+                }
+                Operation::RegisterKeys(params)
+            }
+            ApiKeyCommand::Delete { user_id, ids } => {
+                Operation::DeleteKeys(intent::DeleteApiKeysIntent {
+                    user_id: user_id.to_string(),
+                    api_key_ids: ids.into_iter().map(|id| id.to_string()).collect(),
+                })
+            }
+        };
+        Ok(PreparedResource { operation })
+    }
+}
+
+impl PreparedResource {
+    pub fn command(&self) -> &'static str {
+        match &self.operation {
+            Operation::Users => "user.list",
+            Operation::User(_) => "user.get",
+            Operation::CreateUsers(_) => "user.create",
+            Operation::UpdateUser(_) => "user.update",
+            Operation::DeleteUsers(_) => "user.delete",
+            Operation::Tags => "user.tag.list",
+            Operation::CreateTag(_) => "user.tag.create",
+            Operation::UpdateTag(_) => "user.tag.update",
+            Operation::DeleteTags(_) => "user.tag.delete",
+            Operation::Policies => "policy.list",
+            Operation::Policy(_) => "policy.get",
+            Operation::CreatePolicy(_) => "policy.create",
+            Operation::CreatePolicies(_) => "policy.create-batch",
+            Operation::UpdatePolicy(_) => "policy.update",
+            Operation::DeletePolicy(_) | Operation::DeletePolicies(_) => "policy.delete",
+            Operation::Evaluations(_) => "policy.evaluations",
+            Operation::ApiKeys(_) => "api-key.list",
+            Operation::RegisterKeys(_) => "api-key.register",
+            Operation::DeleteKeys(_) => "api-key.delete",
+        }
+    }
+
+    pub async fn run(self, auth: ResolvedAuth) -> Result<OperationOutput> {
+        self.run_with_credentials(auth.org_id, auth.api_base_url, auth.stamper)
+            .await
+    }
+
+    async fn run_with_credentials(
+        self,
+        organization_id: String,
+        api_base_url: String,
+        stamper: TurnkeyP256ApiKey,
+    ) -> Result<OperationOutput> {
+        let command = self.command();
+        macro_rules! submit_operation {
+            ($params:expr, $request:ident, $kind:literal, $endpoint:literal) => {{
+                let request = activity::$request {
+                    r#type: $kind.to_owned(),
+                    timestamp_ms: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)?
+                        .as_millis()
+                        .to_string(),
+                    organization_id,
+                    parameters: Some($params),
+                    generate_app_proofs: None,
+                };
+                submit(
+                    command,
+                    concat!("/public/v1/submit/", $endpoint),
+                    &request,
+                    &api_base_url,
+                    &stamper,
+                )
+                .await
+            }};
+        }
+        // Query clients are created only on read paths. Mutation transport always
+        // disables redirects and preserves uncertain submission outcomes.
+        macro_rules! client {
+            () => {
+                crate::client::build_turnkey_client(stamper, &api_base_url)?
+            };
+        }
+        let response = match self.operation {
+            Operation::Users => OperationOutput::result(
+                command,
+                serde_json::to_value(
+                    client!()
+                        .get_users(query::GetUsersRequest { organization_id })
+                        .await?,
+                )?,
+            ),
+            Operation::User(id) => {
+                let response = client!()
+                    .get_user(query::GetUserRequest {
+                        organization_id,
+                        user_id: id.to_string(),
+                    })
+                    .await?;
+                if response.user.is_none() {
+                    return Err(MissingResource::new("user", id.to_string()).into());
+                }
+                OperationOutput::result(command, serde_json::to_value(response)?)
+            }
+            Operation::CreateUsers(params) => submit_operation!(
+                params,
+                CreateUsersRequest,
+                "ACTIVITY_TYPE_CREATE_USERS_V4",
+                "create_users"
+            ),
+            Operation::UpdateUser(params) => submit_operation!(
+                params,
+                UpdateUserRequest,
+                "ACTIVITY_TYPE_UPDATE_USER",
+                "update_user"
+            ),
+            Operation::DeleteUsers(params) => submit_operation!(
+                params,
+                DeleteUsersRequest,
+                "ACTIVITY_TYPE_DELETE_USERS",
+                "delete_users"
+            ),
+            Operation::Tags => OperationOutput::result(
+                command,
+                serde_json::to_value(
+                    client!()
+                        .list_user_tags(query::ListUserTagsRequest { organization_id })
+                        .await?,
+                )?,
+            ),
+            Operation::CreateTag(params) => submit_operation!(
+                params,
+                CreateUserTagRequest,
+                "ACTIVITY_TYPE_CREATE_USER_TAG",
+                "create_user_tag"
+            ),
+            Operation::UpdateTag(params) => submit_operation!(
+                params,
+                UpdateUserTagRequest,
+                "ACTIVITY_TYPE_UPDATE_USER_TAG",
+                "update_user_tag"
+            ),
+            Operation::DeleteTags(params) => submit_operation!(
+                params,
+                DeleteUserTagsRequest,
+                "ACTIVITY_TYPE_DELETE_USER_TAGS",
+                "delete_user_tags"
+            ),
+            Operation::Policies => OperationOutput::result(
+                command,
+                serde_json::to_value(
+                    client!()
+                        .get_policies(query::GetPoliciesRequest { organization_id })
+                        .await?,
+                )?,
+            ),
+            Operation::Policy(id) => {
+                let response = client!()
+                    .get_policy(query::GetPolicyRequest {
+                        organization_id,
+                        policy_id: id.to_string(),
+                    })
+                    .await?;
+                if response.policy.is_none() {
+                    return Err(MissingResource::new("policy", id.to_string()).into());
+                }
+                OperationOutput::result(command, serde_json::to_value(response)?)
+            }
+            Operation::CreatePolicy(params) => submit_operation!(
+                params,
+                CreatePolicyRequest,
+                "ACTIVITY_TYPE_CREATE_POLICY_V3",
+                "create_policy"
+            ),
+            Operation::CreatePolicies(params) => submit_operation!(
+                params,
+                CreatePoliciesRequest,
+                "ACTIVITY_TYPE_CREATE_POLICIES",
+                "create_policies"
+            ),
+            Operation::UpdatePolicy(params) => submit_operation!(
+                params,
+                UpdatePolicyRequest,
+                "ACTIVITY_TYPE_UPDATE_POLICY_V2",
+                "update_policy"
+            ),
+            Operation::DeletePolicy(params) => submit_operation!(
+                params,
+                DeletePolicyRequest,
+                "ACTIVITY_TYPE_DELETE_POLICY",
+                "delete_policy"
+            ),
+            Operation::DeletePolicies(params) => submit_operation!(
+                params,
+                DeletePoliciesRequest,
+                "ACTIVITY_TYPE_DELETE_POLICIES",
+                "delete_policies"
+            ),
+            Operation::Evaluations(id) => OperationOutput::result(
+                command,
+                serde_json::to_value(
+                    client!()
+                        .get_policy_evaluations(query::GetPolicyEvaluationsRequest {
+                            organization_id,
+                            activity_id: id.to_string(),
+                        })
+                        .await?,
+                )?,
+            ),
+            Operation::ApiKeys(user_id) => OperationOutput::result(
+                command,
+                serde_json::to_value(
+                    client!()
+                        .get_api_keys(query::GetApiKeysRequest {
+                            organization_id,
+                            user_id: user_id.map(|id| id.to_string()),
+                        })
+                        .await?,
+                )?,
+            ),
+            Operation::RegisterKeys(params) => submit_operation!(
+                params,
+                CreateApiKeysRequest,
+                "ACTIVITY_TYPE_CREATE_API_KEYS_V2",
+                "create_api_keys"
+            ),
+            Operation::DeleteKeys(params) => submit_operation!(
+                params,
+                DeleteApiKeysRequest,
+                "ACTIVITY_TYPE_DELETE_API_KEYS",
+                "delete_api_keys"
+            ),
+        };
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    const ID: &str = "11111111-1111-4111-8111-111111111111";
+    const OTHER: &str = "22222222-2222-4222-8222-222222222222";
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: TestCommand,
+    }
+
+    #[derive(Subcommand)]
+    enum TestCommand {
+        User(UserArgs),
+        Policy(PolicyArgs),
+        ApiKey(ApiKeyArgs),
+    }
+
+    fn prepare(args: &[&str]) -> Result<PreparedResource> {
+        let cli = TestCli::try_parse_from(std::iter::once("tk").chain(args.iter().copied()))?;
+        match cli.command {
+            TestCommand::User(args) => args.prepare(),
+            TestCommand::Policy(args) => args.prepare(),
+            TestCommand::ApiKey(args) => args.prepare(),
+        }
+    }
+
+    #[test]
+    fn malformed_and_unsupported_inputs_fail_before_auth() {
+        for args in [
+            vec!["user", "get", "not-a-uuid"],
+            vec!["user", "delete"],
+            vec!["policy", "delete"],
+            vec!["policy", "list", "--cursor", "invented"],
+            vec![
+                "policy",
+                "create",
+                "--input-json",
+                "{}",
+                "--input-file",
+                "-",
+            ],
+            vec!["policy", "create"],
+            vec!["user", "create", "--input-json", r#"{"users":[]}"#],
+            vec![
+                "api-key",
+                "register",
+                "--input-json",
+                r#"{"userId":"bad","apiKeys":[]}"#,
+            ],
+            vec![
+                "policy",
+                "update",
+                "--input-json",
+                r#"{"policyId":"11111111-1111-4111-8111-111111111111","effect":"EFFECT_ALLOW"}"#,
+            ],
+            vec![
+                "user",
+                "create",
+                "--input-json",
+                r#"{"users":[{"userName":"agent","apiKeys":[{"apiKeyName":"key","publicKey":"03ab","curveType":"API_KEY_CURVE_P256","privateKey":"secret"}]}]}"#,
+            ],
+        ] {
+            assert!(
+                prepare(&args).is_err(),
+                "input unexpectedly accepted: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_file_preserves_exact_expressions() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let params = json!({
+            "policyName": "agent policy",
+            "effect": "EFFECT_ALLOW",
+            "condition": "activity.action == 'SIGN' &&\n  wallet.id == 'literal'",
+            "consensus": "approvers.any(user, user.id == 'literal')",
+            "notes": "Reviewed policy",
+            "time": null
+        });
+        std::fs::write(file.path(), serde_json::to_vec(&params).unwrap()).unwrap();
+        let body = file.path().display().to_string();
+        let command = prepare(&["policy", "create", "--input-file", &body]).unwrap();
+        match command.operation {
+            Operation::CreatePolicy(actual) => {
+                assert_eq!(serde_json::to_value(actual).unwrap(), params)
+            }
+            _ => panic!("expected prepared policy creation"),
+        }
+    }
+
+    #[tokio::test]
+    async fn all_mutations_use_versioned_envelopes_and_submit_once() {
+        let user_body = r#"{"users":[{"userName":"agent","userTags":["11111111-1111-4111-8111-111111111111"]}]}"#;
+        let update_user =
+            r#"{"userId":"11111111-1111-4111-8111-111111111111","userName":"renamed"}"#;
+        let tag_body =
+            r#"{"userTagName":"agents","userIds":["11111111-1111-4111-8111-111111111111"]}"#;
+        let update_tag = r#"{"userTagId":"11111111-1111-4111-8111-111111111111","addUserIds":["22222222-2222-4222-8222-222222222222"]}"#;
+        let policy_body = r#"{"policyName":"agent","effect":"EFFECT_ALLOW","condition":"true","consensus":"true","notes":"test"}"#;
+        let policies_body =
+            r#"{"policies":[{"policyName":"agent","effect":"EFFECT_ALLOW","notes":"test"}]}"#;
+        let update_policy = r#"{"policyId":"11111111-1111-4111-8111-111111111111","policyEffect":"EFFECT_DENY","policyCondition":"true"}"#;
+        let keys_body = r#"{"userId":"11111111-1111-4111-8111-111111111111","apiKeys":[{"apiKeyName":"agent","publicKey":"03ab","curveType":"API_KEY_CURVE_P256"}]}"#;
+        let cases = [
+            (
+                vec!["user", "create", "--input-json", user_body],
+                "create_users",
+                "ACTIVITY_TYPE_CREATE_USERS_V4",
+            ),
+            (
+                vec!["user", "update", "--input-json", update_user],
+                "update_user",
+                "ACTIVITY_TYPE_UPDATE_USER",
+            ),
+            (
+                vec!["user", "delete", ID],
+                "delete_users",
+                "ACTIVITY_TYPE_DELETE_USERS",
+            ),
+            (
+                vec!["user", "tag", "create", "--input-json", tag_body],
+                "create_user_tag",
+                "ACTIVITY_TYPE_CREATE_USER_TAG",
+            ),
+            (
+                vec!["user", "tag", "update", "--input-json", update_tag],
+                "update_user_tag",
+                "ACTIVITY_TYPE_UPDATE_USER_TAG",
+            ),
+            (
+                vec!["user", "tag", "delete", ID],
+                "delete_user_tags",
+                "ACTIVITY_TYPE_DELETE_USER_TAGS",
+            ),
+            (
+                vec!["policy", "create", "--input-json", policy_body],
+                "create_policy",
+                "ACTIVITY_TYPE_CREATE_POLICY_V3",
+            ),
+            (
+                vec!["policy", "create-batch", "--input-json", policies_body],
+                "create_policies",
+                "ACTIVITY_TYPE_CREATE_POLICIES",
+            ),
+            (
+                vec!["policy", "update", "--input-json", update_policy],
+                "update_policy",
+                "ACTIVITY_TYPE_UPDATE_POLICY_V2",
+            ),
+            (
+                vec!["policy", "delete", ID],
+                "delete_policy",
+                "ACTIVITY_TYPE_DELETE_POLICY",
+            ),
+            (
+                vec!["policy", "delete", ID, OTHER],
+                "delete_policies",
+                "ACTIVITY_TYPE_DELETE_POLICIES",
+            ),
+            (
+                vec!["api-key", "register", "--input-json", keys_body],
+                "create_api_keys",
+                "ACTIVITY_TYPE_CREATE_API_KEYS_V2",
+            ),
+            (
+                vec!["api-key", "delete", "--user-id", ID, OTHER],
+                "delete_api_keys",
+                "ACTIVITY_TYPE_DELETE_API_KEYS",
+            ),
+        ];
+        for (args, endpoint, kind) in cases {
+            for status in [
+                "ACTIVITY_STATUS_PENDING",
+                "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                "ACTIVITY_STATUS_REJECTED",
+                "ACTIVITY_STATUS_FAILED",
+                "ACTIVITY_STATUS_COMPLETED",
+            ] {
+                let server = MockServer::start().await;
+                let expected: activity::Activity = serde_json::from_value(json!({
+                    "id": OTHER, "organizationId": ID, "type": kind,
+                    "status": status, "fingerprint": "fixture"
+                }))
+                .unwrap();
+                Mock::given(method("POST"))
+                    .and(path(format!("/public/v1/submit/{endpoint}")))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_json(json!({"activity": expected})),
+                    )
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+                let result = prepare(&args)
+                    .unwrap()
+                    .run_with_credentials(
+                        ID.to_owned(),
+                        server.uri(),
+                        TurnkeyP256ApiKey::generate(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    serde_json::to_value(result).unwrap()["data"]["activity"],
+                    serde_json::to_value(expected).unwrap()
+                );
+                let requests = server.received_requests().await.unwrap();
+                assert_eq!(requests.len(), 1);
+                let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+                assert_eq!(body["type"], kind);
+                assert_eq!(body["organizationId"], ID);
+                assert!(
+                    body["timestampMs"]
+                        .as_str()
+                        .unwrap()
+                        .parse::<u128>()
+                        .unwrap()
+                        > 0
+                );
+                assert!(requests[0].headers.contains_key("x-stamp"));
+                if endpoint == "update_policy" {
+                    assert_eq!(
+                        body["parameters"],
+                        json!({
+                            "policyId": ID, "policyName": null, "policyEffect": "EFFECT_DENY",
+                            "policyCondition": "true", "policyConsensus": null, "policyNotes": null, "time": null
+                        })
+                    );
+                }
+                server.verify().await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn queries_use_supported_shapes_and_preserve_results() {
+        let cases = [
+            (
+                vec!["user", "list"],
+                "list_users",
+                json!({"organizationId": ID}),
+                json!({"users": []}),
+            ),
+            (
+                vec!["user", "tag", "list"],
+                "list_user_tags",
+                json!({"organizationId": ID}),
+                json!({"userTags": []}),
+            ),
+            (
+                vec!["policy", "list"],
+                "list_policies",
+                json!({"organizationId": ID}),
+                json!({"policies": []}),
+            ),
+            (
+                vec!["policy", "evaluations", OTHER],
+                "get_policy_evaluations",
+                json!({"organizationId": ID,"activityId": OTHER}),
+                json!({"policyEvaluations": []}),
+            ),
+            (
+                vec!["api-key", "list", "--user-id", OTHER],
+                "get_api_keys",
+                json!({"organizationId": ID,"userId": OTHER}),
+                json!({"apiKeys": []}),
+            ),
+        ];
+        for (args, endpoint, request, response) in cases {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path(format!("/public/v1/query/{endpoint}")))
+                .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let result = prepare(&args)
+                .unwrap()
+                .run_with_credentials(ID.to_owned(), server.uri(), TurnkeyP256ApiKey::generate())
+                .await
+                .unwrap();
+            assert_eq!(serde_json::to_value(result).unwrap()["data"], response);
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(
+                serde_json::from_slice::<Value>(&requests[0].body).unwrap(),
+                request
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_lookup_preserves_typed_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/get_user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user": null})))
+            .mount(&server)
+            .await;
+        let result = prepare(&["user", "get", ID])
+            .unwrap()
+            .run_with_credentials(ID.to_owned(), server.uri(), TurnkeyP256ApiKey::generate())
+            .await;
+        match result {
+            Err(error) => assert!(error.downcast_ref::<MissingResource>().is_some()),
+            Ok(_) => panic!("missing user was accepted"),
+        }
+    }
+    #[tokio::test]
+    async fn mutation_transport_refuses_redirects_and_preserves_uncertain_outcomes() {
+        for (template, expected_code) in [
+            (
+                ResponseTemplate::new(307).insert_header("Location", "/redirect-target"),
+                "api_error",
+            ),
+            (
+                ResponseTemplate::new(308).insert_header("Location", "/redirect-target"),
+                "api_error",
+            ),
+            (
+                ResponseTemplate::new(200).set_body_string("not JSON"),
+                "submission_unknown",
+            ),
+            (
+                ResponseTemplate::new(200).set_body_json(json!({})),
+                "submission_unknown",
+            ),
+            (
+                ResponseTemplate::new(401).set_body_json(json!({"message":"denied"})),
+                "unauthorized",
+            ),
+            (
+                ResponseTemplate::new(403).set_body_json(json!({"message":"denied"})),
+                "unauthorized",
+            ),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/public/v1/submit/delete_users"))
+                .respond_with(template)
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(path("/redirect-target"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+            let output = prepare(&["user", "delete", ID])
+                .unwrap()
+                .run_with_credentials(ID.to_owned(), server.uri(), TurnkeyP256ApiKey::generate())
+                .await
+                .unwrap();
+            assert!(output.failed());
+            let record = serde_json::to_value(output).unwrap();
+            assert_eq!(record["command"], "user.delete");
+            assert_eq!(record["code"], expected_code);
+            if expected_code == "submission_unknown" {
+                assert_eq!(record["status"], "unknown");
+            }
+            assert_eq!(server.received_requests().await.unwrap().len(), 1);
+            server.verify().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn mutation_timeout_is_unknown_and_never_resubmitted() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/delete_users"))
+            .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(31)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let output = prepare(&["user", "delete", ID])
+            .unwrap()
+            .run_with_credentials(ID.to_owned(), server.uri(), TurnkeyP256ApiKey::generate())
+            .await
+            .unwrap();
+        let record = serde_json::to_value(output).unwrap();
+        assert_eq!(record["code"], "submission_unknown");
+        assert_eq!(record["status"], "unknown");
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+}

--- a/tvc/src/shared_wallets.rs
+++ b/tvc/src/shared_wallets.rs
@@ -1,0 +1,429 @@
+//! Wallet discovery and typed signing inputs for the shared CLI.
+use crate::{
+    shared_auth::ResolvedAuth,
+    shared_operations::{OperationOutput, submit},
+};
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Value, to_value};
+use std::{
+    io::Read,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use turnkey_client::generated::{
+    GetWalletAccountsRequest, GetWalletRequest, GetWalletsRequest,
+    external::activity::v1::{
+        CreateWalletAccountsRequest, CreateWalletRequest, SignRawPayloadRequest,
+        SignTransactionRequest, UpdateWalletRequest,
+    },
+    immutable::activity::v1::{
+        CreateWalletAccountsIntent, CreateWalletIntent, SignRawPayloadIntentV2,
+        SignTransactionIntentV2, UpdateWalletIntent,
+    },
+};
+use uuid::Uuid;
+
+/// Structured parameters are parsed before resolving any credentials.
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub struct JsonInput {
+    #[arg(long)]
+    input_json: Option<String>,
+    /// JSON parameters file, or - for stdin.
+    #[arg(long)]
+    input_file: Option<PathBuf>,
+}
+impl JsonInput {
+    fn parse<T: DeserializeOwned + Serialize>(self) -> Result<T> {
+        let source = match (self.input_json, self.input_file) {
+            (Some(value), None) => value,
+            (None, Some(path)) if path.as_os_str() == "-" => {
+                let mut value = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut value)
+                    .context("read JSON parameters from stdin")?;
+                value
+            }
+            (None, Some(path)) => std::fs::read_to_string(&path)
+                .with_context(|| format!("read JSON parameters from {}", path.display()))?,
+            _ => anyhow::bail!("exactly one JSON input is required"),
+        };
+        let original: Value = serde_json::from_str(&source).context("parse command parameters")?;
+        let parsed: T =
+            serde_json::from_value(original.clone()).context("parse typed command parameters")?;
+        reject_unknown_fields(&original, &to_value(&parsed)?)?;
+        Ok(parsed)
+    }
+}
+
+fn reject_unknown_fields(input: &Value, parsed: &Value) -> Result<()> {
+    match (input, parsed) {
+        (Value::Object(fields), Value::Object(known)) => {
+            for (name, value) in fields {
+                let normalized = known
+                    .get(name)
+                    .with_context(|| format!("unknown parameter {name}"))?;
+                reject_unknown_fields(value, normalized)?;
+            }
+        }
+        (Value::Array(values), Value::Array(known)) => {
+            for (value, normalized) in values.iter().zip(known) {
+                reject_unknown_fields(value, normalized)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WalletCommand {
+    List,
+    Get {
+        id: Uuid,
+    },
+    Create(JsonInput),
+    Update(JsonInput),
+    Account {
+        #[command(subcommand)]
+        command: AccountCommand,
+    },
+}
+#[derive(Debug, Subcommand)]
+pub enum AccountCommand {
+    List {
+        #[arg(long)]
+        wallet_id: Uuid,
+    },
+    Create(JsonInput),
+}
+#[derive(Debug, Subcommand)]
+pub enum SignCommand {
+    /// Sign a payload with explicit encoding and hash function in JSON input.
+    Payload(JsonInput),
+    /// Sign an already serialized transaction; does not broadcast.
+    Transaction(JsonInput),
+}
+
+pub enum PreparedWalletCommand {
+    List,
+    Get(Uuid),
+    Create(CreateWalletIntent),
+    Update(UpdateWalletIntent),
+    Accounts(Uuid),
+    CreateAccounts(CreateWalletAccountsIntent),
+    Payload(SignRawPayloadIntentV2),
+    Transaction(SignTransactionIntentV2),
+}
+impl WalletCommand {
+    pub fn prepare(self) -> Result<PreparedWalletCommand> {
+        Ok(match self {
+            Self::List => PreparedWalletCommand::List,
+            Self::Get { id } => PreparedWalletCommand::Get(id),
+            Self::Create(input) => PreparedWalletCommand::Create(input.parse()?),
+            Self::Update(input) => {
+                let params: UpdateWalletIntent = input.parse()?;
+                Uuid::parse_str(&params.wallet_id).context("walletId must be a UUID")?;
+                PreparedWalletCommand::Update(params)
+            }
+            Self::Account {
+                command: AccountCommand::List { wallet_id },
+            } => PreparedWalletCommand::Accounts(wallet_id),
+            Self::Account {
+                command: AccountCommand::Create(input),
+            } => {
+                let params: CreateWalletAccountsIntent = input.parse()?;
+                Uuid::parse_str(&params.wallet_id).context("walletId must be a UUID")?;
+                PreparedWalletCommand::CreateAccounts(params)
+            }
+        })
+    }
+}
+impl SignCommand {
+    pub fn prepare(self) -> Result<PreparedWalletCommand> {
+        Ok(match self {
+            Self::Payload(input) => PreparedWalletCommand::Payload(input.parse()?),
+            Self::Transaction(input) => PreparedWalletCommand::Transaction(input.parse()?),
+        })
+    }
+}
+impl PreparedWalletCommand {
+    pub async fn run(self, auth: ResolvedAuth) -> Result<OperationOutput> {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .to_string();
+        let organization_id = auth.org_id.clone();
+        let output = match self {
+            Self::List => {
+                let client = crate::client::build_turnkey_client(auth.stamper, &auth.api_base_url)?;
+                let data = client
+                    .get_wallets(GetWalletsRequest { organization_id })
+                    .await?;
+                OperationOutput::result("wallet.list", to_value(data)?)
+            }
+            Self::Get(id) => {
+                let client = crate::client::build_turnkey_client(auth.stamper, &auth.api_base_url)?;
+                let data = client
+                    .get_wallet(GetWalletRequest {
+                        organization_id,
+                        wallet_id: id.to_string(),
+                    })
+                    .await?;
+                data.wallet
+                    .as_ref()
+                    .ok_or_else(|| crate::errors::MissingResource::new("wallet", id.to_string()))?;
+                OperationOutput::result("wallet.get", to_value(data)?)
+            }
+            Self::Accounts(id) => {
+                let client = crate::client::build_turnkey_client(auth.stamper, &auth.api_base_url)?;
+                let data = client
+                    .get_wallet_accounts(GetWalletAccountsRequest {
+                        organization_id,
+                        wallet_id: Some(id.to_string()),
+                        include_wallet_details: None,
+                        pagination_options: None,
+                    })
+                    .await?;
+                OperationOutput::result("wallet.account.list", to_value(data)?)
+            }
+            Self::Create(parameters) => {
+                submit(
+                    "wallet.create",
+                    "/public/v1/submit/create_wallet",
+                    &CreateWalletRequest {
+                        r#type: "ACTIVITY_TYPE_CREATE_WALLET".into(),
+                        timestamp_ms,
+                        organization_id,
+                        parameters: Some(parameters),
+                        generate_app_proofs: None,
+                    },
+                    &auth.api_base_url,
+                    &auth.stamper,
+                )
+                .await
+            }
+            Self::Update(parameters) => {
+                submit(
+                    "wallet.update",
+                    "/public/v1/submit/update_wallet",
+                    &UpdateWalletRequest {
+                        r#type: "ACTIVITY_TYPE_UPDATE_WALLET".into(),
+                        timestamp_ms,
+                        organization_id,
+                        parameters: Some(parameters),
+                        generate_app_proofs: None,
+                    },
+                    &auth.api_base_url,
+                    &auth.stamper,
+                )
+                .await
+            }
+            Self::CreateAccounts(parameters) => {
+                submit(
+                    "wallet.account.create",
+                    "/public/v1/submit/create_wallet_accounts",
+                    &CreateWalletAccountsRequest {
+                        r#type: "ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS".into(),
+                        timestamp_ms,
+                        organization_id,
+                        parameters: Some(parameters),
+                        generate_app_proofs: None,
+                    },
+                    &auth.api_base_url,
+                    &auth.stamper,
+                )
+                .await
+            }
+            Self::Payload(parameters) => {
+                submit(
+                    "sign.payload",
+                    "/public/v1/submit/sign_raw_payload",
+                    &SignRawPayloadRequest {
+                        r#type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".into(),
+                        timestamp_ms,
+                        organization_id,
+                        parameters: Some(parameters),
+                        generate_app_proofs: None,
+                    },
+                    &auth.api_base_url,
+                    &auth.stamper,
+                )
+                .await
+            }
+            Self::Transaction(parameters) => {
+                submit(
+                    "sign.transaction",
+                    "/public/v1/submit/sign_transaction",
+                    &SignTransactionRequest {
+                        r#type: "ACTIVITY_TYPE_SIGN_TRANSACTION_V2".into(),
+                        timestamp_ms,
+                        organization_id,
+                        parameters: Some(parameters),
+                        generate_app_proofs: None,
+                    },
+                    &auth.api_base_url,
+                    &auth.stamper,
+                )
+                .await
+            }
+        };
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    #[derive(Parser)]
+    struct WalletParser {
+        #[command(subcommand)]
+        command: WalletCommand,
+    }
+    #[derive(Parser)]
+    struct SignParser {
+        #[command(subcommand)]
+        command: SignCommand,
+    }
+
+    #[test]
+    fn conflicting_or_missing_inputs_fail_during_parsing() {
+        assert!(WalletParser::try_parse_from(["wallet", "create"]).is_err());
+        assert!(
+            WalletParser::try_parse_from([
+                "wallet",
+                "create",
+                "--input-json",
+                "{}",
+                "--input-file",
+                "x"
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn wallet_uuid_is_checked_before_authentication() {
+        assert!(WalletParser::try_parse_from(["wallet", "get", "not-an-id"]).is_err());
+        let parsed = WalletParser::try_parse_from([
+            "wallet",
+            "update",
+            "--input-json",
+            r#"{"walletId":"bad","walletName":"next"}"#,
+        ])
+        .unwrap();
+        assert!(parsed.command.prepare().is_err());
+    }
+
+    #[test]
+    fn signing_requires_explicit_algorithm_inputs() {
+        let parsed = SignParser::try_parse_from([
+            "sign",
+            "payload",
+            "--input-json",
+            r#"{"signWith":"opaque-key","payload":"00"}"#,
+        ])
+        .unwrap();
+        assert!(parsed.command.prepare().is_err());
+    }
+
+    #[test]
+    fn signing_preserves_opaque_key_identifiers() {
+        let parsed = SignParser::try_parse_from(["sign", "transaction", "--input-json", r#"{"signWith":"opaque-key","unsignedTransaction":"00","type":"TRANSACTION_TYPE_ETHEREUM"}"#]).unwrap();
+        let PreparedWalletCommand::Transaction(params) = parsed.command.prepare().unwrap() else {
+            panic!("expected prepared transaction")
+        };
+        assert_eq!(params.sign_with, "opaque-key");
+    }
+    #[tokio::test]
+    async fn transaction_submission_is_typed_and_not_retried_when_pending() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{body_partial_json, method, path},
+        };
+        #[derive(Parser)]
+        struct IdentityParser {
+            #[command(flatten)]
+            options: crate::shared_auth::AuthOptions,
+        }
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let key = turnkey_api_key_stamper::TurnkeyP256ApiKey::generate();
+        let key_path = dir.path().join("credential.json");
+        let config_path = dir.path().join("config.toml");
+        let key_value = crate::config::turnkey::StoredApiKey {
+            public_key: hex::encode(key.compressed_public_key()),
+            private_key: hex::encode(key.private_key()),
+            curve: crate::config::turnkey::KeyCurve::P256,
+        };
+        std::fs::write(&key_path, serde_json::to_vec(&key_value).unwrap()).unwrap();
+        let org = "00000000-0000-4000-8000-000000000001";
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"version = 1
+active_profile = "test"
+[profiles.test]
+organization_id = "{org}"
+api_base_url = "{}"
+api_key_file = "{}"
+"#,
+                server.uri(),
+                key_path.display()
+            ),
+        )
+        .unwrap();
+        let parsed = IdentityParser::try_parse_from([
+            "identity",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--profile",
+            "test",
+        ])
+        .unwrap();
+        let auth = crate::shared_auth::resolve(&parsed.options).await.unwrap();
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_transaction"))
+            .and(body_partial_json(serde_json::json!({"organizationId": org, "type": "ACTIVITY_TYPE_SIGN_TRANSACTION_V2", "parameters": {"signWith": "opaque-key", "unsignedTransaction": "00", "type": "TRANSACTION_TYPE_ETHEREUM"}})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"activity":{"id":"pending-id","status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}})))
+            .expect(1).mount(&server).await;
+        let parsed = SignParser::try_parse_from(["sign", "transaction", "--input-json", r#"{"signWith":"opaque-key","unsignedTransaction":"00","type":"TRANSACTION_TYPE_ETHEREUM"}"#]).unwrap();
+        let output = parsed.command.prepare().unwrap().run(auth).await.unwrap();
+        assert!(!output.failed());
+        let value = serde_json::to_value(output).unwrap();
+        assert_eq!(value["status"], "pending");
+        assert_eq!(value["activity"]["id"], "pending-id");
+        server.verify().await;
+        for response in [serde_json::json!({}), serde_json::json!({"wallet": null})] {
+            server.reset().await;
+            Mock::given(method("POST"))
+                .and(path("/public/v1/query/get_wallet"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(response))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let parsed = IdentityParser::try_parse_from([
+                "identity",
+                "--config",
+                config_path.to_str().unwrap(),
+                "--profile",
+                "test",
+            ])
+            .unwrap();
+            let auth = crate::shared_auth::resolve(&parsed.options).await.unwrap();
+            let error = PreparedWalletCommand::Get(Uuid::parse_str(org).unwrap())
+                .run(auth)
+                .await
+                .unwrap_err();
+            assert!(
+                error
+                    .downcast_ref::<crate::errors::MissingResource>()
+                    .is_some()
+            );
+            server.verify().await;
+        }
+    }
+}

--- a/tvc/tests/shared_auth.rs
+++ b/tvc/tests/shared_auth.rs
@@ -1,0 +1,402 @@
+use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use serde_json::{Value, json};
+use std::{fs, path::Path};
+use tempfile::TempDir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{body_json, method, path},
+};
+
+const ORG: &str = "00000000-0000-4000-8000-000000000001";
+fn command(temp: &TempDir) -> Command {
+    let mut command = cargo_bin_cmd!("tk");
+    for name in [
+        "TK_CONFIG",
+        "TK_PROFILE",
+        "TURNKEY_ORGANIZATION_ID",
+        "TURNKEY_API_PUBLIC_KEY",
+        "TURNKEY_API_PRIVATE_KEY",
+        "TURNKEY_API_BASE_URL",
+        "TVC_ORG_ID",
+        "TVC_API_KEY_PUBLIC",
+        "TVC_API_KEY_PRIVATE",
+        "TVC_API_BASE_URL",
+    ] {
+        command.env_remove(name);
+    }
+    command
+        .env("HOME", temp.path())
+        .arg("--message-format=json");
+    command
+}
+fn key(path: &Path) -> (String, String) {
+    let key = TurnkeyP256ApiKey::generate();
+    let public = hex::encode(key.compressed_public_key());
+    let private = hex::encode(key.private_key());
+    fs::write(
+        path,
+        serde_json::to_vec(&json!({"public_key": public, "private_key": private, "curve": "p256"}))
+            .unwrap(),
+    )
+    .unwrap();
+    (public, private)
+}
+fn registry(temp: &TempDir) -> (String, String) {
+    let directory = temp.path().join(".config/turnkey");
+    fs::create_dir_all(&directory).unwrap();
+    let (admin, _) = key(&directory.join("admin.json"));
+    let (agent, _) = key(&directory.join("agent.json"));
+    fs::write(
+        directory.join("tk.config.toml"),
+        format!(
+            r#"version = 1
+active_profile = "admin"
+[profiles.admin]
+organization_id = "{ORG}"
+api_base_url = "https://api.turnkey.com"
+api_key_file = "{}/admin.json"
+[profiles.agent]
+organization_id = "{ORG}"
+api_base_url = "https://api.turnkey.com"
+api_key_file = "{}/agent.json"
+"#,
+            directory.display(),
+            directory.display()
+        ),
+    )
+    .unwrap();
+    (admin, agent)
+}
+fn output(command: &mut Command) -> Value {
+    let result = command.assert().success();
+    serde_json::from_slice(&result.get_output().stdout).unwrap()
+}
+#[test]
+fn two_identities_share_an_org_and_explicit_selection_ignores_ambient_credentials() {
+    let temp = TempDir::new().unwrap();
+    let (admin, agent) = registry(&temp);
+    let result = output(command(&temp).args(["auth", "status"]));
+    assert_eq!(result["data"]["publicKey"], admin);
+    let result = output(
+        command(&temp)
+            .env("TURNKEY_API_PRIVATE_KEY", "unused-secret")
+            .env("TVC_ORG_ID", "invalid")
+            .args(["--profile", "agent", "auth", "status"]),
+    );
+    assert_eq!(
+        result["data"],
+        json!({"ready": true, "profile": "agent", "organizationId": ORG, "apiBaseUrl": "https://api.turnkey.com", "publicKey": agent, "credentialSource": "profile"})
+    );
+    assert!(!temp.path().join(".config/turnkey/tvc.config.toml").exists());
+}
+#[test]
+fn environment_auth_does_not_require_home_or_read_bad_registry() {
+    let temp = TempDir::new().unwrap();
+    let (public, private) = key(&temp.path().join("key.json"));
+    let config = temp.path().join("bad.toml");
+    fs::write(&config, "not valid toml").unwrap();
+    let result = output(
+        command(&temp)
+            .env_remove("HOME")
+            .env("TK_CONFIG", &config)
+            .env("TURNKEY_ORGANIZATION_ID", ORG)
+            .env("TURNKEY_API_PUBLIC_KEY", &public)
+            .env("TURNKEY_API_PRIVATE_KEY", private)
+            .args(["auth", "status"]),
+    );
+    assert_eq!(result["data"]["credentialSource"], "environment");
+    assert_eq!(result["data"]["publicKey"], public);
+}
+#[test]
+fn partial_and_mixed_bundles_fail_without_leaking_secrets() {
+    let temp = TempDir::new().unwrap();
+    registry(&temp);
+    for mixed in [false, true] {
+        let mut cmd = command(&temp);
+        cmd.env("TURNKEY_API_PRIVATE_KEY", "never-print-this");
+        if mixed {
+            cmd.env("TVC_ORG_ID", ORG);
+        }
+        let result = cmd.args(["auth", "status"]).assert().failure();
+        let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+        assert!(!stdout.contains("never-print-this"));
+        let parsed: Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(parsed["schemaVersion"], 1);
+    }
+}
+#[test]
+fn malformed_selected_registry_reports_invalid_input_without_source_text() {
+    let temp = TempDir::new().unwrap();
+    registry(&temp);
+    fs::write(
+        temp.path().join(".config/turnkey/tk.config.toml"),
+        "secret-pasted-on-invalid-line",
+    )
+    .unwrap();
+    let result = command(&temp)
+        .args(["--profile", "agent", "auth", "status"])
+        .assert()
+        .failure();
+    let parsed: Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(parsed["code"], "invalid_input");
+    assert!(
+        !parsed["message"]
+            .as_str()
+            .unwrap()
+            .contains("secret-pasted")
+    );
+}
+#[test]
+fn profile_delete_and_logout_keep_credentials() {
+    let temp = TempDir::new().unwrap();
+    registry(&temp);
+    output(command(&temp).args(["profile", "use", "agent"]));
+    output(command(&temp).args(["auth", "logout"]));
+    let list = output(command(&temp).args(["profile", "list"]));
+    assert!(list["data"]["activeProfile"].is_null());
+    output(command(&temp).args(["profile", "delete", "agent"]));
+    assert!(temp.path().join(".config/turnkey/agent.json").exists());
+    assert!(temp.path().join(".config/turnkey/admin.json").exists());
+}
+#[tokio::test]
+async fn login_verifies_identity_and_saves_no_operator_state() {
+    let temp = TempDir::new().unwrap();
+    let key_path = temp.path().join("key.json");
+    key(&key_path);
+    let server = MockServer::start().await;
+    let identity = json!({"organizationId": ORG, "organizationName": "test", "userId": "user-1", "username": "alice"});
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/whoami"))
+        .and(body_json(json!({"organizationId": ORG})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&identity))
+        .expect(2)
+        .mount(&server)
+        .await;
+    let login = output(
+        command(&temp)
+            .args([
+                "--profile",
+                "admin",
+                "--organization-id",
+                ORG,
+                "--api-base-url",
+                &server.uri(),
+                "login",
+                "--api-key-file",
+            ])
+            .arg(&key_path),
+    );
+    assert_eq!(login["data"]["identity"], identity);
+    let whoami = output(command(&temp).arg("whoami"));
+    assert_eq!(whoami["data"], identity);
+    assert!(!temp.path().join(".config/turnkey/tvc.config.toml").exists());
+    assert!(!temp.path().join(".config/turnkey/orgs").exists());
+}
+
+#[test]
+fn experimental_import_preserves_source_and_does_not_select_or_leak_credentials() {
+    let temp = TempDir::new().unwrap();
+    let (public, private) = key(&temp.path().join("original-key.json"));
+    let source = temp.path().join("legacy.toml");
+    let original = format!(
+        r#"[turnkey]
+organizationId = "{ORG}"
+apiPublicKey = "{public}"
+apiPrivateKey = "{private}"
+apiBaseUrl = "https://api.turnkey.com"
+privateKeyId = "ssh-signing-key"
+"#
+    );
+    fs::write(&source, &original).unwrap();
+    let imported = output(
+        command(&temp)
+            .args([
+                "profile",
+                "import",
+                "--from",
+                "experimental-tk",
+                "--name",
+                "agent",
+                "--source",
+            ])
+            .arg(&source),
+    );
+    assert_eq!(
+        imported["data"],
+        json!({"name": "agent", "selected": false})
+    );
+    let list = output(command(&temp).args(["profile", "list"]));
+    assert!(list["data"]["activeProfile"].is_null());
+    assert!(!list.to_string().contains(&private));
+    let profile = &list["data"]["profiles"]["agent"];
+    assert_eq!(profile["ssh_signing_key_id"], "ssh-signing-key");
+    let credential = Path::new(profile["api_key_file"].as_str().unwrap());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(credential).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    assert_eq!(fs::read_to_string(source).unwrap(), original);
+    let status = output(command(&temp).args(["--profile", "agent", "auth", "status"]));
+    assert_eq!(status["data"]["publicKey"], public);
+}
+
+#[test]
+fn invalid_key_length_is_an_error_without_panic() {
+    let temp = TempDir::new().unwrap();
+    let result = command(&temp)
+        .env("TURNKEY_ORGANIZATION_ID", ORG)
+        .env("TURNKEY_API_PUBLIC_KEY", "00")
+        .env("TURNKEY_API_PRIVATE_KEY", "01")
+        .args(["auth", "status"])
+        .assert()
+        .code(1);
+    assert!(result.get_output().stderr.is_empty());
+    let parsed: Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(parsed["reason"], "command_error");
+}
+
+#[test]
+fn shared_selectors_cannot_silently_use_a_different_tvc_identity() {
+    let temp = TempDir::new().unwrap();
+    let result = command(&temp)
+        .args(["--profile", "agent", "tvc", "app", "list"])
+        .assert()
+        .failure();
+    let parsed: Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(parsed["code"], "invalid_input");
+    assert!(!temp.path().join(".config").exists());
+}
+
+#[test]
+fn tvc_import_preserves_source_and_reuses_only_api_identity() {
+    let temp = TempDir::new().unwrap();
+    let key_path = temp.path().join("tvc-key.json");
+    let (public, _) = key(&key_path);
+    let source = temp.path().join("tvc.config.toml");
+    let original = format!(
+        r#"version = 1
+active_org = "dev"
+[orgs.dev]
+id = "{ORG}"
+api_key_path = "{}"
+api_base_url = "https://api.turnkey.com"
+"#,
+        key_path.display()
+    );
+    fs::write(&source, &original).unwrap();
+    output(
+        command(&temp)
+            .args([
+                "profile", "import", "--from", "tvc", "--name", "imported", "--source",
+            ])
+            .arg(&source),
+    );
+    let status = output(command(&temp).args(["--profile", "imported", "auth", "status"]));
+    assert_eq!(status["data"]["publicKey"], public);
+    assert_eq!(fs::read_to_string(source).unwrap(), original);
+    assert!(!temp.path().join(".config/turnkey/orgs").exists());
+}
+
+#[test]
+fn empty_environment_bundle_does_not_fall_back_to_saved_admin() {
+    let temp = TempDir::new().unwrap();
+    registry(&temp);
+    let result = command(&temp)
+        .env("TURNKEY_API_PRIVATE_KEY", "")
+        .args(["auth", "status"])
+        .assert()
+        .code(1);
+    let parsed: Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(parsed["reason"], "command_error");
+    output(command(&temp).env("TURNKEY_API_PRIVATE_KEY", "").args([
+        "--profile",
+        "agent",
+        "auth",
+        "status",
+    ]));
+}
+
+#[cfg(unix)]
+#[test]
+fn nonunicode_credential_environment_does_not_fall_back() {
+    use std::os::unix::ffi::OsStringExt;
+    let temp = TempDir::new().unwrap();
+    registry(&temp);
+    command(&temp)
+        .env(
+            "TURNKEY_API_PRIVATE_KEY",
+            std::ffi::OsString::from_vec(vec![255]),
+        )
+        .args(["auth", "status"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn malformed_tvc_import_never_echoes_source_lines() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("bad.toml");
+    fs::write(&source, "PRIVATE_MARKER_UNTERMINATED = \"").unwrap();
+    let result = command(&temp)
+        .args([
+            "profile", "import", "--from", "tvc", "--name", "a", "--source",
+        ])
+        .arg(&source)
+        .assert()
+        .code(1);
+    let text = String::from_utf8_lossy(&result.get_output().stdout);
+    assert!(!text.contains("PRIVATE_MARKER"));
+    assert!(text.contains("bad.toml"));
+}
+
+#[test]
+fn experimental_import_defaults_absent_endpoint_and_rejects_bad_explicit_endpoint() {
+    let temp = TempDir::new().unwrap();
+    let (public, private) = key(&temp.path().join("key.json"));
+    let source = temp.path().join("legacy.toml");
+    let contents = format!(
+        r#"[turnkey]
+organizationId = "{ORG}"
+apiPublicKey = "{public}"
+apiPrivateKey = "{private}"
+"#
+    );
+    fs::write(&source, &contents).unwrap();
+    output(
+        command(&temp)
+            .args([
+                "profile",
+                "import",
+                "--from",
+                "experimental-tk",
+                "--name",
+                "default",
+                "--source",
+            ])
+            .arg(&source),
+    );
+    let selected = output(command(&temp).args(["--profile", "default", "auth", "status"]));
+    assert_eq!(selected["data"]["apiBaseUrl"], "https://api.turnkey.com");
+    let credentials = temp.path().join(".config/turnkey/credentials");
+    let count = fs::read_dir(&credentials).unwrap().count();
+    fs::write(&source, format!("{contents}apiBaseUrl = 'not a URL'\n")).unwrap();
+    command(&temp)
+        .args([
+            "profile",
+            "import",
+            "--from",
+            "experimental-tk",
+            "--name",
+            "bad",
+            "--source",
+        ])
+        .arg(&source)
+        .assert()
+        .code(1);
+    assert_eq!(fs::read_dir(credentials).unwrap().count(), count);
+}

--- a/tvc/tests/tk_entrypoint.rs
+++ b/tvc/tests/tk_entrypoint.rs
@@ -1,0 +1,65 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use clap::Parser;
+use serde_json::Value;
+use tempfile::TempDir;
+use tvc::cli::TkCli;
+
+#[test]
+fn unified_command_tree_accepts_shared_flags_and_scopes_cloud_commands() {
+    for args in [
+        vec!["tk", "--message-format=json", "version"],
+        vec!["tk", "version", "--message-format=json"],
+        vec!["tk", "tvc", "app", "list", "--non-interactive"],
+    ] {
+        TkCli::try_parse_from(args).expect("unified invocation should parse");
+    }
+    for command in ["login", "profile", "version"] {
+        assert!(TkCli::try_parse_from(["tk", "tvc", command]).is_err());
+    }
+    assert!(TkCli::try_parse_from(["tk", "deploy"]).is_err());
+}
+
+#[test]
+fn legacy_and_nested_commands_produce_identical_offline_artifacts_and_json() {
+    let temp = TempDir::new().unwrap();
+    let output_path = temp.path().join("deploy.json");
+    let legacy = cargo_bin_cmd!("tvc")
+        .env("HOME", temp.path())
+        .current_dir(temp.path())
+        .args(["deploy", "init", "--message-format=json", "--output"])
+        .arg(&output_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let artifact = std::fs::read(&output_path).unwrap();
+    std::fs::remove_file(&output_path).unwrap();
+    let nested = cargo_bin_cmd!("tk")
+        .env("HOME", temp.path())
+        .current_dir(temp.path())
+        .args(["--message-format=json", "tvc", "deploy", "init", "--output"])
+        .arg(&output_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        serde_json::from_slice::<Value>(&legacy).unwrap(),
+        serde_json::from_slice::<Value>(&nested).unwrap()
+    );
+    assert_eq!(artifact, std::fs::read(&output_path).unwrap());
+}
+
+#[test]
+fn unified_usage_errors_follow_the_existing_json_protocol() {
+    let result = cargo_bin_cmd!("tk")
+        .args(["--message-format=json", "tvc", "unknown-command"])
+        .assert()
+        .code(2);
+    let message: Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(message["reason"], "command_error");
+    assert_eq!(message["code"], "usage_error");
+    assert!(result.get_output().stderr.is_empty());
+}

--- a/tvc/tests/tk_operations.rs
+++ b/tvc/tests/tk_operations.rs
@@ -1,0 +1,177 @@
+use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{body_string, method, path},
+};
+
+const ORG: &str = "00000000-0000-4000-8000-000000000001";
+fn cli() -> Command {
+    let mut cmd = cargo_bin_cmd!("tk");
+    for name in [
+        "HOME",
+        "TK_CONFIG",
+        "TK_PROFILE",
+        "TURNKEY_ORGANIZATION_ID",
+        "TURNKEY_API_PUBLIC_KEY",
+        "TURNKEY_API_PRIVATE_KEY",
+        "TURNKEY_API_BASE_URL",
+        "TVC_ORG_ID",
+        "TVC_API_KEY_PUBLIC",
+        "TVC_API_KEY_PRIVATE",
+        "TVC_API_BASE_URL",
+    ] {
+        cmd.env_remove(name);
+    }
+    cmd.arg("--message-format=json");
+    cmd
+}
+fn authed(base: &str) -> Command {
+    let mut cmd = cli();
+    let key = TurnkeyP256ApiKey::generate();
+    cmd.env("TURNKEY_ORGANIZATION_ID", ORG)
+        .env(
+            "TURNKEY_API_PUBLIC_KEY",
+            hex::encode(key.compressed_public_key()),
+        )
+        .env("TURNKEY_API_PRIVATE_KEY", hex::encode(key.private_key()))
+        .arg("--api-base-url")
+        .arg(base);
+    cmd
+}
+fn record(cmd: &mut Command, code: i32) -> Value {
+    let result = cmd.assert().code(code);
+    assert!(result.get_output().stderr.is_empty());
+    serde_json::from_slice(&result.get_output().stdout).unwrap()
+}
+#[test]
+fn malformed_local_inputs_are_rejected_before_credentials() {
+    for args in [
+        vec![
+            "request",
+            "--path",
+            "/public/v1/query/whoami",
+            "--body",
+            "{",
+        ],
+        vec!["user", "create", "--input-json", "{"],
+        vec!["wallet", "create", "--input-json", "{"],
+        vec!["sign", "payload", "--input-json", "{"],
+    ] {
+        let result = record(cli().args(args), 1);
+        assert!(!result["message"].as_str().unwrap().contains("HOME"));
+    }
+}
+#[test]
+fn offline_generation_needs_no_identity_and_never_overwrites() {
+    let temp = TempDir::new().unwrap();
+    let key = temp.path().join("key.json");
+    let result = record(cli().args(["api-key", "generate", "--output"]).arg(&key), 0);
+    assert_eq!(result["command"], "api-key.generate");
+    let bytes = std::fs::read(&key).unwrap();
+    let stored: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(
+        !result
+            .to_string()
+            .contains(stored["private_key"].as_str().unwrap())
+    );
+    record(cli().args(["api-key", "generate", "--output"]).arg(&key), 1);
+    assert_eq!(std::fs::read(key).unwrap(), bytes);
+}
+#[tokio::test]
+async fn signed_request_preserves_body_and_pending_vs_rejected_exit_codes() {
+    let server = MockServer::start().await;
+    let body = format!("{{\n  \"organizationId\": \"{ORG}\"\n}}\n");
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/example"))
+        .and(body_string(&body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({"activity":{"id":"pending-id","status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}}),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let pending = record(
+        authed(&server.uri()).args([
+            "request",
+            "--path",
+            "/public/v1/submit/example",
+            "--body",
+            &body,
+        ]),
+        0,
+    );
+    assert_eq!(pending["status"], "pending");
+    assert_eq!(pending["activity"]["id"], "pending-id");
+    server.reset().await;
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/get_activity"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({"activity":{"id":"rejected-id","status":"ACTIVITY_STATUS_REJECTED"}}),
+        ))
+        .expect(2)
+        .mount(&server)
+        .await;
+    let inspected = record(
+        authed(&server.uri()).args(["activity", "get", "rejected-id"]),
+        0,
+    );
+    assert_eq!(inspected["activity"]["status"], "ACTIVITY_STATUS_REJECTED");
+    let waited = record(
+        authed(&server.uri()).args(["activity", "wait", "rejected-id"]),
+        1,
+    );
+    assert_eq!(waited["status"], "rejected");
+}
+#[tokio::test]
+async fn shared_resource_and_wallet_queries_use_selected_identity() {
+    let server = MockServer::start().await;
+    for (args, endpoint, response, command) in [
+        (
+            vec!["user", "list"],
+            "list_users",
+            json!({"users":[]}),
+            "user.list",
+        ),
+        (
+            vec!["policy", "list"],
+            "list_policies",
+            json!({"policies":[]}),
+            "policy.list",
+        ),
+        (
+            vec!["wallet", "list"],
+            "list_wallets",
+            json!({"wallets":[]}),
+            "wallet.list",
+        ),
+    ] {
+        Mock::given(method("POST"))
+            .and(path(format!("/public/v1/query/{endpoint}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let result = record(authed(&server.uri()).args(args), 0);
+        assert_eq!(result["command"], command);
+    }
+}
+
+#[tokio::test]
+async fn payload_signing_preserves_pending_activity_without_resubmission() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/sign_raw_payload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({"activity":{"id":"sign-id","status":"ACTIVITY_STATUS_CONSENSUS_NEEDED"}}),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let result = record(authed(&server.uri()).args(["sign", "payload", "--input-json", r#"{"signWith":"0x1234","payload":"abcd","encoding":"PAYLOAD_ENCODING_HEXADECIMAL","hashFunction":"HASH_FUNCTION_NO_OP"}"#]), 0);
+    assert_eq!(result["command"], "sign.payload");
+    assert_eq!(result["status"], "pending");
+    assert_eq!(result["activity"]["id"], "sign-id");
+}


### PR DESCRIPTION
# Add a unified tk CLI preview

Add a tk entry point alongside tvc, preserving existing TVC command behavior. Shared commands provide credential profiles and login/status/whoami, exact-body requests, activity inspection and recovery, user/policy/API-key management, wallets, and serialized signing. Local key generation writes an exclusive protected credential file and returns public material only.

This is an unreleased preview. TVC still uses its existing credential configuration; shared selectors are rejected there. Live lifecycle acceptance, browser onboarding, complete pagination, managed transaction delivery, import/export, and distribution remain follow-ups.

Validation: the implementation passed 460 CLI tests; the final mechanical helper move passed strict Clippy across all targets and a debug build/version smoke. The consolidated branch preserves that source exactly; only preview documentation was subsequently edited. No live organization acceptance was performed.

Review packet: https://reviews.figitaki.dev/r/ZG8muCcG

Integration status: main has advanced since this preview was validated. Merge conflicts in tvc/Cargo.toml and tvc/src/lib.rs must be resolved and checks rerun before this draft is ready to merge.
